### PR TITLE
Bugfixes for libzmq-pw on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn main() {
             println!("cargo:rustc-flags=-L {}/lib", prebuilt_dir);
             println!("cargo:include={}/include", prebuilt_dir);
 
-	    let files = vec![ "libeay32md.dll", "libsodium.dll", "libzmq.dll", "ssleay32md.dll" ];
+	    let files = vec![ "libeay32md.dll", "libsodium.dll", "libzmq-pw.dll", "ssleay32md.dll" ];
 	    for f in files.iter() {
 	        if let Ok(_) = fs::copy(&prebuilt.join(f), &dst.join(f)) {
 	            println!("copy {} -> {}", &prebuilt.join(f).display(), &dst.join(f).display());


### PR DESCRIPTION
Copy of libzmq-pw.dll to output directory on windows instead of libzmq.dll