### PR TITLE
Made python wrapper compatible with Python 3.5

### DIFF
--- a/samples/python/src/utils.py
+++ b/samples/python/src/utils.py
@@ -1,5 +1,4 @@
-from os import environ, makedirs
-from os.path import dirname
+from os import environ
 from pathlib import Path
 from tempfile import gettempdir
 
@@ -29,8 +28,7 @@ def pool_genesis_txn_data():
 def save_pool_genesis_txn_file(path):
     data = pool_genesis_txn_data()
 
-    if not path.exists():
-        makedirs(dirname(path))
+    path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(str(path), "w+") as f:
         f.writelines(data)

--- a/wrappers/python/indy/agent.py
+++ b/wrappers/python/indy/agent.py
@@ -15,8 +15,12 @@ class Event:
     :error: (IndyError) If event is erroneous contains related IndyError exception
     """
 
-    handle: int
-    error: IndyError
+    # handle: int
+    # error: IndyError
+
+    def __init__(self, handle: int, err: int):
+        self.handle = handle
+        self.error = IndyError(ErrorCode(err)) if err != ErrorCode.Success else None
 
     def is_success(self):
         """
@@ -36,9 +40,9 @@ class ConnectionEvent(Event):
     :sender_did: Sender DID
     :receiver_did: Receiver DID
     """
-    connection_handle: int
-    sender_did: str
-    receiver_did: str
+    # connection_handle: int
+    # sender_did: str
+    # receiver_did: str
 
     def __init__(self, handle: int, err: int, connection_handle: int, sender_did: bytes, receiver_did: bytes):
         logger = logging.getLogger(__name__)
@@ -50,11 +54,9 @@ class ConnectionEvent(Event):
                      sender_did,
                      receiver_did)
 
-        self.handle = handle
+        super().__init__(handle, err)
 
-        if err != ErrorCode.Success:
-            self.error = IndyError(ErrorCode(err))
-        else:
+        if self.is_success():
             self.connection_handle = connection_handle
             self.sender_did = sender_did.decode()
             self.receiver_did = receiver_did.decode()
@@ -69,7 +71,7 @@ class MessageEvent(Event):
     :message: Incoming message
     """
 
-    message: str
+    # message: str
 
     def __init__(self, handle: int, err: int, message: bytes):
         logger = logging.getLogger(__name__)
@@ -78,18 +80,16 @@ class MessageEvent(Event):
                      err,
                      message)
 
-        self.handle = handle
+        super().__init__(handle, err)
 
-        if err != ErrorCode.Success:
-            self._error = IndyError(ErrorCode(err))
-        else:
+        if self.is_success():
             self.message = message.decode()
 
         logger.debug("MessageEvent:__init__ <<< self: %r", self)
 
 
-_events: List[Event] = []
-_event_waiters: List[Tuple[List[int], Any, Any]] = []
+_events = []  # type: List[Event]
+_event_waiters = []  # type: List[Tuple[List[int], Any, Any]]
 
 
 def _notify_event_waiters():

--- a/wrappers/python/indy/error.py
+++ b/wrappers/python/indy/error.py
@@ -115,7 +115,7 @@ class ErrorCode(IntEnum):
 
 
 class IndyError(Exception):
-    error_code: ErrorCode
+    # error_code: ErrorCode
 
     def __init__(self, error_code: ErrorCode):
         self.error_code = error_code

--- a/wrappers/python/tests/anoncreds/conftest.py
+++ b/wrappers/python/tests/anoncreds/conftest.py
@@ -18,8 +18,8 @@ def path_home():
 
 
 @pytest.fixture(scope="module")
-async def pool_name():
-    yield x_pool_name()
+def pool_name():
+    return x_pool_name()
 
 
 @pytest.fixture(scope="module")
@@ -44,10 +44,10 @@ def xwallet_cleanup():
 
 # noinspection PyUnusedLocal
 @pytest.fixture(scope="module")
-async def xwallet(pool_name, wallet_name, wallet_type, xwallet_cleanup, path_home):
-    # noinspection PyTypeChecker
-    async for i in x_xwallet(pool_name, wallet_name, wallet_type, xwallet_cleanup, path_home):
-        yield i
+def xwallet(event_loop, pool_name, wallet_name, wallet_type, xwallet_cleanup, path_home):
+    xwallet_gen = x_xwallet(event_loop, pool_name, wallet_name, wallet_type, xwallet_cleanup, path_home)
+    yield next(xwallet_gen)
+    next(xwallet_gen)
 
 
 @pytest.fixture(scope="module")
@@ -56,10 +56,10 @@ def wallet_handle_cleanup():
 
 
 @pytest.fixture(scope="module")
