### PR TITLE
Java wrapper: variable names consistent with libindy API

### DIFF
--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
@@ -58,10 +58,10 @@ public abstract class LibIndy {
 		public int indy_create_and_store_my_did(int command_handle, int wallet_handle, String did_json, Callback cb);
 		public int indy_replace_keys(int command_handle, int wallet_handle, String did, String identity_json, Callback cb);
 		public int indy_store_their_did(int command_handle, int wallet_handle, String identity_json, Callback cb);
-		public int indy_sign(int command_handle, int wallet_handle, String did, byte[] msg, int msg_len, Callback cb);
-		public int indy_verify_signature(int command_handle, int wallet_handle, int pool_handle, String did, byte[] msg, int msg_len, byte[] signature, int signature_len, Callback cb);
-		public int indy_encrypt(int command_handle, int wallet_handle, int pool_handle, String myDid, String did, byte[] msg, int msg_len, Callback cb);
-		public int indy_decrypt(int command_handle, int wallet_handle, String myDid, String did, byte[] encrypted_msg, int encrypted_msg_len, byte[] nonce, int nonce_len, Callback cb);
+		public int indy_sign(int command_handle, int wallet_handle, String did, byte[] message_raw, int message_len, Callback cb);
+		public int indy_verify_signature(int command_handle, int wallet_handle, int pool_handle, String did, byte[] message_raw, int message_len, byte[] signature_raw, int signature_len, Callback cb);
+		public int indy_encrypt(int command_handle, int wallet_handle, int pool_handle, String my_did, String did, byte[] message_raw, int message_len, Callback cb);
+		public int indy_decrypt(int command_handle, int wallet_handle, String myDid, String did, byte[] encrypted_msg_raw, int encrypted_msg_len, byte[] nonce_raw, int nonce_len, Callback cb);
 
 		// anoncreds.rs
 


### PR DESCRIPTION
@Artemkaaas I agree the approach with `byte[]` and `Pointer` is correct, this here is just a small patch for variable names.
