### PR TITLE
Feature/java rename connection observer

### DIFF
--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/ErrorCode.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/ErrorCode.java
@@ -115,7 +115,7 @@ public enum ErrorCode {
 	SignusUnknownCryptoError(500);
 
 	private int value;
-	private static Map<Integer, ErrorCode> map = new HashMap<Integer, ErrorCode> ();
+	private static Map<Integer, ErrorCode> map = new HashMap<Integer, ErrorCode>();
 	private ErrorCode(int value) {
 
 		this.value = value;

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/IndyJava.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/IndyJava.java
@@ -29,7 +29,7 @@ public class IndyJava {
 		 */
 
 		private static AtomicInteger atomicInteger = new AtomicInteger();
-		private static Map<Integer, CompletableFuture<?>> futures = new ConcurrentHashMap<Integer, CompletableFuture<?>> ();
+		private static Map<Integer, CompletableFuture<?>> futures = new ConcurrentHashMap<Integer, CompletableFuture<?>>();
 
 		protected static int newCommandHandle() {
 
@@ -106,7 +106,7 @@ public class IndyJava {
 
 	public abstract static class JsonParameter {
 
-		protected Map<String, Object> map = new HashMap<String, Object> ();
+		protected Map<String, Object> map = new HashMap<String, Object>();
 
 		/*
 		 * JSON CREATION

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/Agent.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/Agent.java
@@ -33,7 +33,7 @@ public class Agent extends IndyJava.API {
 
 	private static void addMessageObserver(int commandHandle, AgentObservers.MessageObserver messageObserver) {
 
-		assert (!Agent.messageObserver.containsKey(commandHandle));
+		assert(! Agent.messageObserver.containsKey(commandHandle));
 		Agent.messageObserver.put(commandHandle, messageObserver);
 
 	}
@@ -41,14 +41,14 @@ public class Agent extends IndyJava.API {
 	private static AgentObservers.MessageObserver removeMessageObserver(int xcommand_handle) {
 
 		AgentObservers.MessageObserver future = messageObserver.remove(xcommand_handle);
-		assert (future != null);
+		assert(future != null);
 
 		return future;
 	}
 
 	private static void addConnectionObserver(int commandHandle, AgentObservers.ConnectionObserver connectionObserver) {
 
-		assert (!connectionObservers.containsKey(commandHandle));
+		assert(! connectionObservers.containsKey(commandHandle));
 		connectionObservers.put(commandHandle, connectionObserver);
 
 	}
@@ -56,7 +56,7 @@ public class Agent extends IndyJava.API {
 	private static AgentObservers.ConnectionObserver removeConnectionObserver(int xcommand_handle) {
 
 		AgentObservers.ConnectionObserver future = connectionObservers.remove(xcommand_handle);
-		assert (future != null);
+		assert(future != null);
 
 		return future;
 	}
@@ -71,9 +71,9 @@ public class Agent extends IndyJava.API {
 		public void callback(int xcommand_handle, int err, int connection_handle) throws IndyException {
 
 			CompletableFuture<Connection> future = (CompletableFuture<Connection>) removeFuture(xcommand_handle);
-			if (!checkCallback(future, err)) return;
+			if (! checkCallback(future, err)) return;
 
-			assert (!connections.containsKey(connection_handle));
+			assert(! connections.containsKey(connection_handle));
 			Agent.Connection connection = new Agent.Connection(connection_handle);
 			connections.put(connection_handle, connection);
 
@@ -104,9 +104,9 @@ public class Agent extends IndyJava.API {
 		public void callback(int xcommand_handle, int err, int listener_handle) throws IndyException {
 
 			CompletableFuture<Listener> future = (CompletableFuture<Listener>) removeFuture(xcommand_handle);
-			if (!checkCallback(future, err)) return;
+			if (! checkCallback(future, err)) return;
 
-			assert (!listeners.containsKey(listener_handle));
+			assert(! listeners.containsKey(listener_handle));
 			Agent.Listener listener = new Agent.Listener(listener_handle);
 			listeners.put(listener_handle, listener);
 
@@ -126,7 +126,7 @@ public class Agent extends IndyJava.API {
 			Agent.Listener listener = listeners.get(xlistener_handle);
 			if (listener == null) return;
 
-			assert (!connections.containsKey(connection_handle));
+			assert(! connections.containsKey(connection_handle));
 			Agent.Connection connection = new Agent.Connection(connection_handle);
 			connections.put(connection_handle, connection);
 
@@ -156,7 +156,7 @@ public class Agent extends IndyJava.API {
 		public void callback(int xcommand_handle, int err, int listener_handle) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
-			if (!checkCallback(future, err)) return;
+			if (! checkCallback(future, err)) return;
 
 			future.complete(null);
 		}
@@ -168,7 +168,7 @@ public class Agent extends IndyJava.API {
 		public void callback(int xcommand_handle, int err, int listener_handle) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
-			if (!checkCallback(future, err)) return;
+			if (! checkCallback(future, err)) return;
 
 			future.complete(null);
 		}
@@ -180,7 +180,7 @@ public class Agent extends IndyJava.API {
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
-			if (!checkCallback(future, err)) return;
+			if (! checkCallback(future, err)) return;
 
 			future.complete(null);
 		}
@@ -192,7 +192,7 @@ public class Agent extends IndyJava.API {
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
-			if (!checkCallback(future, err)) return;
+			if (! checkCallback(future, err)) return;
 
 			future.complete(null);
 		}
@@ -204,7 +204,7 @@ public class Agent extends IndyJava.API {
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
-			if (!checkCallback(future, err)) return;
+			if (! checkCallback(future, err)) return;
 
 			future.complete(null);
 		}

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/Agent.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/Agent.java
@@ -29,7 +29,7 @@ public class Agent extends IndyJava.API {
 	 */
 
 	private static Map<Integer, AgentObservers.MessageObserver> messageObserver = new ConcurrentHashMap<Integer, AgentObservers.MessageObserver>();
-	private static Map<Integer, AgentObservers.IncomingConnectionObserver> connectionObservers = new ConcurrentHashMap<Integer, AgentObservers.IncomingConnectionObserver>();
+	private static Map<Integer, AgentObservers.ConnectionObserver> connectionObservers = new ConcurrentHashMap<Integer, AgentObservers.ConnectionObserver>();
 
 	private static void addMessageObserver(int commandHandle, AgentObservers.MessageObserver messageObserver) {
 
@@ -46,16 +46,16 @@ public class Agent extends IndyJava.API {
 		return future;
 	}
 
-	private static void addIncomingConnectionObserver(int commandHandle, AgentObservers.IncomingConnectionObserver incomingConnectionObserver) {
+	private static void addConnectionObserver(int commandHandle, AgentObservers.ConnectionObserver connectionObserver) {
 
 		assert (!connectionObservers.containsKey(commandHandle));
-		connectionObservers.put(commandHandle, incomingConnectionObserver);
+		connectionObservers.put(commandHandle, connectionObserver);
 
 	}
 
-	private static AgentObservers.IncomingConnectionObserver removeIncomingConnectionObserver(int xcommand_handle) {
+	private static AgentObservers.ConnectionObserver removeConnectionObserver(int xcommand_handle) {
 
-		AgentObservers.IncomingConnectionObserver future = connectionObservers.remove(xcommand_handle);
+		AgentObservers.ConnectionObserver future = connectionObservers.remove(xcommand_handle);
 		assert (future != null);
 
 		return future;
@@ -110,7 +110,7 @@ public class Agent extends IndyJava.API {
 			Agent.Listener listener = new Agent.Listener(listener_handle);
 			listeners.put(listener_handle, listener);
 
-			listener.incomingConnectionObserver = removeIncomingConnectionObserver(xcommand_handle);
+			listener.connectionObserver = removeConnectionObserver(xcommand_handle);
 
 			future.complete(listener);
 		}
@@ -130,8 +130,8 @@ public class Agent extends IndyJava.API {
 			Agent.Connection connection = new Agent.Connection(connection_handle);
 			connections.put(connection_handle, connection);
 
-			AgentObservers.IncomingConnectionObserver incomingConnectionObserver = listener.incomingConnectionObserver;
-			connection.messageObserver = incomingConnectionObserver.onConnection(listener, connection, sender_did, receiver_did);
+			AgentObservers.ConnectionObserver connectionObserver = listener.connectionObserver;
+			connection.messageObserver = connectionObserver.onConnection(listener, connection, sender_did, receiver_did);
 		}
 	};
 
@@ -244,11 +244,11 @@ public class Agent extends IndyJava.API {
 
 	public static CompletableFuture<Listener> agentListen(
 			String endpoint,
-			AgentObservers.IncomingConnectionObserver incomingConnectionObserver) throws IndyException {
+			AgentObservers.ConnectionObserver connectionObserver) throws IndyException {
 
 		CompletableFuture<Listener> future = new CompletableFuture<>();
 		int commandHandle = addFuture(future);
-		addIncomingConnectionObserver(commandHandle, incomingConnectionObserver);
+		addConnectionObserver(commandHandle, connectionObserver);
 
 		int result = LibIndy.api.indy_agent_listen(
 				commandHandle,
@@ -378,7 +378,7 @@ public class Agent extends IndyJava.API {
 	public static class Listener {
 
 		private final int listenerHandle;
-		private AgentObservers.IncomingConnectionObserver incomingConnectionObserver;
+		private AgentObservers.ConnectionObserver connectionObserver;
 
 		private Listener(int listenerHandle) {
 

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/AgentObservers.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/AgentObservers.java
@@ -9,12 +9,7 @@ public final class AgentObservers {
 
 	}
 
-	public interface ListenerObserver {
-
-		public ConnectionObserver onListener(Agent.Listener listener);
-	}
-
-	public interface ConnectionObserver {
+	public interface IncomingConnectionObserver {
 
 		public MessageObserver onConnection(Agent.Listener listener, Agent.Connection connection, String senderDid, String receiverDid);
 	}

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/AgentObservers.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/AgentObservers.java
@@ -9,7 +9,7 @@ public final class AgentObservers {
 
 	}
 
-	public interface IncomingConnectionObserver {
+	public interface ConnectionObserver {
 
 		public MessageObserver onConnection(Agent.Listener listener, Agent.Connection connection, String senderDid, String receiverDid);
 	}

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
@@ -26,7 +26,7 @@ public class Anoncreds extends IndyJava.API {
 
 	private static Callback issuerCreateAndStoreClaimDefCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String claim_def_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -39,7 +39,7 @@ public class Anoncreds extends IndyJava.API {
 
 	private static Callback issuerCreateAndStoreRevocRegCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String revoc_reg_json, String revoc_reg_uuid) {
 
 			CompletableFuture<IssuerCreateAndStoreRevocRegResult> future = (CompletableFuture<IssuerCreateAndStoreRevocRegResult>) removeFuture(xcommand_handle);
@@ -52,7 +52,7 @@ public class Anoncreds extends IndyJava.API {
 
 	private static Callback issuerCreateClaimCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String revoc_reg_update_json, String xclaim_json) {
 
 			CompletableFuture<IssuerCreateClaimResult> future = (CompletableFuture<IssuerCreateClaimResult>) removeFuture(xcommand_handle);
@@ -65,7 +65,7 @@ public class Anoncreds extends IndyJava.API {
 
 	private static Callback issuerRevokeClaimCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String revoc_reg_update_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -78,7 +78,7 @@ public class Anoncreds extends IndyJava.API {
 
 	private static Callback proverStoreClaimOfferCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -91,7 +91,7 @@ public class Anoncreds extends IndyJava.API {
 
 	private static Callback proverGetClaimOffersCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String claim_offers_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -113,7 +113,7 @@ public class Anoncreds extends IndyJava.API {
 			String signatureType, 
 			boolean createNonRevoc) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -138,7 +138,7 @@ public class Anoncreds extends IndyJava.API {
 			int schemaSeqNo, 
 			int maxClaimNum) throws IndyException {
 
-		CompletableFuture<IssuerCreateAndStoreRevocRegResult> future = new CompletableFuture<IssuerCreateAndStoreRevocRegResult> ();
+		CompletableFuture<IssuerCreateAndStoreRevocRegResult> future = new CompletableFuture<IssuerCreateAndStoreRevocRegResult>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -163,7 +163,7 @@ public class Anoncreds extends IndyJava.API {
 			int revocRegSeqNo,
 			int userRevocIndex) throws IndyException {
 
-		CompletableFuture<IssuerCreateClaimResult> future = new CompletableFuture<IssuerCreateClaimResult> ();
+		CompletableFuture<IssuerCreateClaimResult> future = new CompletableFuture<IssuerCreateClaimResult>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -187,7 +187,7 @@ public class Anoncreds extends IndyJava.API {
 			int revocRegSeqNo, 
 			int userRevocIndex) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -208,7 +208,7 @@ public class Anoncreds extends IndyJava.API {
 			Wallet wallet,
 			String claimOfferJson) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -228,7 +228,7 @@ public class Anoncreds extends IndyJava.API {
 			Wallet wallet,
 			String filterJson) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/ledger/Ledger.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/ledger/Ledger.java
@@ -25,7 +25,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback signAndSubmitRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_result_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -38,7 +38,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback submitRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_result_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -51,7 +51,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildGetDdoRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -64,7 +64,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildNymRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -77,7 +77,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildAttribRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -90,7 +90,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildGetAttribRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -103,7 +103,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildGetNymRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -116,7 +116,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildSchemaRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -129,7 +129,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildGetSchemaRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -142,7 +142,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildClaimDefTxnCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -155,7 +155,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildGetClaimDefTxnCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -168,7 +168,7 @@ public class Ledger extends IndyJava.API {
 
 	private static Callback buildNodeRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -181,7 +181,7 @@ public class Ledger extends IndyJava.API {
 
 	public static Callback buildGetTxnRequestCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String request_json) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -202,7 +202,7 @@ public class Ledger extends IndyJava.API {
 			String submitterDid,
 			String requestJson) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int poolHandle = pool.getPoolHandle();
@@ -225,7 +225,7 @@ public class Ledger extends IndyJava.API {
 			Pool pool,
 			String requestJson) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int poolHandle = pool.getPoolHandle();
@@ -246,7 +246,7 @@ public class Ledger extends IndyJava.API {
 			String targetDid,
 			String requestJson) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_get_ddo_request(
@@ -267,7 +267,7 @@ public class Ledger extends IndyJava.API {
 			String alias,
 			String role) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_nym_request(
@@ -291,7 +291,7 @@ public class Ledger extends IndyJava.API {
 			String raw,
 			String enc) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_attrib_request(
@@ -313,7 +313,7 @@ public class Ledger extends IndyJava.API {
 			String targetDid,
 			String data) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_get_attrib_request(
@@ -332,7 +332,7 @@ public class Ledger extends IndyJava.API {
 			String submitterDid,
 			String targetDid) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_get_nym_request(
@@ -350,7 +350,7 @@ public class Ledger extends IndyJava.API {
 			String submitterDid,
 			String data) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_schema_request(
@@ -368,7 +368,7 @@ public class Ledger extends IndyJava.API {
 			String submitterDid,
 			String data) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_get_schema_request(
@@ -387,7 +387,7 @@ public class Ledger extends IndyJava.API {
 			String xref,
 			String data) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_claim_def_txn(
@@ -406,7 +406,7 @@ public class Ledger extends IndyJava.API {
 			String submitterDid,
 			String xref) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_get_claim_def_txn(
@@ -425,7 +425,7 @@ public class Ledger extends IndyJava.API {
 			String targetDid,
 			String data) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_node_request(
@@ -444,7 +444,7 @@ public class Ledger extends IndyJava.API {
 			String submitterDid,
 			int data) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_build_get_txn_request(

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
@@ -31,7 +31,7 @@ public class Pool extends IndyJava.API {
 
 	private static Callback createPoolLedgerConfigCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -44,7 +44,7 @@ public class Pool extends IndyJava.API {
 
 	private static Callback openPoolLedgerCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, int pool_handle) {
 
 			CompletableFuture<Pool> future = (CompletableFuture<Pool>) removeFuture(xcommand_handle);
@@ -59,7 +59,7 @@ public class Pool extends IndyJava.API {
 
 	private static Callback refreshPoolLedgerCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -72,7 +72,7 @@ public class Pool extends IndyJava.API {
 
 	private static Callback closePoolLedgerCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -85,7 +85,7 @@ public class Pool extends IndyJava.API {
 
 	private static Callback deletePoolLedgerConfigCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -104,7 +104,7 @@ public class Pool extends IndyJava.API {
 			String configName,
 			String config) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_create_pool_ledger_config(
@@ -122,7 +122,7 @@ public class Pool extends IndyJava.API {
 			String configName,
 			String config) throws IndyException {
 
-		CompletableFuture<Pool> future = new CompletableFuture<Pool> ();
+		CompletableFuture<Pool> future = new CompletableFuture<Pool>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_open_pool_ledger(
@@ -139,7 +139,7 @@ public class Pool extends IndyJava.API {
 	private static CompletableFuture<Void> refreshPoolLedger(
 			Pool pool) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int handle = pool.getPoolHandle();
@@ -157,7 +157,7 @@ public class Pool extends IndyJava.API {
 	private static CompletableFuture<Void> closePoolLedger(
 			Pool pool) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int handle = pool.getPoolHandle();
@@ -175,7 +175,7 @@ public class Pool extends IndyJava.API {
 	public static CompletableFuture<Void> deletePoolLedgerConfig(
 			String configName) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_delete_pool_ledger_config(

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/signus/Signus.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/signus/Signus.java
@@ -27,7 +27,7 @@ public class Signus extends IndyJava.API {
 
 	private static Callback createAndStoreMyDidCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String did, String verkey, String pk) {
 
 			CompletableFuture<CreateAndStoreMyDidResult> future = (CompletableFuture<CreateAndStoreMyDidResult>) removeFuture(xcommand_handle);
@@ -40,7 +40,7 @@ public class Signus extends IndyJava.API {
 
 	private static Callback replaceKeysCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String verkey, String pk) {
 
 			CompletableFuture<ReplaceKeysResult> future = (CompletableFuture<ReplaceKeysResult>) removeFuture(xcommand_handle);
@@ -53,7 +53,7 @@ public class Signus extends IndyJava.API {
 
 	private static Callback storeTheirDidCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -66,7 +66,7 @@ public class Signus extends IndyJava.API {
 
 	private static Callback signCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String signature) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -79,7 +79,7 @@ public class Signus extends IndyJava.API {
 
 	private static Callback verifySignatureCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, boolean valid) {
 
 			CompletableFuture<Boolean> future = (CompletableFuture<Boolean>) removeFuture(xcommand_handle);
@@ -92,7 +92,7 @@ public class Signus extends IndyJava.API {
 
 	private static Callback encryptCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String encryptedMsg) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -105,7 +105,7 @@ public class Signus extends IndyJava.API {
 
 	private static Callback decryptCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String decryptedMsg) {
 
 			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
@@ -124,7 +124,7 @@ public class Signus extends IndyJava.API {
 			Wallet wallet,
 			String didJson) throws IndyException {
 
-		CompletableFuture<CreateAndStoreMyDidResult> future = new CompletableFuture<CreateAndStoreMyDidResult> ();
+		CompletableFuture<CreateAndStoreMyDidResult> future = new CompletableFuture<CreateAndStoreMyDidResult>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -145,7 +145,7 @@ public class Signus extends IndyJava.API {
 			String did,
 			String identityJson) throws IndyException {
 
-		CompletableFuture<ReplaceKeysResult> future = new CompletableFuture<ReplaceKeysResult> ();
+		CompletableFuture<ReplaceKeysResult> future = new CompletableFuture<ReplaceKeysResult>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -166,7 +166,7 @@ public class Signus extends IndyJava.API {
 			Wallet wallet,
 			String identityJson) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -187,7 +187,7 @@ public class Signus extends IndyJava.API {
 			String did,
 			String msg) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -210,7 +210,7 @@ public class Signus extends IndyJava.API {
 			String did,
 			String signedMsg) throws IndyException {
 
-		CompletableFuture<Boolean> future = new CompletableFuture<Boolean> ();
+		CompletableFuture<Boolean> future = new CompletableFuture<Boolean>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -234,7 +234,7 @@ public class Signus extends IndyJava.API {
 			String did,
 			String msg) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();
@@ -256,7 +256,7 @@ public class Signus extends IndyJava.API {
 			String did,
 			String encryptedMsg) throws IndyException {
 
-		CompletableFuture<String> future = new CompletableFuture<String> ();
+		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/wallet/Wallet.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/wallet/Wallet.java
@@ -31,7 +31,7 @@ public class Wallet extends IndyJava.API {
 
 	private static Callback createWalletCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -44,7 +44,7 @@ public class Wallet extends IndyJava.API {
 
 	private static Callback openWalletCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, int handle) {
 
 			CompletableFuture<Wallet> future = (CompletableFuture<Wallet>) removeFuture(xcommand_handle);
@@ -59,7 +59,7 @@ public class Wallet extends IndyJava.API {
 
 	private static Callback closeWalletCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -72,7 +72,7 @@ public class Wallet extends IndyJava.API {
 
 	private static Callback deleteWalletCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -85,7 +85,7 @@ public class Wallet extends IndyJava.API {
 
 	private static Callback walletSetSeqNoForValueCb = new Callback() {
 
-		@SuppressWarnings({ "unused", "unchecked" })
+		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err) {
 
 			CompletableFuture<Void> future = (CompletableFuture<Void>) removeFuture(xcommand_handle);
@@ -111,7 +111,7 @@ public class Wallet extends IndyJava.API {
 			String config,
 			String credentials) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_create_wallet(
@@ -133,7 +133,7 @@ public class Wallet extends IndyJava.API {
 			String runtimeConfig,
 			String credentials) throws IndyException {
 
-		CompletableFuture<Wallet> future = new CompletableFuture<Wallet> ();
+		CompletableFuture<Wallet> future = new CompletableFuture<Wallet>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_open_wallet(
@@ -151,7 +151,7 @@ public class Wallet extends IndyJava.API {
 	private static CompletableFuture<Void> closeWallet(
 			Wallet wallet) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int handle = wallet.getWalletHandle();
@@ -170,7 +170,7 @@ public class Wallet extends IndyJava.API {
 			String name,
 			String credentials) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int result = LibIndy.api.indy_delete_wallet(
@@ -189,7 +189,7 @@ public class Wallet extends IndyJava.API {
 			String walletKey,
 			String configName) throws IndyException {
 
-		CompletableFuture<Void> future = new CompletableFuture<Void> ();
+		CompletableFuture<Void> future = new CompletableFuture<Void>();
 		int commandHandle = addFuture(future);
 
 		int walletHandle = wallet.getWalletHandle();

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/AgentTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/AgentTest.java
@@ -3,7 +3,7 @@ package org.hyperledger.indy.sdk;
 import org.hyperledger.indy.sdk.agent.Agent;
 import org.hyperledger.indy.sdk.agent.Agent.Connection;
 import org.hyperledger.indy.sdk.agent.Agent.Listener;
-import org.hyperledger.indy.sdk.agent.AgentObservers.IncomingConnectionObserver;
+import org.hyperledger.indy.sdk.agent.AgentObservers.ConnectionObserver;
 import org.hyperledger.indy.sdk.agent.AgentObservers.MessageObserver;
 import org.hyperledger.indy.sdk.ledger.Ledger;
 import org.hyperledger.indy.sdk.pool.Pool;
@@ -67,7 +67,7 @@ public class AgentTest extends IndyIntegrationTest {
 			}
 		};
 
-		final IncomingConnectionObserver incomingConnectionObserver = new IncomingConnectionObserver() {
+		final ConnectionObserver incomingConnectionObserver = new ConnectionObserver() {
 
 			public MessageObserver onConnection(Listener listener, Connection connection, String senderDid, String receiverDid) {
 

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/IndyIntegrationTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/IndyIntegrationTest.java
@@ -14,11 +14,14 @@ import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
 public class IndyIntegrationTest {
+
+	public static final String TRUSTEE_SEED = "000000000000000000000000Trustee1";
+
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
 	@Rule
-	public Timeout globalTimeout = new Timeout(1, TimeUnit.SECONDS);
+	public Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
 
 	@Before
 	public void setUp() throws IOException {

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/utils/PoolUtils.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/utils/PoolUtils.java
@@ -11,6 +11,9 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 public class PoolUtils {
+
+	public static final String DEFAULT_POOL_NAME = "default_pool";
+
 	public static File createGenesisTxnFile(String filename) throws IOException {
 		return createGenesisTxnFile(filename, 4);
 	}
@@ -44,9 +47,8 @@ public class PoolUtils {
 	}
 
 	public static String createPoolLedgerConfig(int nodesCnt) throws InterruptedException, ExecutionException, IndyException, IOException {
-		String poolName = "test";
-		createPoolLedgerConfig(poolName, nodesCnt);
-		return poolName;
+		createPoolLedgerConfig(DEFAULT_POOL_NAME, nodesCnt);
+		return DEFAULT_POOL_NAME;
 	}
 
 	public static void createPoolLedgerConfig(String poolName, int nodesCnt) throws IOException, InterruptedException, java.util.concurrent.ExecutionException, IndyException {


### PR DESCRIPTION
new PR based on @jovfer 's feature/java_agent_rm_listener_observer branch, just renaming IncomingConnectionObserver back to ConnectionObserver, and adding some whitespace style changes