-async def wallet_handle(wallet_name, xwallet, wallet_runtime_config, wallet_handle_cleanup):
-    # noinspection PyTypeChecker
-    async for i in x_wallet_handle(wallet_name, xwallet, wallet_runtime_config, wallet_handle_cleanup):
-        yield i
+def wallet_handle(event_loop, wallet_name, xwallet, wallet_runtime_config, wallet_handle_cleanup):
+    wallet_handle_gen = x_wallet_handle(event_loop, wallet_name, xwallet, wallet_runtime_config, wallet_handle_cleanup)
+    yield next(wallet_handle_gen)
+    next(wallet_handle_gen)
 
 
 @pytest.fixture(scope="module")

--- a/wrappers/python/tests/conftest.py
+++ b/wrappers/python/tests/conftest.py
@@ -1,8 +1,7 @@
 import asyncio
 import json
 import logging
-from os import environ, makedirs
-from os.path import dirname
+from os import environ
 from pathlib import Path
 from shutil import rmtree
 from tempfile import gettempdir
@@ -55,7 +54,7 @@ def seed_my1():
 
 
 @pytest.fixture
-async def endpoint():
+def endpoint():
     return "127.0.0.1:9700"
 
 
@@ -147,7 +146,7 @@ def xwallet_cleanup():
 
 # noinspection PyUnusedLocal
 @pytest.fixture
-async def xwallet(pool_name, wallet_name, wallet_type, xwallet_cleanup, path_home):
+def xwallet(event_loop, pool_name, wallet_name, wallet_type, xwallet_cleanup, path_home):
     logger = logging.getLogger(__name__)
     logger.debug("xwallet: >>> pool_name: %r, wallet_type: %r, xwallet_cleanup: %r, path_home: %r",
                  pool_name,
@@ -156,13 +155,13 @@ async def xwallet(pool_name, wallet_name, wallet_type, xwallet_cleanup, path_hom
                  path_home)
 
     logger.debug("xwallet: Creating wallet")
-    await wallet.create_wallet(pool_name, wallet_name, wallet_type, None, None)
+    event_loop.run_until_complete(wallet.create_wallet(pool_name, wallet_name, wallet_type, None, None))
 
     logger.debug("xwallet: yield")
     yield
 
     logger.debug("xwallet: Deleting wallet")
-    await wallet.delete_wallet(wallet_name, None) if xwallet_cleanup else None
+    event_loop.run_until_complete(wallet.delete_wallet(wallet_name, None)) if xwallet_cleanup else None
 
     logger.debug("xwallet: <<<")
 
@@ -190,7 +189,7 @@ def wallet_handle_cleanup():
 
 
 @pytest.fixture
-async def wallet_handle(wallet_name, xwallet, wallet_runtime_config, wallet_handle_cleanup):
+def wallet_handle(event_loop, wallet_name, xwallet, wallet_runtime_config, wallet_handle_cleanup):
     logger = logging.getLogger(__name__)
     logger.debug(
         "wallet_handle: >>> wallet_name: %r, xwallet: %r, wallet_runtime_config: %r, wallet_handle_cleanup: %r",
@@ -200,14 +199,14 @@ async def wallet_handle(wallet_name, xwallet, wallet_runtime_config, wallet_hand
         wallet_handle_cleanup)
 
     logger.debug("wallet_handle: Opening wallet")
-    wallet_handle = await wallet.open_wallet(wallet_name, wallet_runtime_config, None)
+    wallet_handle = event_loop.run_until_complete(wallet.open_wallet(wallet_name, wallet_runtime_config, None))
     assert type(wallet_handle) is int
 
     logger.debug("wallet_handle: yield %r", wallet_handle)
     yield wallet_handle
 
     logger.debug("wallet_handle: Closing wallet")
-    await wallet.close_wallet(wallet_handle) if wallet_handle_cleanup else None
+    event_loop.run_until_complete(wallet.close_wallet(wallet_handle)) if wallet_handle_cleanup else None
 
     logger.debug("wallet_handle: <<<")
 
@@ -289,7 +288,7 @@ def pool_genesis_txn_file(pool_genesis_txn_path, pool_genesis_txn_data):
                  pool_genesis_txn_path,
                  pool_genesis_txn_data)
 
-    makedirs(dirname(pool_genesis_txn_path))
+    pool_genesis_txn_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(str(pool_genesis_txn_path), "w+") as f:
         f.writelines(pool_genesis_txn_data)
@@ -304,8 +303,8 @@ def pool_ledger_config_cleanup():
 
 # noinspection PyUnusedLocal
 @pytest.fixture
-async def pool_ledger_config(pool_name, pool_genesis_txn_path, pool_genesis_txn_file, pool_ledger_config_cleanup,
-                             path_home):
+def pool_ledger_config(event_loop, pool_name, pool_genesis_txn_path, pool_genesis_txn_file,
+                       pool_ledger_config_cleanup, path_home):
     logger = logging.getLogger(__name__)
     logger.debug("pool_ledger_config: >>> pool_name: %r, pool_genesis_txn_path: %r, pool_genesis_txn_file: %r,"
                  " pool_ledger_config_cleanup: %r, path_home: %r",
@@ -316,17 +315,17 @@ async def pool_ledger_config(pool_name, pool_genesis_txn_path, pool_genesis_txn_
                  path_home)
 
     logger.debug("pool_ledger_config: Creating pool ledger config")
-    await pool.create_pool_ledger_config(
+    event_loop.run_until_complete(pool.create_pool_ledger_config(
         pool_name,
         json.dumps({
             "genesis_txn": str(pool_genesis_txn_path)
-        }))
+        })))
 
     logger.debug("pool_ledger_config: yield")
     yield
 
     logger.debug("pool_ledger_config: Deleting pool ledger config")
