### PR TITLE
Java Wrapper: Platform-independent way to init libindy

### DIFF
--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
@@ -5,6 +5,7 @@ import java.io.File;
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
 
 public abstract class LibIndy {
 
@@ -109,7 +110,19 @@ public abstract class LibIndy {
 	/**
 	 * Initializes the API with the path to the C-Callable library.
 	 * 
-	 * @param file The path to the C-Callable library.
+	 * @param path The path to the directory containing the C-Callable library file.
+	 */
+	public static void init(String searchPath) {
+
+		NativeLibrary.addSearchPath(LIBRARY_NAME, searchPath);
+		api = Native.loadLibrary(LIBRARY_NAME, API.class);
+	}
+
+	/**
+	 * Initializes the API with the path to the C-Callable library.
+	 * Warning: This is not platform-independent.
+	 *
+	 * @param file The absolute path to the C-Callable library file.
 	 */
 	public static void init(File file) {
 

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/IndyIntegrationTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/IndyIntegrationTest.java
@@ -29,18 +29,14 @@ public class IndyIntegrationTest {
 
 	private static Boolean isWalletRegistered = false;
 
-	@BeforeClass
-	public static void registerWallet() throws IndyException, InterruptedException, ExecutionException {
+	@Before
+	public void setUp() throws IOException, InterruptedException, ExecutionException, IndyException {
+		InitHelper.init();
+		StorageUtils.cleanupStorage();
 		if (!isWalletRegistered){
 			Wallet.registerWalletType("inmem", WalletTypeInmem.getInstance()).get();
 		}
 		isWalletRegistered = true;
-	}
-
-	@Before
-	public void setUp() throws IOException {
-		InitHelper.init();
-		StorageUtils.cleanupStorage();
 	}
 
 	protected HashSet<Pool> openedPools = new HashSet<>();

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/utils/InitHelper.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/utils/InitHelper.java
@@ -3,12 +3,10 @@ package org.hyperledger.indy.sdk.utils;
 
 import org.hyperledger.indy.sdk.LibIndy;
 
-import java.io.File;
-
 public class InitHelper {
 	public static void init() {
 
-		if (!LibIndy.isInitialized()) LibIndy.init(new File("./lib/libindy"));
+		if (!LibIndy.isInitialized()) LibIndy.init("./lib/");
 
 	}
 }


### PR DESCRIPTION
I think 9ad2cb6eff85589666664e6717456cadca7ffb42 added Windows support in `wrappers/java/src/test/java/org/hyperledger/indy/sdk/utils/InitHelper.java` but broke Linux. I propose this change to add a more platform-independent way to load the library.