### PR TITLE
Java method name did not match the SDK function.

### DIFF
--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
@@ -115,7 +115,7 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
-	private static Callback proverCreateClaimReqCb = new Callback() {
+	private static Callback proverCreateAndStoreClaimReqCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
 		public void callback(int xcommand_handle, int err, String claim_req_json) {
@@ -357,7 +357,7 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
-	public static CompletableFuture<String> proverCreateClaimReq(
+	public static CompletableFuture<String> proverCreateAndStoreClaimReq(
 			Wallet wallet,
 			String proverDid,
 			String claimOfferJson,
@@ -376,7 +376,7 @@ public class Anoncreds extends IndyJava.API {
 				claimOfferJson,
 				claimDefJson,
 				masterSecretName,
-				proverCreateClaimReqCb);
+				proverCreateAndStoreClaimReqCb);
 
 		checkResult(result);
 

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/AnoncredsIntegrationTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/AnoncredsIntegrationTest.java
@@ -62,7 +62,7 @@ public class AnoncredsIntegrationTest {
 
 		String claimOffer = String.format("{\"issuer_did\":\"%s\",\"schema_seq_no\":%d}", issuerDid, 1);
 
-		String claimRequest = Anoncreds.proverCreateClaimReq(wallet, "CnEDk9HrMnmiHXEV1WFgbVCRteYnPqsJwrTdcZaNhFVW", claimOffer, claimDef, masterSecretName).get();
+		String claimRequest = Anoncreds.proverCreateAndStoreClaimReq(wallet, "CnEDk9HrMnmiHXEV1WFgbVCRteYnPqsJwrTdcZaNhFVW", claimOffer, claimDef, masterSecretName).get();
 
 		String claim = "{\"sex\":[\"male\",\"5944657099558967239210949258394887428692050081607692519917050011144233115103\"],\n" +
 				"                 \"name\":[\"Alex\",\"1139481716457488690172217916278103335\"],\n" +

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/ProverCreateAndStoreClaimReqTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/ProverCreateAndStoreClaimReqTest.java
@@ -15,7 +15,7 @@ public class ProverCreateAndStoreClaimReqTest extends AnoncredsIntegrationTest {
 
 		String claimOffer = String.format(claimOfferTemplate, issuerDid, 1);
 
-		Anoncreds.proverCreateClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
+		Anoncreds.proverCreateAndStoreClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
 	}
 
 	@Test
@@ -28,7 +28,7 @@ public class ProverCreateAndStoreClaimReqTest extends AnoncredsIntegrationTest {
 
 		String claimOffer = String.format(claimOfferTemplate, "acWziYqKpYi6ov5FcYDi1e3", 1);
 
-		Anoncreds.proverCreateClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
+		Anoncreds.proverCreateAndStoreClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
 	}
 
 	@Test
@@ -41,7 +41,7 @@ public class ProverCreateAndStoreClaimReqTest extends AnoncredsIntegrationTest {
 
 		String claimOffer = String.format(claimOfferTemplate, issuerDid, 2);
 
-		Anoncreds.proverCreateClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
+		Anoncreds.proverCreateAndStoreClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
 	}
 
 	@Test
@@ -54,7 +54,7 @@ public class ProverCreateAndStoreClaimReqTest extends AnoncredsIntegrationTest {
 
 		String claimOffer = String.format("{\"issuer_did\":\"%s\"}", issuerDid);
 
-		Anoncreds.proverCreateClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
+		Anoncreds.proverCreateAndStoreClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
 	}
 
 	@Test
@@ -67,6 +67,6 @@ public class ProverCreateAndStoreClaimReqTest extends AnoncredsIntegrationTest {
 
 		String claimOffer = String.format(claimOfferTemplate, issuerDid, 1);
 
-		Anoncreds.proverCreateClaimReq(wallet, proverDid, claimOffer, claimDef, "other_master_secret").get();
+		Anoncreds.proverCreateAndStoreClaimReq(wallet, proverDid, claimOffer, claimDef, "other_master_secret").get();
 	}
 }

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/ProverStoreClaimTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/ProverStoreClaimTest.java
@@ -21,7 +21,7 @@ public class ProverStoreClaimTest extends AnoncredsIntegrationTest {
 
 		String claimOffer = String.format(claimOfferTemplate, issuerDid, 1);
 
-		String claimRequest = Anoncreds.proverCreateClaimReq(proverWallet, proverDid, claimOffer, claimDef, masterSecretName).get();
+		String claimRequest = Anoncreds.proverCreateAndStoreClaimReq(proverWallet, proverDid, claimOffer, claimDef, masterSecretName).get();
 
 		String claim = "{\"sex\":[\"male\",\"5944657099558967239210949258394887428692050081607692519917050011144233115103\"],\n" +
 				"                 \"name\":[\"Alex\",\"1139481716457488690172217916278103335\"],\n" +
@@ -66,7 +66,7 @@ public class ProverStoreClaimTest extends AnoncredsIntegrationTest {
 
 		String claimOffer = String.format(claimOfferTemplate, issuerDid, 1);
 
-		Anoncreds.proverCreateClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
+		Anoncreds.proverCreateAndStoreClaimReq(wallet, proverDid, claimOffer, claimDef, masterSecretName).get();
 
 		String claimJson = "{\"claim\":{\"sex\":[\"male\",\"1\"],\"age\":[\"28\",\"28\"],\"name\":[\"Alex\",\"1\"],\"height\":[\"175\",\"175\"]},\n" +
 				"            \"issuer_did\":1,\"\n" +

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/demo/AnoncredsDemoTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/demo/AnoncredsDemoTest.java
@@ -99,7 +99,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		//8. Prover create ClaimReq
 		String proverDid = "BzfFCYk";
-		String claimReq = Anoncreds.proverCreateClaimReq(proverWallet, proverDid, claimOfferJson, claimDef, masterSecret).get();
+		String claimReq = Anoncreds.proverCreateAndStoreClaimReq(proverWallet, proverDid, claimOfferJson, claimDef, masterSecret).get();
 		assertNotNull(claimReq);
 
 		//9. Issuer create Claim
@@ -236,7 +236,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		//8. Prover create ClaimReq for GVT Claim Offer
 		String proverDid = "BzfFCYk";
-		String gvtClaimReq = Anoncreds.proverCreateClaimReq(proverWallet, proverDid, gvtClaimOffer, gvtClaimDef, masterSecret).get();
+		String gvtClaimReq = Anoncreds.proverCreateAndStoreClaimReq(proverWallet, proverDid, gvtClaimOffer, gvtClaimDef, masterSecret).get();
 
 		//9. Issuer create Claim
 		String gvtClaimAttributesJson = "{\n" +
@@ -253,7 +253,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 		Anoncreds.proverStoreClaim(proverWallet, gvtClaimJson).get();
 
 		//11. Prover create ClaimReq for GVT Claim Offer
-		String xyzClaimReq = Anoncreds.proverCreateClaimReq(proverWallet, proverDid, xyzClaimOffer, xyzClaimDef, masterSecret).get();
+		String xyzClaimReq = Anoncreds.proverCreateAndStoreClaimReq(proverWallet, proverDid, xyzClaimOffer, xyzClaimDef, masterSecret).get();
 
 		//12. Issuer create Claim
 		String xyzClaimAttributesJson = "{\n" +
@@ -389,7 +389,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		//7. Prover create ClaimReq for GVT Claim Offer
 		String proverDid = "BzfFCYk";
-		String gvtClaimReq = Anoncreds.proverCreateClaimReq(proverWallet, proverDid, gvtClaimOffer, gvtClaimDef, masterSecret).get();
+		String gvtClaimReq = Anoncreds.proverCreateAndStoreClaimReq(proverWallet, proverDid, gvtClaimOffer, gvtClaimDef, masterSecret).get();
 
 		//8. Issuer create Claim
 		String gvtClaimAttributesJson = "{\n" +
@@ -406,7 +406,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 		Anoncreds.proverStoreClaim(proverWallet, gvtClaimJson).get();
 
 		//10. Prover create ClaimReq for GVT Claim Offer
-		String xyzClaimReq = Anoncreds.proverCreateClaimReq(proverWallet, proverDid, xyzClaimOffer, xyzClaimDef, masterSecret).get();
+		String xyzClaimReq = Anoncreds.proverCreateAndStoreClaimReq(proverWallet, proverDid, xyzClaimOffer, xyzClaimDef, masterSecret).get();
 
 		//11. Issuer create Claim
 		String xyzClaimAttributesJson = "{\n" +
@@ -514,7 +514,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		//5. Prover create ClaimReq
 		String proverDid = "BzfFCYk";
-		String claimReq = Anoncreds.proverCreateClaimReq(proverWallet, proverDid, claimOfferJson, claimDef, masterSecret).get();
+		String claimReq = Anoncreds.proverCreateAndStoreClaimReq(proverWallet, proverDid, claimOfferJson, claimDef, masterSecret).get();
 		assertNotNull(claimReq);
 
 		//6. Issuer create Claim


### PR DESCRIPTION
The proverCreateClaimReq() method name did not match the underlying SDK function name indy_prover_create_and_store_claim_req.