### PR TITLE
Java wrapper Pool.closePoolLedger method did not use correct C-callable sdk function

### DIFF
--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
@@ -141,7 +141,7 @@ public class Pool extends SovrinJava.API {
 			}
 		};
 
-		int result = LibSovrin.api.sovrin_refresh_pool_ledger(
+		int result = LibSovrin.api.sovrin_close_pool_ledger(
 				FIXED_COMMAND_HANDLE, 
 				handle, 
 				callback);


### PR DESCRIPTION
Simple change to use correct underlying function call.