### PR TITLE
Javadocs

### DIFF
--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/ErrorCode.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/ErrorCode.java
@@ -3,119 +3,204 @@ package org.hyperledger.indy.sdk;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Enumeration of error codes returned by the indy SDK.
+ */
 public enum ErrorCode {
 
+	/**
+	 * Success
+	 */
 	Success(0),
 
 	// Common errors
 
-	// Caller passed invalid value as param 1 (null, invalid json and etc..)
+	/**
+	 * Caller passed invalid value as param 1 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam1(100),
 
-	// Caller passed invalid value as param 2 (null, invalid json and etc..)
+	/**
+	 * Caller passed invalid value as param 2 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam2(101),
 
-	// Caller passed invalid value as param 3 (null, invalid json and etc..)
+	/**
+	 * Caller passed invalid value as param 3 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam3(102),
 
-	// Caller passed invalid value as param 4 (null, invalid json and etc..)
+	/**
+	 * Caller passed invalid value as param 4 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam4(103),
 
-	// Caller passed invalid value as param 5 (null, invalid json and etc..)
+	/**
+	 * Caller passed invalid value as param 5 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam5(104),
-
-	// Caller passed invalid value as param 6 (null, invalid json and etc..)
+ 
+	/**
+	 * Caller passed invalid value as param 6 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam6(105),
 
-	// Caller passed invalid value as param 7 (null, invalid json and etc..)
+	/**
+	 * Caller passed invalid value as param 7 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam7(106),
 
-	// Caller passed invalid value as param 8 (null, invalid json and etc..)
+	/**
+	 * Caller passed invalid value as param 8 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam8(107),
 
-	// Caller passed invalid value as param 9 (null, invalid json and etc..)
+	/**
+	 * Caller passed invalid value as param 9 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam9(108),
-
-	// Caller passed invalid value as param 10 (null, invalid json and etc..)
+ 
+	/**
+	 * Caller passed invalid value as param 10 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam10(109),
-
-	// Caller passed invalid value as param 11 (null, invalid json and etc..)
+ 
+	/**
+	 * Caller passed invalid value as param 11 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam11(110),
 
-	// Caller passed invalid value as param 12 (null, invalid json and etc..)
+	/**
+	 * Caller passed invalid value as param 12 (null, invalid json and etc..)
+	 */
 	CommonInvalidParam12(111),
 
-	// Invalid library state was detected in runtime. It signals library bug
+	/**
+	 * Invalid library state was detected in runtime. It signals library bug
+	 */
 	CommonInvalidState(112),
-
-	// Object (json, config, key, claim and etc...) passed by library caller has invalid structure
+ 
+	/**
+	 * Object (json, config, key, claim and etc...) passed by library caller has invalid structure
+	 */
 	CommonInvalidStructure(113),
 
-	// IO Error
+	/**
+	 * IO Error
+	 */
 	CommonIOError(114),
 
 	// Wallet errors
-	// Caller passed invalid wallet handle
+	 
+	/**
+	 * Caller passed invalid wallet handle
+	 */
 	WalletInvalidHandle(200),
 
-	// Unknown type of wallet was passed on create_wallet
+	/**
+	 * Unknown type of wallet was passed on create_wallet
+	 */
 	WalletUnknownTypeError(201),
 
-	// Attempt to register already existing wallet type
+	/**
+	 * Attempt to register already existing wallet type
+	 */
 	WalletTypeAlreadyRegisteredError(202),
 
-	// Attempt to create wallet with name used for another exists wallet
+	/**
+	 * Attempt to create wallet with name used for another exists wallet
+	 */
 	WalletAlreadyExistsError(203),
-
-	// Requested entity id isn't present in wallet
+ 
+	/**
+	 * Requested entity id isn't present in wallet
+	 */
 	WalletNotFoundError(204),
-
-	// Trying to use wallet with pool that has different name
+ 
+	/**
+	 * Trying to use wallet with pool that has different name
+	 */
 	WalletIncompatiblePoolError(205),
 
-	// Trying to open wallet that was opened already
+	/**
+	 * Trying to open wallet that was opened already
+	 */
 	WalletAlreadyOpenedError(206),
 
 	// Ledger errors
-	// Trying to open pool ledger that wasn't created before
+	
+	/**
+	 * Trying to open pool ledger that wasn't created before
+	 */
 	PoolLedgerNotCreatedError(300),
 
-	// Caller passed invalid pool ledger handle
+	/**
+	 * Caller passed invalid pool ledger handle
+	 */
 	PoolLedgerInvalidPoolHandle(301),
 
-	// Pool ledger terminated
+	/**
+	 * Pool ledger terminated
+	 */
 	PoolLedgerTerminated(302),
 
-	// No concensus during ledger operation
+	/**
+	 *  No concensus during ledger operation
+	 */
 	LedgerNoConsensusError(303),
 
-	// Attempt to send unknown or incomplete transaction message
+	/**
+	 * Attempt to send unknown or incomplete transaction message
+	 */
 	LedgerInvalidTransaction(304),
-
-	// Attempt to send transaction without the necessary privileges
+	
+	/**
+	 * Attempt to send transaction without the necessary privileges
+	 */
 	LedgerSecurityError(305),
 
 	// Crypto errors
-	// Revocation registry is full and creation of new registry is necessary
+
+	/**
+	 * Revocation registry is full and creation of new registry is necessary
+	 */
 	AnoncredsRevocationRegistryFullError(400),
 
+	/**
+	 * ???
+	 */
 	AnoncredsInvalidUserRevocIndex(401),
 
+	/**
+	 * ???
+	 */
 	AnoncredsAccumulatorIsFull(402),
 
+	/**
+	 * ???
+	 */
 	AnoncredsNotIssuedError(403),
-
-	// Attempt to generate master secret with dupplicated name
+ 
+	/**
+	 * Attempt to generate master secret with dupplicated name
+	 */
 	AnoncredsMasterSecretDuplicateNameError(404),
 
+	/**
+	 * ???
+	 */
 	AnoncredsProofRejected(405),
 
 	// Signus errors
-	// Unknown format of DID entity keys
+	
+	/**
+	 * Unknown format of DID entity keys
+	 */
 	SignusUnknownCryptoError(500);
 
 	private int value;
 	private static Map<Integer, ErrorCode> map = new HashMap<Integer, ErrorCode>();
+	
 	private ErrorCode(int value) {
 
 		this.value = value;
@@ -129,11 +214,22 @@ public enum ErrorCode {
 		}
 	}
 
+	/**
+	 * Gets the ErrorCode that corresponds to the specified int value.
+	 * 
+	 * @param value	The integer to get the error code for.
+	 * @return	The ErrorCode that corresponds to the specified integer.
+	 */
 	public static ErrorCode valueOf(int value) {
 
 		return map.get(Integer.valueOf(value));
 	}
 
+	/**
+	 * Gets the integer value for a specific ErrorCode.
+	 * 
+	 * @return The integer value of the ErrorCode.
+	 */
 	public int value() {
 
 		return this.value;

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/IndyConstants.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/IndyConstants.java
@@ -1,8 +1,18 @@
 package org.hyperledger.indy.sdk;
 
+/**
+ * Constants used by the Indy SDK.
+ */
 public class IndyConstants {
 
+	/**
+	 * The Trustee role.
+	 */
 	public static final String ROLE_TRUSTEE = "TRUSTEE";
+	
+	/**
+	 * The Steward role.
+	 */
 	public static final String ROLE_STEWARD = "STEWARD";
 
 	public static final String OP_NODE = "0";

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/IndyException.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/IndyException.java
@@ -1,21 +1,39 @@
 package org.hyperledger.indy.sdk;
 
+/**
+ * Indy specific exception.
+ */
 public class IndyException extends Exception {
 
 	private static final long serialVersionUID = 2650355290834266477L;
 
 	private ErrorCode errorCode;
 
+	/**
+	 * Initializes a new IndyException with the specified message.
+	 * 
+	 * @param message The message for the exception.
+	 */
 	public IndyException(String message) {
 
 		super(message);
 	}
 
+	/**
+	 * Initializes a new IndyException using the specified ErrorCode.
+	 * 
+	 * @param errorCode The error code for the exception.
+	 */
 	public IndyException(ErrorCode errorCode) {
 		this(String.format("%s: %d", errorCode.name(), errorCode.value()));
 		this.errorCode = errorCode;
 	}
 
+	/**
+	 * Gets the ErrorCode for the exception.
+	 * 
+	 * @return The ErrorCode used to construct the exception.
+	 */
 	public ErrorCode getErrorCode() {
 		return errorCode;
 	}

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/IndyJava.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/IndyJava.java
@@ -22,6 +22,9 @@ public class IndyJava {
 	 * API
 	 */
 
+	/**
+	 * Common features for API classes.
+	 */
 	public static class API {
 
 		/*
@@ -31,11 +34,22 @@ public class IndyJava {
 		private static AtomicInteger atomicInteger = new AtomicInteger();
 		private static Map<Integer, CompletableFuture<?>> futures = new ConcurrentHashMap<Integer, CompletableFuture<?>>();
 
+		/**
+		 * Generates and returns a new command handle.
+		 * 
+		 * @return The new command handle.
+		 */
 		protected static int newCommandHandle() {
 
 			return Integer.valueOf(atomicInteger.incrementAndGet());
 		}
 
+		/**
+		 * Adds a future to track.
+		 * 
+		 * @param future The future to track.
+		 * @return The command handle the future is being tracked against.
+		 */
 		protected static int addFuture(CompletableFuture<?> future) {
 
 			int commandHandle = newCommandHandle();
@@ -45,6 +59,12 @@ public class IndyJava {
 			return commandHandle;
 		}
 
+		/**
+		 * Stops tracking the future associated with the provided command handle and returns it.
+		 * 
+		 * @param xcommand_handle The command handle for the future to stop tracking.
+		 * @return The future associated with the command handle.
+		 */
 		protected static CompletableFuture<?> removeFuture(int xcommand_handle) {
 
 			CompletableFuture<?> future = futures.remove(Integer.valueOf(xcommand_handle));
@@ -57,6 +77,13 @@ public class IndyJava {
 		 * ERROR CHECKING
 		 */
 
+		/**
+		 * Sets the provided future with an exception if the error code provided does not indicate success.
+		 * 
+		 * @param future The future.
+		 * @param err The error value to check.
+		 * @return true if the error code indeicated Success, otherwise false.
+		 */
 		protected static boolean checkCallback(CompletableFuture<?> future, int err) {
 
 			ErrorCode errorCode = ErrorCode.valueOf(err);
@@ -65,12 +92,25 @@ public class IndyJava {
 			return true;
 		}
 
+		//TODO: Is this redundant?
+		/**
+		 * Throws an IndyException if the provided error code does not indicate success.
+		 * 
+		 * @param err The error code to check.
+		 * @throws IndyException Thrown if the error code does not indicate success.
+		 */
 		protected static void checkCallback(int err) throws IndyException {
 
 			ErrorCode errorCode = ErrorCode.valueOf(err);
 			if (! ErrorCode.Success.equals(errorCode)) throw new IndyException(errorCode);
 		}
 
+		/**
+		 * Throws an IndyException if the provided error code does not indicate success.
+		 * 
+		 * @param err The error code to check.
+		 * @throws IndyException Thrown if the error code does not indicate success.
+		 */
 		protected static void checkResult(int err) throws IndyException {
 
 			ErrorCode errorCode = ErrorCode.valueOf(err);
@@ -104,6 +144,9 @@ public class IndyJava {
 	 * JSON PARAMETER
 	 */
 
+	/**
+	 * Base class for parameter objects that return JSON.
+	 */
 	public abstract static class JsonParameter {
 
 		protected Map<String, Object> map = new HashMap<String, Object>();
@@ -112,6 +155,11 @@ public class IndyJava {
 		 * JSON CREATION
 		 */
 
+		/**
+		 * Converts the map of parameters to a JSON string.
+		 * 
+		 * @return The JSON string.
+		 */
 		public final String toJson() {
 
 			StringBuilder builder = new StringBuilder();

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
@@ -14,6 +14,9 @@ public abstract class LibIndy {
 	 * Native library interface
 	 */
 
+	/**
+	 * JNA method signatures for calling SDK function.
+	 */
 	public interface API extends Library {
 
 		// pool.rs
@@ -103,16 +106,29 @@ public abstract class LibIndy {
 		}
 	}
 
+	/**
+	 * Initializes the API with the path to the C-Callable library.
+	 * 
+	 * @param file The path to the C-Callable library.
+	 */
 	public static void init(File file) {
 
 		api = Native.loadLibrary(file.getAbsolutePath(), API.class);
 	}
 
+	/**
+	 * Initializes the API with the default library.
+	 */
 	public static void init() {
 
 		api = Native.loadLibrary(LIBRARY_NAME, API.class);
 	}
 
+	/**
+	 * Indicates whether or not the API has been initialized.
+	 * 
+	 * @return true if the API is initialize, otherwise false.
+	 */
 	public static boolean isInitialized() {
 
 		return api != null;

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/Agent.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/Agent.java
@@ -15,6 +15,10 @@ import com.sun.jna.Callback;
 /**
  * agent.rs API
  */
+
+/**
+ * Agent related functionality.
+ */
 public class Agent extends IndyJava.API {
 
 	private static Map<Integer, Agent.Connection> connections = new ConcurrentHashMap<Integer, Agent.Connection>();
@@ -31,6 +35,12 @@ public class Agent extends IndyJava.API {
 	private static Map<Integer, AgentObservers.MessageObserver> messageObserver = new ConcurrentHashMap<Integer, AgentObservers.MessageObserver>();
 	private static Map<Integer, AgentObservers.ConnectionObserver> connectionObservers = new ConcurrentHashMap<Integer, AgentObservers.ConnectionObserver>();
 
+	/**
+	 * Adds a message observer to track against the specified command handle.
+	 * 
+	 * @param commandHandle The command handle to track against.
+	 * @param messageObserver	The message observer to track.
+	 */
 	private static void addMessageObserver(int commandHandle, AgentObservers.MessageObserver messageObserver) {
 
 		assert(! Agent.messageObserver.containsKey(commandHandle));
@@ -38,6 +48,12 @@ public class Agent extends IndyJava.API {
 
 	}
 
+	/**
+	 * Removes a message observer from tracking.
+	 * 
+	 * @param xcommand_handle The command handle the message observer is tracked against.
+	 * @return The message observer.
+	 */
 	private static AgentObservers.MessageObserver removeMessageObserver(int xcommand_handle) {
 
 		AgentObservers.MessageObserver future = messageObserver.remove(xcommand_handle);
@@ -46,6 +62,12 @@ public class Agent extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Adds a connection observer to track against the specified command handle.
+	 * 
+	 * @param commandHandle The command handle to track against.
+	 * @param connectionObserver The connection observer to track.
+	 */
 	private static void addConnectionObserver(int commandHandle, AgentObservers.ConnectionObserver connectionObserver) {
 
 		assert(! connectionObservers.containsKey(commandHandle));
@@ -53,6 +75,12 @@ public class Agent extends IndyJava.API {
 
 	}
 
+	/**
+	 * Removes a connection observer from tracking.
+	 * 
+	 * @param xcommand_handle The command handle the connection observer is tracked against.
+	 * @return The connection observer.
+	 */
 	private static AgentObservers.ConnectionObserver removeConnectionObserver(int xcommand_handle) {
 
 		AgentObservers.ConnectionObserver future = connectionObservers.remove(xcommand_handle);
@@ -65,6 +93,9 @@ public class Agent extends IndyJava.API {
 	 * STATIC CALLBACKS
 	 */
 
+	/**
+	 * Callback used when an outgoing connection is established.
+	 */
 	private static Callback agentConnectConnectionCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -83,6 +114,9 @@ public class Agent extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when am outgoing connection receives a message.
+	 */
 	private static Callback agentConnectMessageCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -98,6 +132,9 @@ public class Agent extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when a listener is ready to accept connections.
+	 */
 	private static Callback agentListenListenerCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -116,6 +153,9 @@ public class Agent extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when a listener receives an incoming connection.
+	 */
 	private static Callback agentListenConnectionCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -135,6 +175,9 @@ public class Agent extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when a listener connection receives a message.
+	 */
 	private static Callback agentListenMessageCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -150,6 +193,9 @@ public class Agent extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when an identity is added to a listener.
+	 */
 	private static Callback agentAddIdentityCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -162,6 +208,9 @@ public class Agent extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when an identity is removed from a listener.
+	 */
 	private static Callback agentRemoveIdentityCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -174,6 +223,9 @@ public class Agent extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when a message is sent.
+	 */
 	private static Callback agentSendCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -186,6 +238,9 @@ public class Agent extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when a connection is closed.
+	 */
 	private static Callback agentCloseConnectionCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -198,6 +253,9 @@ public class Agent extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when a listener is closed.
+	 */
 	private static Callback agentCloseListenerCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -214,6 +272,17 @@ public class Agent extends IndyJava.API {
 	 * STATIC METHODS
 	 */
 
+	/**
+	 * Establishes an outgoing connection.
+	 * 
+	 * @param pool The pool.
+	 * @param wallet The wallet.
+	 * @param senderDid The sender DID.
+	 * @param receiverDid The receiver DID.
+	 * @param messageObserver The message observer that will be notified when a message is received on the connection.
+	 * @return A future that resolves to a Connection.
+	 * @throws IndyException Thrown if a failure occurs when calling the SDK.
+	 */
 	public static CompletableFuture<Connection> agentConnect(
 			Pool pool,
 			Wallet wallet,
@@ -242,6 +311,14 @@ public class Agent extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Starts a listener that listens for incoming connections.
+	 * 
+	 * @param endpoint The endpoint on which the listener should listen for connections.
+	 * @param connectionObserver An observer that will be notified when new incoming connections are established.
+	 * @return A future that resolves to a listener.
+	 * @throws IndyException Thrown if an error occurs when calling the SDK.
+	 */
 	public static CompletableFuture<Listener> agentListen(
 			String endpoint,
 			AgentObservers.ConnectionObserver connectionObserver) throws IndyException {
@@ -262,6 +339,16 @@ public class Agent extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Adds an identity to the specified listener.
+	 * 
+	 * @param listener The listener to add the identity to.
+	 * @param pool The pool.
+	 * @param wallet The wallet.
+	 * @param did The DID of the identity to add.
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+	 */
 	public static CompletableFuture<Void> agentAddIdentity(
 			Agent.Listener listener,
 			Pool pool,
@@ -288,6 +375,15 @@ public class Agent extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Removes an identity from the specified listener.
+	 * 
+	 * @param listener The listener to remove the identity from.
+	 * @param wallet The wallet.
+	 * @param did The DID of the identity to remove.
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+	 */
 	public static CompletableFuture<Void> agentRemoveIdentity(
 			Agent.Listener listener,
 			Wallet wallet,
@@ -311,6 +407,14 @@ public class Agent extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Sends a message to the specified connection.
+	 * 
+	 * @param connection The connection to send the message to.
+	 * @param message The message to send.
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+	 */
 	public static CompletableFuture<Void> agentSend(
 			Agent.Connection connection,
 			String message) throws IndyException {
@@ -331,6 +435,13 @@ public class Agent extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Closes the provided connection.
+	 * 
+	 * @param connection The connection to close. 
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+	 */
 	public static CompletableFuture<Void> agentCloseConnection(
 			Agent.Connection connection) throws IndyException {
 
@@ -351,6 +462,13 @@ public class Agent extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Closes the specified listener.
+	 * 
+	 * @param listener The listener to close.
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+	 */
 	public static CompletableFuture<Void> agentCloseListener(
 			Agent.Listener listener) throws IndyException {
 
@@ -375,6 +493,9 @@ public class Agent extends IndyJava.API {
 	 * NESTED CLASSES WITH INSTANCE METHODS
 	 */
 
+	/**
+	 * Listens for incoming connections.
+	 */
 	public static class Listener {
 
 		private final int listenerHandle;
@@ -385,27 +506,58 @@ public class Agent extends IndyJava.API {
 			this.listenerHandle = listenerHandle;
 		}
 
+		/**
+		 * Gets the handle of the listener.
+		 * 
+		 * @return The handle of the listener.
+		 */
 		public int getListenerHandle() {
 
 			return this.listenerHandle;
 		}
 
+		/**
+		 * Adds an identity to the listener.
+		 * 
+		 * @param pool The pool.
+		 * @param wallet The wallet.
+		 * @param did The DID of the identity to add.
+		 * @return A future that does not resolve a value.
+		 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+		 */
 		public CompletableFuture<Void> agentAddIdentity(Pool pool, Wallet wallet, String did) throws IndyException {
 
 			return Agent.agentAddIdentity(this, pool, wallet, did);
 		}
 
+		/**
+		 * Removes an identity from the listener.
+		 * 
+		 * @param wallet The wallet.
+		 * @param did The DID of the identity to remove.
+		 * @return A future that does not resolve a value.
+		 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+		 */
 		public CompletableFuture<Void> agentRemoveIdentity(Wallet wallet, String did) throws IndyException {
 
 			return Agent.agentRemoveIdentity(this, wallet, did);
 		}
 
+		/**
+		 * Closes the listener.
+		 * 
+		 * @return A future that does not resolve a value.
+		 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+		 */
 		public CompletableFuture<Void> agentCloseListener() throws IndyException {
 
 			return Agent.agentCloseListener(this);
 		}
 	}
 
+	/**
+	 * A connection between two agents.
+	 */
 	public static class Connection {
 
 		private final int connectionHandle;
@@ -416,16 +568,34 @@ public class Agent extends IndyJava.API {
 			this.connectionHandle = connectionHandle;
 		}
 
+		/**
+		 * Gets the handle of the connection.
+		 * 
+		 * @return The handle of the connection.
+		 */
 		public int getConnectionHandle() {
 
 			return this.connectionHandle;
 		}
 
+		/**
+		 * Sends a message on the connection.
+		 * 
+		 * @param message The message to send.
+		 * @return A future that does not resolve a value.
+		 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+		 */
 		public CompletableFuture<Void> agentSend(String message) throws IndyException {
 
 			return Agent.agentSend(this, message);
 		}
 
+		/**
+		 * Closes the connection.
+		 * 
+		 * @return A future that does not resolve a value.
+		 * @throws IndyException Thrown if an error occurs when calling the SDK. 
+		 */
 		public CompletableFuture<Void> agentCloseConnection() throws IndyException {
 
 			return Agent.agentCloseConnection(this);

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/AgentObservers.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/agent/AgentObservers.java
@@ -3,19 +3,43 @@ package org.hyperledger.indy.sdk.agent;
 /**
  * agent.rs observers
  */
+/**
+ * Observer interfaces for agents.
+ */
 public final class AgentObservers {
 
 	private AgentObservers() {
 
 	}
 
+	/**
+	 * An observer to receive notification of the establishment of a connection.
+	 */
 	public interface ConnectionObserver {
 
+		/**
+		 * Called when a connection is established.
+		 * 
+		 * @param listener The listener the connection is associated with.  Can be null for outgoing connections.
+		 * @param connection The connection that has been established.
+		 * @param senderDid The DID of the identity that initated the connection.
+		 * @param receiverDid The DID of the identity that received the connection.
+		 * @return A MessageObserver that will receive notifications when the connection receives a message.
+		 */
 		public MessageObserver onConnection(Agent.Listener listener, Agent.Connection connection, String senderDid, String receiverDid);
 	}
 
+	/**
+	 * An observer to receive notification of the receipt of a message.
+	 */
 	public interface MessageObserver {
 
+		/**
+		 * Called when a message is received.
+		 * 
+		 * @param connection The connection the message was received on.
+		 * @param message The received message.
+		 */
 		public void onMessage(Agent.Connection connection, String message);
 	}
 }

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
@@ -14,6 +14,10 @@ import com.sun.jna.Callback;
 /**
  * anoncreds.rs API
  */
+
+/**
+ * Functionality for anonymous credentials
+ */
 public class Anoncreds extends IndyJava.API {
 
 	private Anoncreds() {
@@ -24,6 +28,9 @@ public class Anoncreds extends IndyJava.API {
 	 * STATIC CALLBACKS
 	 */
 
+	/**
+	 * Callback used when issuerCreateAndStoreClaimDef completes.
+	 */
 	private static Callback issuerCreateAndStoreClaimDefCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -37,6 +44,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when issuerCreateAndStoreRevocReg completes.
+	 */
 	private static Callback issuerCreateAndStoreRevocRegCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -50,6 +60,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when issuerCreateClaim completes.
+	 */
 	private static Callback issuerCreateClaimCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -63,6 +76,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when issuerRevokeClaim completes.
+	 */
 	private static Callback issuerRevokeClaimCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -76,6 +92,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when proverStoreClaimOffer completes.
+	 */
 	private static Callback proverStoreClaimOfferCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -89,6 +108,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when proverGetClaimOffers completes.
+	 */
 	private static Callback proverGetClaimOffersCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -102,6 +124,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when proverCreateMasterSecret completes.
+	 */
 	private static Callback proverCreateMasterSecretCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -115,6 +140,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when proverCreateAndStoreClaimReq completes.
+	 */
 	private static Callback proverCreateClaimReqCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -128,6 +156,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when proverStoreClaim completes.
+	 */
 	private static Callback proverStoreClaimCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -141,6 +172,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when proverGetClaims completes.
+	 */
 	private static Callback proverGetClaimsCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -154,6 +188,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when proverGetClaimsForProofReq completes.
+	 */
 	private static Callback proverGetClaimsForProofReqCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -167,6 +204,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when proverCreateProof completes.
+	 */
 	private static Callback proverCreateProofCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -180,6 +220,9 @@ public class Anoncreds extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when verifierVerifyProof completes.
+	 */
 	private static Callback verifierVerifyProofCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -199,6 +242,17 @@ public class Anoncreds extends IndyJava.API {
 	 * STATIC METHODS
 	 */
 
+	/**
+	 * Create keys (both primary and revocation) for the given schema and signature type (currently only CL signature type is supported).
+	 * 
+	 * @param wallet The wallet.
+	 * @param issuerDid The DID of the issuer.
+	 * @param schemaJson The JSON schema for the claim.
+	 * @param signatureType The signature type.
+	 * @param createNonRevoc Whether or not to create a non-revokable claim definition.
+	 * @return A future resolving to a JSON string containing the claim definition.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> issuerCreateAndStoreClaimDef(
 			Wallet wallet,
 			String issuerDid,
@@ -225,6 +279,16 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Create a new revocation registry for the given claim definition
+	 * 
+	 * @param wallet The wallet.
+	 * @param issuerDid	The DID of the issuer.
+	 * @param schemaSeqNo The sequence number of the schema to use.
+	 * @param maxClaimNum The maximum claim numbber.
+	 * @return A future resolving to a JSON string containing the revocation registry.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<IssuerCreateAndStoreRevocRegResult> issuerCreateAndStoreRevocReg(
 			Wallet wallet,
 			String issuerDid,
@@ -249,6 +313,17 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Signs a given claim for the given user by a given key (claim def).
+	 * 
+	 * @param wallet The wallet.
+	 * @param claimReqJson  a claim request with a blinded secret
+	 * @param claimJson a claim containing attribute values for each of requested attribute names.
+	 * @param revocRegSeqNo (Optional, pass -1 if revoc_reg_seq_no is absentee) seq no of a revocation registry transaction in Ledger
+	 * @param userRevocIndex index of a new user in the revocation registry (optional, pass -1 if user_revoc_index is absentee; default one is used if not provided)
+	 * @return A future resolving to a revocation registry update json with a newly issued claim
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<IssuerCreateClaimResult> issuerCreateClaim(
 			Wallet wallet,
 			String claimReqJson, 
@@ -275,6 +350,15 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Revokes a user identified by a revoc_id in a given revoc-registry.
+	 * 
+	 * @param wallet A wallet.
+	 * @param revocRegSeqNo seq no of a revocation registry transaction in Ledger
+	 * @param userRevocIndex index of the user in the revocation registry
+	 * @return A future resolving to a revocation registry update json with a revoked claim
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> issuerRevokeClaim(
 			Wallet wallet,
 			int revocRegSeqNo, 
@@ -297,6 +381,14 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Stores a claim offer from the given issuer in a secure storage.
+	 * 
+	 * @param wallet A wallet.
+	 * @param claimOfferJson claim offer as a json containing information about the issuer and a claim
+	 * @return A future that does not resolve any value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<Void> proverStoreClaimOffer(
 			Wallet wallet,
 			String claimOfferJson) throws IndyException {
@@ -317,6 +409,14 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Gets all stored claim offers (see prover_store_claim_offer).
+	 * 
+	 * @param wallet A wallet.
+	 * @param filterJson optional filter to get claim offers for specific Issuer, claim_def or schema only only
+	 * @return A future that resolves to a json with a list of claim offers for the filter.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> proverGetClaimOffers(
 			Wallet wallet,
 			String filterJson) throws IndyException {
@@ -337,6 +437,14 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Creates a master secret with a given name and stores it in the wallet.
+	 * 
+	 * @param wallet A wallet.
+	 * @param masterSecretName a new master secret name.
+	 * @return A future that does not resolve any value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<Void> proverCreateMasterSecret(
 			Wallet wallet,
 			String masterSecretName) throws IndyException {
@@ -357,6 +465,17 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Creates a clam request json for the given claim offer and stores it in a secure wallet.
+	 * 
+	 * @param wallet A wallet.
+	 * @param proverDid The DID of the prover.
+	 * @param claimOfferJson claim offer as a json containing information about the issuer and a claim
+	 * @param claimDefJson claim definition json associated with issuer_did and schema_seq_no in the claim_offer
+	 * @param masterSecretName the name of the master secret stored in the wallet
+	 * @return A future that resolves to a claim request json.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> proverCreateClaimReq(
 			Wallet wallet,
 			String proverDid,
@@ -383,6 +502,14 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Updates the claim by a master secret and stores in a secure wallet.
+	 * 
+	 * @param wallet A Wallet.
+	 * @param claim The claim to store.
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<Void> proverStoreClaim(
 			Wallet wallet,
 			String claim) throws IndyException {
@@ -403,6 +530,14 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Gets human readable claims according to the filter.
+	 * 
+	 * @param wallet A wallet.
+	 * @param filter filter for claims
+	 * @return A future that resolves to a claims json
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> proverGetClaims(
 			Wallet wallet,
 			String filter) throws IndyException {
@@ -423,6 +558,14 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Gets human readable claims matching the given proof request.
+	 * 
+	 * @param wallet A wallet.
+	 * @param proofRequest proof request json
+	 * @return A future that resolves to a json with claims for the given pool request.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> proverGetClaimsForProofReq(
 			Wallet wallet,
 			String proofRequest) throws IndyException {
@@ -443,6 +586,19 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Creates a proof according to the given proof request.
+	 * 
+	 * @param wallet A wallet.
+	 * @param proofRequest proof request json as come from the verifier
+	 * @param requestedClaims either a claim or self-attested attribute for each requested attribute
+	 * @param schemas all schema jsons participating in the proof request
+	 * @param masterSecret the name of the master secret stored in the wallet
+	 * @param claimDefs all claim definition jsons participating in the proof request
+	 * @param revocRegs all revocation registry jsons participating in the proof request
+	 * @return A future resolving to a Proof json
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> proverCreateProof(
 			Wallet wallet,
 			String proofRequest,
@@ -473,6 +629,17 @@ public class Anoncreds extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Verifies a proof (of multiple claim).
+	 * 
+	 * @param proofRequest initial proof request as sent by the verifier
+	 * @param proof proof json
+	 * @param schemas all schema jsons participating in the proof
+	 * @param claimDefs all claim definition jsons participating in the proof
+	 * @param revocRegs all revocation registry jsons participating in the proof
+	 * @return A future resolving to true if signature is valid, otherwise false.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<Boolean> verifierVerifyProof(
 			String proofRequest,
 			String proof,

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/AnoncredsResults.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/AnoncredsResults.java
@@ -5,25 +5,58 @@ import org.hyperledger.indy.sdk.IndyJava;
 /**
  * anoncreds.rs results
  */
+/**
+ * Result classes related to anonymous credentials calls.
+ */
 public final class AnoncredsResults {
 
 	private AnoncredsResults() {
 
 	}
 
+	/**
+	 * Result from calling issuerCreateAndStoreRevocReg.
+	 */
 	public static class IssuerCreateAndStoreRevocRegResult extends IndyJava.Result {
 
 		private String revocRegJson, revocRegUuid;
 		IssuerCreateAndStoreRevocRegResult(String revocRegJson, String revocRegUuid) { this.revocRegJson = revocRegJson; this.revocRegUuid = revocRegUuid; }
+		
+		/**
+		 * Gets the revocation registration JSON.
+		 * 
+		 * @return The revocation registration JSON.
+		 */
 		public String getRevocRegJson() { return this.revocRegJson; }
+		
+		/**
+		 * Gets the revocation registration UUID.
+		 * 
+		 * @return The revocation registration UUID.
+		 */
 		public String getRevocRegUuid() { return this.revocRegUuid; }
 	}
 
+	/**
+	 * Result from calling issuerCreateClaim.
+	 */
 	public static class IssuerCreateClaimResult extends IndyJava.Result {
 
 		private String revocRegUpdateJson, claimJson;
 		IssuerCreateClaimResult(String revocRegUpdateJson, String claimJson) { this.revocRegUpdateJson = revocRegUpdateJson; this.claimJson = claimJson; }
+		
+		/**
+		 * Gets the revocation registration update JSON.
+		 * 
+		 * @return The revocation registration update JSON.
+		 */
 		public String getRevocRegUpdateJson() { return this.revocRegUpdateJson; }
+		
+		/**
+		 * Gets the claim JSON.
+		 * 
+		 * @return The claim JSON.
+		 */
 		public String getClaimJson() { return this.claimJson; }
 	}
 }

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/ledger/Ledger.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/ledger/Ledger.java
@@ -13,6 +13,10 @@ import com.sun.jna.Callback;
 /**
  * ledger.rs API
  */
+
+/**
+ * Functionality related to the ledger.
+ */
 public class Ledger extends IndyJava.API {
 
 	private Ledger() {
@@ -23,6 +27,9 @@ public class Ledger extends IndyJava.API {
 	 * STATIC CALLBACKS
 	 */
 
+	/**
+	 * Callback used when signAndSubmitRequest completes.
+	 */
 	private static Callback signAndSubmitRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -36,6 +43,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when submitRequest completes.
+	 */
 	private static Callback submitRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -49,6 +59,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildGetDdoRequest completes.
+	 */
 	private static Callback buildGetDdoRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -62,6 +75,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildNymRequest completes.
+	 */
 	private static Callback buildNymRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -75,6 +91,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildAttribRequest completes.
+	 */
 	private static Callback buildAttribRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -88,6 +107,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildGetAttribRequest completes.
+	 */
 	private static Callback buildGetAttribRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -101,6 +123,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildGetNymRequest completes.
+	 */
 	private static Callback buildGetNymRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -114,6 +139,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildSchemaRequest completes.
+	 */
 	private static Callback buildSchemaRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -127,6 +155,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildGetSchemaRequest completes.
+	 */
 	private static Callback buildGetSchemaRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -140,6 +171,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildClaimDefTxn completes.
+	 */
 	private static Callback buildClaimDefTxnCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -153,6 +187,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildGetClaimDefTxn completes.
+	 */
 	private static Callback buildGetClaimDefTxnCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -166,6 +203,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildNodeRequest completes.
+	 */
 	private static Callback buildNodeRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -179,6 +219,9 @@ public class Ledger extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when buildGetTxnRequest completes.
+	 */
 	public static Callback buildGetTxnRequestCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -196,6 +239,16 @@ public class Ledger extends IndyJava.API {
 	 * STATIC METHODS
 	 */
 
+	/**
+	 * Signs and submits request message to validator pool.
+	 * 
+	 * @param pool A Pool.
+	 * @param wallet A Wallet.
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param requestJson Request data json.
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> signAndSubmitRequest(
 			Pool pool,
 			Wallet wallet,
@@ -221,6 +274,14 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Publishes request message to validator pool (no signing, unlike sign_and_submit_request).
+	 * 
+	 * @param pool The Pool to publish to.
+	 * @param requestJson Request data json.
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> submitRequest(
 			Pool pool,
 			String requestJson) throws IndyException {
@@ -241,10 +302,17 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds a request to get a DDO.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param targetDid Id of Identity stored in secured Wallet.
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildGetDdoRequest(
 			String submitterDid,
-			String targetDid,
-			String requestJson) throws IndyException {
+			String targetDid) throws IndyException {
 
 		CompletableFuture<String> future = new CompletableFuture<String>();
 		int commandHandle = addFuture(future);
@@ -260,6 +328,17 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds a NYM request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param targetDid Id of Identity stored in secured Wallet.
+	 * @param verkey verification key
+	 * @param alias alias
+	 * @param role Role of a user NYM record
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildNymRequest(
 			String submitterDid,
 			String targetDid,
@@ -284,6 +363,17 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds an ATTRIB request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param targetDid Id of Identity stored in secured Wallet.
+	 * @param hash Hash of attribute data
+	 * @param raw represented as json, where key is attribute name and value is it's value
+	 * @param enc Encrypted attribute data
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildAttribRequest(
 			String submitterDid,
 			String targetDid,
@@ -308,6 +398,15 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds a GET_ATTRIB request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param targetDid Id of Identity stored in secured Wallet.
+	 * @param data name (attribute name)
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildGetAttribRequest(
 			String submitterDid,
 			String targetDid,
@@ -328,6 +427,14 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds a GET_NYM request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param targetDid Id of Identity stored in secured Wallet.
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildGetNymRequest(
 			String submitterDid,
 			String targetDid) throws IndyException {
@@ -346,6 +453,14 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds a SCHEMA request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param data name, version, type, attr_names (ip, port, keys)
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildSchemaRequest(
 			String submitterDid,
 			String data) throws IndyException {
@@ -364,6 +479,15 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds a GET_SCHEMA request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param dest Id of Identity stored in secured Wallet.
+	 * @param data name, version
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildGetSchemaRequest(
 			String submitterDid,
 			String dest,
@@ -384,6 +508,16 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds an CLAIM_DEF request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param xref Seq. number of schema
+	 * @param signatureType signature type (only CL supported now)
+	 * @param data components of a key in json: N, R, S, Z
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildClaimDefTxn(
 			String submitterDid,
 			int xref,
@@ -406,6 +540,16 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds a GET_CLAIM_DEF request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param xref Seq. number of schema
+	 * @param signatureType signature type (only CL supported now)
+	 * @param origin issuer did
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildGetClaimDefTxn(
 			String submitterDid,
 			int xref,
@@ -428,6 +572,15 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds a NODE request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param targetDid Id of Identity stored in secured Wallet.
+	 * @param data id of a target NYM record
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildNodeRequest(
 			String submitterDid,
 			String targetDid,
@@ -448,6 +601,14 @@ public class Ledger extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Builds a GET_TXN request.
+	 * 
+	 * @param submitterDid Id of Identity stored in secured Wallet.
+	 * @param data seq_no of transaction in ledger
+	 * @return A future resolving to a JSON request string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> buildGetTxnRequest(
 			String submitterDid,
 			int data) throws IndyException {

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
@@ -11,6 +11,10 @@ import com.sun.jna.Callback;
 /**
  * pool.rs API
  */
+
+/**
+ * High level wrapper around SDK Pool functionality.
+ */
 public class Pool extends IndyJava.API {
 
 	private final int poolHandle;
@@ -20,6 +24,11 @@ public class Pool extends IndyJava.API {
 		this.poolHandle = poolHandle;
 	}
 
+	/**
+	 * Gets the handle for the pool instance.
+	 * 
+	 * @return The handle for the pool instance.
+	 */
 	public int getPoolHandle() {
 
 		return this.poolHandle;
@@ -29,6 +38,9 @@ public class Pool extends IndyJava.API {
 	 * STATIC CALLBACKS
 	 */
 
+	/**
+	 * Callback used when createPoolLedgerConfig completes.
+	 */
 	private static Callback createPoolLedgerConfigCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -42,6 +54,9 @@ public class Pool extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when openPoolLedger completes.
+	 */
 	private static Callback openPoolLedgerCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -57,6 +72,9 @@ public class Pool extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when refreshPoolLedger completes.
+	 */
 	private static Callback refreshPoolLedgerCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -70,6 +88,9 @@ public class Pool extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when closePoolLedger completes.
+	 */
 	private static Callback closePoolLedgerCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -83,6 +104,9 @@ public class Pool extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when deletePoolLedgerConfig completes.
+	 */
 	private static Callback deletePoolLedgerConfigCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -100,6 +124,14 @@ public class Pool extends IndyJava.API {
 	 * STATIC METHODS
 	 */
 
+	/**
+	 * Creates a new local pool ledger configuration that can be used later to connect pool nodes.
+	 * 
+	 * @param configName Name of the pool ledger configuration.
+	 * @param config Pool configuration json. if NULL, then default config will be used.
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<Void> createPoolLedgerConfig(
 			String configName,
 			String config) throws IndyException {
@@ -118,6 +150,14 @@ public class Pool extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Opens pool ledger and performs connecting to pool nodes.
+	 * 
+	 * @param configName Name of the pool ledger configuration.
+	 * @param config Runtime pool configuration json. If NULL, then default config will be used.
+	 * @return A future that resolves to an opened Pool instance.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<Pool> openPoolLedger(
 			String configName,
 			String config) throws IndyException {
@@ -136,6 +176,13 @@ public class Pool extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Refreshes a local copy of a pool ledger and updates pool nodes connections.
+	 * 
+	 * @param pool The pool to refresh.
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	private static CompletableFuture<Void> refreshPoolLedger(
 			Pool pool) throws IndyException {
 
@@ -154,6 +201,13 @@ public class Pool extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Closes opened pool ledger, opened nodes connections and frees allocated resources.
+	 * 
+	 * @param pool The pool to close.
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	private static CompletableFuture<Void> closePoolLedger(
 			Pool pool) throws IndyException {
 
@@ -172,6 +226,13 @@ public class Pool extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Deletes created pool ledger configuration.
+	 * 
+	 * @param configName Name of the pool ledger configuration to delete.
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<Void> deletePoolLedgerConfig(
 			String configName) throws IndyException {
 
@@ -192,12 +253,24 @@ public class Pool extends IndyJava.API {
 	 * INSTANCE METHODS
 	 */
 
+	/**
+	 * Refreshes a local copy of a pool ledger and updates pool nodes connections.
+	 * 
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public CompletableFuture<Void> refreshPoolLedger(
 			) throws IndyException {
 
 		return refreshPoolLedger(this);
 	}
 
+	/**
+	 * Closes opened pool ledger, opened nodes connections and frees allocated resources.
+	 * 
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public CompletableFuture<Void> closePoolLedger(
 			) throws IndyException {
 

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/signus/Signus.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/signus/Signus.java
@@ -15,6 +15,10 @@ import com.sun.jna.Callback;
 /**
  * signus.rs API
  */
+
+/**
+ * High level wrapper around signus SDK functions.
+ */
 public class Signus extends IndyJava.API {
 
 	private Signus() {
@@ -25,6 +29,9 @@ public class Signus extends IndyJava.API {
 	 * STATIC CALLBACKS
 	 */
 
+	/**
+	 * Callback used when createAndStoreMyDid completes.
+	 */
 	private static Callback createAndStoreMyDidCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -38,6 +45,9 @@ public class Signus extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when replaceKeys completes.
+	 */
 	private static Callback replaceKeysCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -51,6 +61,9 @@ public class Signus extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when storeTheirDid completes.
+	 */
 	private static Callback storeTheirDidCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -64,6 +77,9 @@ public class Signus extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when sign completes.
+	 */
 	private static Callback signCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -77,6 +93,9 @@ public class Signus extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when verifySignature completes.
+	 */
 	private static Callback verifySignatureCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -90,6 +109,9 @@ public class Signus extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when encrypt completes.
+	 */
 	private static Callback encryptCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -103,6 +125,9 @@ public class Signus extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when decrypt completes.
+	 */
 	private static Callback decryptCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -120,6 +145,14 @@ public class Signus extends IndyJava.API {
 	 * STATIC METHODS
 	 */
 
+	/**
+	 * Creates keys (signing and encryption keys) for a new DID owned by the caller.
+	 * 
+	 * @param wallet The wallet.
+	 * @param didJson Identity information as json.
+	 * @return A future that resolves to a CreateAndStoreMyDidResult instance.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<CreateAndStoreMyDidResult> createAndStoreMyDid(
 			Wallet wallet,
 			String didJson) throws IndyException {
@@ -140,6 +173,15 @@ public class Signus extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Generated new signing and encryption keys for an existing DID owned by the caller.
+	 * 
+	 * @param wallet The wallet.
+	 * @param did The DID
+	 * @param identityJson identity information as json.
+	 * @return A future that resolves to a ReplaceKeysResult instance.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */	
 	public static CompletableFuture<ReplaceKeysResult> replaceKeys(
 			Wallet wallet,
 			String did,
@@ -162,6 +204,14 @@ public class Signus extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Saves their DID for a pairwise connection in a secured Wallet so that it can be used to verify transaction.
+	 * 
+	 * @param wallet The wallet.
+	 * @param identityJson Identity information as json.
+	 * @return A future that does not resolve any value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<Void> storeTheirDid(
 			Wallet wallet,
 			String identityJson) throws IndyException {
@@ -182,6 +232,15 @@ public class Signus extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Signs a message by a signing key associated with my DID. The DID with a signing key.
+	 * 
+	 * @param wallet The wallet.
+	 * @param did signing DID
+	 * @param msg a message to be signed
+	 * @return A future that resolves to a a signature string.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> sign(
 			Wallet wallet,
 			String did,
@@ -204,6 +263,16 @@ public class Signus extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Verify a signature created by a key associated with a DID.
+	 * 
+	 * @param wallet The wallet.
+	 * @param pool The pool.
+	 * @param did DID that signed the message
+	 * @param signedMsg message
+	 * @return A future that resolves to true if signature is valid, otherwise false.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<Boolean> verifySignature(
 			Wallet wallet,
 			Pool pool,
@@ -229,6 +298,17 @@ public class Signus extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Encrypts a message by a public key associated with a DID.
+	 * 
+	 * @param wallet The wallet.
+	 * @param pool The pool.
+	 * @param myDid encrypting DID
+	 * @param did encrypting DID
+	 * @param msg a message to be signed
+	 * @return A future that resolves to a JSON string containing an encrypted message and nonce.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> encrypt(
 			Wallet wallet,
 			Pool pool,
@@ -256,6 +336,17 @@ public class Signus extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Decrypts a message encrypted by a public key associated with my DID.
+	 * 
+	 * @param wallet The wallet.
+	 * @param myDid DID
+	 * @param did DID that signed the message
+	 * @param encryptedMsg encrypted message
+	 * @param nonce nonce that encrypted message
+	 * @return A future that resolves to a JSON string containing the decrypted message.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
 	public static CompletableFuture<String> decrypt(
 			Wallet wallet,
 			String myDid,

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/signus/SignusResults.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/signus/SignusResults.java
@@ -5,26 +5,65 @@ import org.hyperledger.indy.sdk.IndyJava;
 /**
  * signus.rs results
  */
+/**
+ * Result classes for Signus operations.
+ */
 public final class SignusResults {
 
 	private SignusResults() {
 
 	}
 
+	/**
+	 * Result from calling createAndStoreMyDid.
+	 */
 	public static class CreateAndStoreMyDidResult extends IndyJava.Result {
 
 		private String did, verkey, pk;
 		CreateAndStoreMyDidResult(String did, String verkey, String pk) { this.did = did; this.verkey = verkey; this.pk = pk; }
+		
+		/**
+		 * Gets the DID.
+		 * 
+		 * @return The DID.
+		 */
 		public String getDid() { return this.did; }
+		
+		/**
+		 * Gets the verification key.
+		 * 
+		 * @return The verification key.
+		 */
 		public String getVerkey() { return this.verkey; }
+		
+		/**
+		 * Gets the public key.
+		 * 
+		 * @return The public key.
+		 */
 		public String getPk() { return this.pk; }
 	}
 
+	/**
+	 * Result from calling replaceKeys.
+	 */
 	public static class ReplaceKeysResult extends IndyJava.Result {
 
 		private String verkey, pk;
 		ReplaceKeysResult(String verkey, String pk) { this.verkey = verkey; this.pk = pk; }
+		
+		/**
+		 * Gets the verification key.
+		 * 
+		 * @return The verification key.
+		 */
 		public String getVerkey() { return this.verkey; }
+		
+		/**
+		 * Gets the public key.
+		 * 
+		 * @return The public key.
+		 */
 		public String getPk() { return this.pk; }
 	}
 }

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/wallet/Wallet.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/wallet/Wallet.java
@@ -14,6 +14,9 @@ import com.sun.jna.Callback;
 /**
  * wallet.rs API
  */
+/**
+ * High level wrapper for wallet SDK functions.
+ */
 public class Wallet extends IndyJava.API {
 
 	private final int walletHandle;
@@ -23,6 +26,11 @@ public class Wallet extends IndyJava.API {
 		this.walletHandle = walletHandle;
 	}
 
+	/**
+	 * Gets the handle for the wallet.
+	 * 
+	 * @return The handle for the wallet.
+	 */
 	public int getWalletHandle() {
 
 		return this.walletHandle;
@@ -32,6 +40,9 @@ public class Wallet extends IndyJava.API {
 	 * STATIC CALLBACKS
 	 */
 
+	/**
+	 * Callback used when registerWalletType completes.
+	 */
 	private static Callback registerWalletTypeCb = new Callback() {
 
 		@SuppressWarnings({ "unused", "unchecked" })
@@ -45,6 +56,9 @@ public class Wallet extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when createWallet completes.
+	 */
 	private static Callback createWalletCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -58,6 +72,9 @@ public class Wallet extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when openWallet completes.
+	 */
 	private static Callback openWalletCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -73,6 +90,9 @@ public class Wallet extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when closeWallet completes.
+	 */
 	private static Callback closeWalletCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -86,6 +106,9 @@ public class Wallet extends IndyJava.API {
 		}
 	};
 
+	/**
+	 * Callback used when deleteWallet completes.
+	 */
 	private static Callback deleteWalletCb = new Callback() {
 
 		@SuppressWarnings({"unused", "unchecked"})
@@ -105,6 +128,16 @@ public class Wallet extends IndyJava.API {
 
 	private static final List<String> REGISERED_WALLETS = Collections.synchronizedList(new ArrayList<String>());
 
+	/**
+	 * Registers custom wallet implementation.
+	 * 
+	 * @param xtype Wallet type name.
+	 * @param walletType An instance of a WalletType subclass
+	 * @param forceCreate Allows a new registration with the same name as a previous registration if true.
+	 * @return A future that resolves no value.
+	 * @throws IndyException Thrown if a call to the underlying SDK fails.
+	 * @throws InterruptedException Thrown...???
+	 */
 	public static CompletableFuture<Void> registerWalletType(
 			String xtype,
 			WalletType walletType,
@@ -143,6 +176,17 @@ public class Wallet extends IndyJava.API {
 		}
 	}
 
+	/**
+	 * Creates a new secure wallet with the given unique name.
+	 * 
+	 * @param poolName Name of the pool that corresponds to this wallet.
+	 * @param name Name of the wallet.
+	 * @param xtype Type of the wallet. Defaults to 'default'.
+	 * @param config Wallet configuration json. List of supported keys are defined by wallet type.
+	 * @param credentials Wallet credentials json. List of supported keys are defined by wallet type.
+	 * @return A future that resolves no value.
+	 * @throws IndyException Thrown if a call to the underlying SDK fails.
+	 */
 	public static CompletableFuture<Void> createWallet(
 			String poolName,
 			String name,
@@ -167,6 +211,15 @@ public class Wallet extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Opens the wallet with specific name.
+	 * 
+	 * @param name Name of the wallet.
+	 * @param runtimeConfig Runtime wallet configuration json. if NULL, then default runtime_config will be used.
+	 * @param credentials Wallet credentials json. List of supported keys are defined by wallet type.
+	 * @return A future that resolves no value.
+	 * @throws IndyException Thrown if a call to the underlying SDK fails.
+	 */
 	public static CompletableFuture<Wallet> openWallet(
 			String name,
 			String runtimeConfig,
@@ -187,6 +240,13 @@ public class Wallet extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Closes the specified open wallet and frees allocated resources.
+	 * 
+	 * @param wallet The wallet to close.
+	 * @return A future that resolves no value.
+	 * @throws IndyException Thrown if a call to the underlying SDK fails.
+	 */
 	private static CompletableFuture<Void> closeWallet(
 			Wallet wallet) throws IndyException {
 
@@ -205,6 +265,14 @@ public class Wallet extends IndyJava.API {
 		return future;
 	}
 
+	/**
+	 * Deletes an existing wallet.
+	 * 
+	 * @param name Name of the wallet to delete.
+	 * @param credentials Wallet credentials json. List of supported keys are defined by wallet type.
+	 * @return A future that resolves no value.
+	 * @throws IndyException Thrown if a call to the underlying SDK fails.
+	 */
 	public static CompletableFuture<Void> deleteWallet(
 			String name,
 			String credentials) throws IndyException {
@@ -227,6 +295,12 @@ public class Wallet extends IndyJava.API {
 	 * INSTANCE METHODS
 	 */
 
+	/**
+	 * Closes the wallet and frees allocated resources.
+	 * 
+	 * @return A future that resolves no value.
+	 * @throws IndyException Thrown if a call to the underlying SDK fails.
+	 */
 	public CompletableFuture<Void> closeWallet(
 			) throws IndyException {
 

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/wallet/WalletType.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/wallet/WalletType.java
@@ -6,8 +6,14 @@ import com.sun.jna.Callback;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
 
+/**
+ * Base type for implementing custom wallet types.
+ */
 public abstract class WalletType {
 
+	/**
+	 * Callback called when a wallet is being created.
+	 */
 	private Callback createCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -17,6 +23,9 @@ public abstract class WalletType {
 		}
 	};
 
+	/**
+	 * Callback called when a wallet is being opened.
+	 */
 	private Callback openCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -26,6 +35,9 @@ public abstract class WalletType {
 		}
 	};
 
+	/**
+	 * Callback called when a value is being set on a wallet.
+	 */
 	private Callback setCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -35,6 +47,9 @@ public abstract class WalletType {
 		}
 	};
 
+	/**
+	 * Callback called value is requested from a wallet.
+	 */
 	private Callback getCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -44,6 +59,9 @@ public abstract class WalletType {
 		}
 	};
 
+	/**
+	 * Callback called when an unexpired value is being requested from a wallet.
+	 */
 	private Callback getNotExpiredCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -53,6 +71,9 @@ public abstract class WalletType {
 		}
 	};
 
+	/**
+	 * Callback called when a list of values is being requested from a wallet.
+	 */
 	private Callback listCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -62,6 +83,9 @@ public abstract class WalletType {
 		}
 	};
 
+	/**
+	 * Callback called when a wallet is being closed.
+	 */
 	private Callback closeCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -71,6 +95,9 @@ public abstract class WalletType {
 		}
 	};
 
+	/**
+	 * Callback called when a wallet is being deleted.
+	 */
 	private Callback deleteCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -80,6 +107,9 @@ public abstract class WalletType {
 		}
 	};
 
+	/**
+	 * Callback called when value requested from a wallet is no longer being used and should be freed.
+	 */
 	private Callback freeCb = new Callback() {
 
 		@SuppressWarnings("unused")
@@ -89,48 +119,172 @@ public abstract class WalletType {
 		}
 	};
 
+	/**
+	 * Creates a new wallet.
+	 * 
+	 * @param name The name of the wallet to create.
+	 * @param config The configuration of the wallet.
+	 * @param credentials The credentials of the wallet.
+	 * @return An Errorcode indicating the outcome.
+	 */
 	public abstract ErrorCode create(String name, String config, String credentials);
+	
+	/**
+	 * Opens a wallet.
+	 * 
+	 * @param name The name of the wallet to open.
+	 * @param config The configuration for the wallet specified on creation.
+	 * @param runtimeConfig The runtime configuration for the wallet.
+	 * @param credentials The credentials for the wallet.
+	 * @param handle A handle for the opened wallet instance to be set by the implementer.
+	 * @return An Errorcode indicating the outcome.
+	 */
 	public abstract ErrorCode open(String name, String config, String runtimeConfig, String credentials, Pointer handle);
+	
+	/**
+	 * Sets a value on a wallet instance.
+	 * 
+	 * @param handle The handle of the wallet to set the value on.
+	 * @param key The key to set the value for.
+	 * @param value The value to set.
+	 * @return An ErrorCode indicating the outcome.
+	 */
 	public abstract ErrorCode set(int handle, String key, String value);
+	
+	/**
+	 * Gets a value from a wallet instance.
+	 * 
+	 * @param handle The handle of the wallet to set the value on.
+	 * @param key The key of value to get.
+	 * @param valuePtr A pointer to the value to be set by implementers.
+	 * @return An ErrorCode indicating the outcome.
+	 */
 	public abstract ErrorCode get(int handle, String key, PointerByReference valuePtr);
+	
+	/**
+	 * Gets an unexpired value from a wallet instance.
+	 * 
+	 * @param handle The handle of the wallet to set the value on.
+	 * @param key The key of value to get.
+	 * @param valuePtr A pointer to the return value to be set by implementers.
+	 * @return An ErrorCode indicating the outcome.
+	 */
 	public abstract ErrorCode getNotExpired(int handle, String key, PointerByReference valuePtr);
+	
+	/**
+	 * Gets a list of values optionally filtered by key.
+	 * 
+	 * @param handle The handle of the wallet to set the value on.
+	 * @param keyPrefx The prefix of the keys to filter on.  If null no filter will be applied.
+	 * @param valueJsonPtr A pointer to the return value to be set by implementers.
+	 * @return An ErrorCode indicating the outcome.
+	 */
 	public abstract ErrorCode list(int handle, String keyPrefx, PointerByReference valuesJsonPtr);
+	
+	/**
+	 * Closes a wallet.
+	 * 
+	 * @param handle The handle of the wallet to close.
+	 * @return An ErrorCode indicating the outcome.
+	 */
 	public abstract ErrorCode close(int handle);
+	
+	/**
+	 * Deletes a wallet.
+	 * 
+	 * @param name The name of the wallet.
+	 * @param config The configuration of the wallet.
+	 * @param credentials The credentials of the wallet.
+	 * @return
+	 */
 	public abstract ErrorCode delete(String name, String config, String credentials);
+	
+	/**
+	 * Frees a value returned by a wallet.
+	 * 
+	 * @param walletHandle The handle of the wallet the value belongs to.
+	 * @param value A pointer to the value to be freed.
+	 * @return An ErrorCode indicating the outcome.
+	 */
 	public abstract ErrorCode free(int walletHandle, Pointer value);
 	
+	/**
+	 * Gets the create callback.
+	 * 
+	 * @return The create callback.
+	 */
 	public Callback getCreateCb() {
 		return createCb;
 	}
 
+	/**
+	 * Gets the open callback.
+	 * 
+	 * @return The open callback.
+	 */
 	public Callback getOpenCb() {
 		return openCb;
 	}
 
+	/**
+	 * Gets the set callback.
+	 * 
+	 * @return The set callback.
+	 */
 	public Callback getSetCb() {
 		return setCb;
 	}
 
+	/**
+	 * Gets the get callback.
+	 * 
+	 * @return The get callback.
+	 */
 	public Callback getGetCb() {
 		return getCb;
 	}
 
+	/**
+	 * Gets the getNotExpired callback.
+	 * 
+	 * @return The getNotExpired callback.
+	 */
 	public Callback getGetNotExpiredCb() {
 		return getNotExpiredCb;
 	}
 
+	/**
+	 * Gets the list callback.
+	 * 
+	 * @return The list callback.
+	 */
 	public Callback getListCb() {
 		return listCb;
 	}
 
+	/**
+	 * Gets the close callback.
+	 * 
+	 * @return The close callback.
+	 */
 	public Callback getCloseCb() {
 		return closeCb;
 	}
 
+	/**
+	 * Gets the delete callback.
+	 * 
+	 * @return The delete callback.
+	 */
 	public Callback getDeleteCb() {
 		return deleteCb;
 	}
 
+	/**
+	 * Gets the free callback.
+	 * 
+	 * @return The free callback.
+	 */
 	public Callback getFreeCb() {
 		return freeCb;
 	}


### PR DESCRIPTION
Added javadocs for the majority of public functions.  The contents of most of these have been pulled from the rust api code and could probably use some adjustment and in future many of these should probably contain hypertlinks to pages that have more detailed documentation that describes accepted JSON structures, etc.