### PR TITLE
Ignore sovrin_submit_node_request_works_for_new_steward test

### DIFF
--- a/tests/ledger.rs
+++ b/tests/ledger.rs
@@ -567,6 +567,7 @@ mod high_cases {
 
         #[test]
         #[cfg(feature = "local_nodes_pool")]
+        #[ignore] //FIXME currently unstable pool behaviour after new non-existing node was added
         fn sovrin_submit_node_request_works_for_new_steward() {
             TestUtils::cleanup_storage();
 


### PR DESCRIPTION
Ignore the test to avoid pool instability.