-    await pool.delete_pool_ledger_config(pool_name) if pool_ledger_config_cleanup else None
+    event_loop.run_until_complete(pool.delete_pool_ledger_config(pool_name)) if pool_ledger_config_cleanup else None
 
     logger.debug("pool_ledger_config: <<<")
 
@@ -355,7 +354,7 @@ def pool_config():
 
 # noinspection PyUnusedLocal
 @pytest.fixture
-async def pool_handle(pool_name, pool_ledger_config, pool_config, pool_handle_cleanup):
+def pool_handle(event_loop, pool_name, pool_ledger_config, pool_config, pool_handle_cleanup):
     logger = logging.getLogger(__name__)
     logger.debug("pool_handle: >>> pool_name: %r, pool_ledger_config: %r, pool_config: %r, pool_handle_cleanup: %r",
                  pool_name,
@@ -364,14 +363,14 @@ async def pool_handle(pool_name, pool_ledger_config, pool_config, pool_handle_cl
                  pool_handle_cleanup)
 
     logger.debug("pool_handle: Opening pool ledger")
-    pool_handle = await pool.open_pool_ledger(pool_name, pool_config)
+    pool_handle = event_loop.run_until_complete(pool.open_pool_ledger(pool_name, pool_config))
     assert type(pool_handle) is int
 
     logger.debug("pool_handle: yield: %r", pool_handle)
     yield pool_handle
 
     logger.debug("pool_handle: Closing pool ledger")
-    await pool.close_pool_ledger(pool_handle) if pool_handle_cleanup else None
+    event_loop.run_until_complete(pool.close_pool_ledger(pool_handle)) if pool_handle_cleanup else None
 
     logger.debug("pool_handle: <<<")
 
@@ -380,14 +379,14 @@ async def pool_handle(pool_name, pool_ledger_config, pool_config, pool_handle_cl
 async def identity_trustee1(wallet_handle, seed_trustee1):
     (trustee_did, trustee_verkey, _) = await signus.create_and_store_my_did(wallet_handle,
                                                                             json.dumps({"seed": seed_trustee1}))
-    yield (trustee_did, trustee_verkey)
+    return (trustee_did, trustee_verkey)
 
 
 @pytest.fixture
 async def identity_steward1(wallet_handle, seed_steward1):
     (steward_did, steward_verkey, _) = await signus.create_and_store_my_did(wallet_handle,
                                                                             json.dumps({"seed": seed_steward1}))
-    yield (steward_did, steward_verkey)
+    return (steward_did, steward_verkey)
 
 
 @pytest.fixture
@@ -400,4 +399,4 @@ async def identity_my1(wallet_handle, pool_handle, identity_trustee1, seed_my1, 
     nym_request = await ledger.build_nym_request(trustee_did, my_did, my_verkey, None, None)
     await ledger.sign_and_submit_request(pool_handle, wallet_handle, trustee_did, nym_request)
 
-    yield (my_did, my_verkey)
+    return (my_did, my_verkey)

--- a/wrappers/python/tests/ledger/test_build_nym_request.py
+++ b/wrappers/python/tests/ledger/test_build_nym_request.py
@@ -64,7 +64,6 @@ async def test_nym_request_works_for_different_roles(wallet_handle, pool_handle,
     await check_for_role(pool_handle, wallet_handle, trustee_did, 'STEWARD', '2')
 
 
-@pytest.mark.asyncio
 async def check_for_role(pool_handle, wallet_handle, trustee_did, role, expected_role_value):
     (my_did, my_verkey, _) = await signus.create_and_store_my_did(wallet_handle, "{}")
 


### PR DESCRIPTION
- Provided compatibility of libindy python wrapper with Python 3.5 (previously Python 3.6+ was required) since Python 3.5 is the target platform for indy-node.
- Fixed a bug in pool_genesis_txn_file fixture.
- Fixed a bug in save_pool_genesis_txn_file function.
- Removed Python 3.6 from CI scripts and dockerfiles.