### PR TITLE
Update sodiumoxide version from 0.0.14 to 0.0.16

### DIFF
--- a/libindy/Cargo.toml
+++ b/libindy/Cargo.toml
@@ -53,7 +53,7 @@ serde_derive = "1.0"
 sha2 = "0.6.0"
 sha3 = "0.6.0"
 rmp-serde = "0.13.6"
-sodiumoxide = {version = "0.0.14", optional = true}
+sodiumoxide = {version = "0.0.16", optional = true}
 time = "0.1.36"
 zmq = "0.8.2"
 lazy_static = "1.0"


### PR DESCRIPTION
This should fix this problem mentioned in Rocketchat: https://chat.hyperledger.org/channel/indy-sdk?msg=BkFvNq3zpyuHLqGBR

```
  = note: /usr/local/lib/../lib/libindy.so: undefined reference to 'crypto_stream_aes128ctr_xor'
          /usr/local/lib/../lib/libindy.so: undefined reference to 'crypto_stream_aes128ctr'
```