### PR TITLE
Update ubuntu-build.md to correct errors in build instructions

### DIFF
--- a/doc/ubuntu-build.md
+++ b/doc/ubuntu-build.md
@@ -16,8 +16,8 @@
 1. Checkout and build the library:
    
    ```
-   git checkout https://github.com/hyperledger/indy-sdk.git
-   cd ./indy-sdk
+   git clone https://github.com/hyperledger/indy-sdk.git
+   cd ./indy-sdk/libindy
    cargo build
    ```
 1. Run integration tests:


### PR DESCRIPTION
Corrected errors in 2 lines.  The instructions said to checkout instead of cloning a git repo, and they put the user in the wrong directory before 'cargo build'