### PR TITLE
README_WikiLink Adds a link to the Hyperledger Wiki-Indy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+
+## Before you Continue
+
+If you haven't done so already, please visit the main resource for all things "Indy" to get acquainted with the code base, helpful resources, and up-to-date information: [Hyperledger Wiki-Indy](https://wiki.hyperledger.org/projects/indy).
+
 # Indy SDK
 
 This is the official SDK for [Hyperledger Indy](https://www.hyperledger.org/projects),


### PR DESCRIPTION
Adds a link to the Hyperledger Wiki-Indy page within the README.md file
in an effort to consolidate and encourage the wiki page to be the
main "hub" starting point for the Indy documentation.

Signed-off-by: TechWritingWhiz <TechWritingWhiz@gmail.com>