### PR TITLE
Make clarifying changes in README and rhel-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,34 +15,34 @@ in project IS (note that regular Indy tickets are in the INDY project instead...
 us on [Hyperledger's Rocket.Chat](https://chat.hyperledger.org/) at #indy-sdk to discuss.
 
 
-## How to install
+## Installation
 ### Release channels
 Indy SDK release process defines the following release channels:
-    
+
 * `master` - development builds for each push to master branch.
 * `rc` - release candidates.
 * `stable` - stable releases.
 
 Please refer to [release workflow](doc/release-workflow.md) for more details.
-### Install for Ubuntu based distro (Ubuntu 16.04)
+
+### Ubuntu based distributions (Ubuntu 16.04)
 It is recommended to install packages with APT:
-    
+
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88
     sudo add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial {release channel}"
     sudo apt-get update
     sudo apt-get install -y libindy
 
 {release channel} must be replaced with master, rc or stable to define corresponded release channel.
-See section "Release channels" for more details.  
-   
-### Install for Windows
+See section "Release channels" for more details.
+
+### Windows
 
 1. follow to https://repo.sovrin.org/windows/libindy/{release-channel}.
 2. download last version of libindy.
 3. unzip archives to directory, where you want to save working library.
 4. After unzip you will get next structure of files:
 
-    
 * `Your working directory`
     * `include`
         * `...`
@@ -52,36 +52,38 @@ See section "Release channels" for more details.
         * `libsodium.dll`
         * `libzmq.dll`
         * `ssleay32md.dll`
-            
+
 `include` contains c-header files which contains all necessary declarations
-that may be need for your applications. 
+that may be need for your applications.
 
 `lib` contains all necessary binaries which contains libindy and all it's dependencies.
  `You must add to PATH environment variable path to lib`. It's necessary for dynamic linkage
- your application with libindy.       
+ your application with libindy.
 
 {release channel} must be replaced with master, rc or stable to define corresponded release channel.
 See section "Release channels" for more details.
-### Install for iOS
 
+### iOS
 See [wrapper iOS install documentation](wrappers/ios/README.md "How to install").
 
-### Install for MacOS        
-Now we haven't prebuild library in some shared place. You can build
-library yourself. Please refer to How-to-build section. 
+### MacOS
 
-After build add to LD_LIBRARY_PATH and to DYLD_LIBRARY_PATH 
-environment variables path to builded library. It's necessary 
-for dynamic linkage your application with libindy. At first dynamic linker
-browse library in LD_LIBRARY_PATH, if library in your application doesn't include directory names.
-If library in your application include any directory name, then dynamic linker will search library
-in DYLD_LIBRARY_PATH(not LD_LIBRARY_PATH). So for reliability we recommend you set both this variables.
-            
-### Install for RHEL based distro (Amazon Linux 2017.03)           
+Pre-built libraries are not provided for MacOS. Please look [here](blob/master/doc/mac-build.md)
+for details on building from source for MacOS.
+
+After building `libindy`, add the path containing the library the `LD_LIBRARY_PATH` and
+`DYLD_LIBRARY_PATH` environment variables. This is necessary for dynamically linking
+your application with `libindy`. The dynamic linker will first check for the library in
+`LD_LIBRARY_PATH` if the library in your application doesn't include directory names.
+If the library in your application does include any directory name, then dynamic
+linker will search for the library in `DYLD_LIBRARY_PATH` (not `LD_LIBRARY_PATH`)
+so we recommend you set both variables to be safe.
+
+### Install for RHEL based distro (Amazon Linux 2017.03)
 Now we haven't prebuild library in some shared place. You can build
 library yourself. Please refer to How-to-build section.
 
-After build add to LD_LIBRARY_PATH environment variable path to builded library. 
+After build add to LD_LIBRARY_PATH environment variable path to builded library.
 It's necessary for dynamic linkage your application with libindy.
 
 ## How to build
@@ -94,25 +96,25 @@ It's necessary for dynamic linkage your application with libindy.
 ## How to start local nodes pool with docker
 
 Start local nodes pool on `127.0.0.1:9701-9708` with Docker:
-          
-```     
+
+```
 docker build -f ci/indy-pool.dockerfile -t indy_pool .
 docker run -itd -p 9701-9708:9701-9708 indy_pool
-```     
-     
- Dockerfile `ci/indy-pool.dockerfile` supports optional pool_ip param that allows 
- changing ip of pool nodes in generated pool configuration. The following commands 
- allow to start local nodes pool in custom docker network and access this pool 
+```
+
+ Dockerfile `ci/indy-pool.dockerfile` supports optional pool_ip param that allows
+ changing ip of pool nodes in generated pool configuration. The following commands
+ allow to start local nodes pool in custom docker network and access this pool
  by custom ip in docker network:
-     
+
  ```
  docker network create --subnet 10.0.0.0/8 indy_pool_network
  docker build --build-arg pool_ip=10.0.0.2 -f ci/indy-pool.dockerfile -t indy_pool .
  docker run -d --ip="10.0.0.2" --net=indy_pool_network indy_pool
- ``` 
+ ```
  Note that for Windows and MacOS this approach has some issues. Docker for these OS run in
  their virtual environment. First command creates network for container and host can't
- get access to that network because container placed on virtual machine. You must appropriate set up 
+ get access to that network because container placed on virtual machine. You must appropriate set up
  networking on your virtual environment.
 
 ## Wrappers documentation

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See [wrapper iOS install documentation](wrappers/ios/README.md "How to install")
 
 ### MacOS
 
-Pre-built libraries are not provided for MacOS. Please look [here](blob/master/doc/mac-build.md)
+Pre-built libraries are not provided for MacOS. Please look [here](doc/mac-build.md)
 for details on building from source for MacOS.
 
 After building `libindy`, add the path containing the library the `LD_LIBRARY_PATH` and

--- a/README.md
+++ b/README.md
@@ -79,17 +79,18 @@ If the library in your application does include any directory name, then dynamic
 linker will search for the library in `DYLD_LIBRARY_PATH` (not `LD_LIBRARY_PATH`)
 so we recommend you set both variables to be safe.
 
-### Install for RHEL based distro (Amazon Linux 2017.03)
-Now we haven't prebuild library in some shared place. You can build
-library yourself. Please refer to How-to-build section.
+### RHEL-based distributions (Amazon Linux 2017.03)
+Pre-built libraries are not provided for RHEL-based distributions. Please look [here](doc/rhel-build.md)
+for details on building from source for RHEL-based distributions.
 
-After build add to LD_LIBRARY_PATH environment variable path to builded library.
-It's necessary for dynamic linkage your application with libindy.
+After successfully compiling `libindy`, you will need to add the path containing `libindy.so` to the
+`LD_LIBRARY_PATH` environment variable. This is required for your application to link to
+`libindy`.
 
 ## How to build
 
-* [Ubuntu based distro (Ubuntu 16.04)](doc/ubuntu-build.md)
-* [RHEL based distro (Amazon Linux 2017.03)](doc/rhel-build.md)
+* [Ubuntu based distributions (Ubuntu 16.04)](doc/ubuntu-build.md)
+* [RHEL based distributions (Amazon Linux 2017.03)](doc/rhel-build.md)
 * [Windows](doc/windows-build.md)
 * [MacOS](doc/mac-build.md)
 

--- a/doc/rhel-build.md
+++ b/doc/rhel-build.md
@@ -72,6 +72,7 @@ git checkout https://github.com/hyperledger/indy-sdk.git
 cd ./indy-sdk/libindy
 cargo build
 ```
+
 ## Building `indy-cli`
 `indy-cli` is dependent on `libindy` and must be built before `indy-cli`.
 
@@ -82,9 +83,13 @@ RUSTFLAGS="-L ../libindy/target/{BUILD_TYPE}" cargo build
 ```
 In the above command, substitute `{BUILD_TYPE}` with `release` or `debug` as appropriate.
 
-In some instances, when `cargo` calls `rustc`, the linker can have difficult finding `libindy.so`
-even after specifying the directory containing it in `LD_LIBRARY_PATH`. Specifying `RUSTFLAGS` in
-the command above will tell `rustc` to also check `../libindy/target/{BUILD_TYPE}` for libraries.
+If you have installed `libindy.so` to a system-wide location and subsequently run `ldconfig`, you do not need
+to specify the `RUSTFLAGS` environment variable as `rustc` should be able to find `libindy.so` without additional
+help.
+
+If not, however, `indy-cli` needs help to be able to find `libindy.so` while being built. Setting `LD_LIBRARY_PATH`
+is only referenced at runtime and not at build time and is not helpful in this case. Specifying `RUSTFLAGS` in the
+command above will tell `rustc` to also check `../libindy/target/{BUILD_TYPE}` for libraries.
 
 ## Running integration tests
 ### Starting up

--- a/doc/rhel-build.md
+++ b/doc/rhel-build.md
@@ -1,74 +1,125 @@
-# Setup Indy SDK build environment for RHEL based distro (Amazon Linux 2017.03)
+# Setup Indy SDK build environment for RHEL-based distributions
+These instructions have been tested on:
+- Amazon Linux 2017.03
+- Fedora 27
 
-1. Install Rust and rustup (https://www.rust-lang.org/install.html).
-1. Install required native libraries and utilities available in repos:
-   
-   ```
-   yum clean all
-   yum upgrade -y
-   yum groupinstall -y "Development Tools"
-   yum install -y \
-       wget \
-       cmake \
-       pkgconfig \
-       openssl-devel \
-       sqlite-devel
-   ```
-1. Build and install modern version of libsodium from sources:
-   
-   ```
-   cd /tmp
-   curl https://download.libsodium.org/libsodium/releases/libsodium-1.0.12.tar.gz | tar -xz
-   cd /tmp/libsodium-1.0.12
-   ./configure
-   make
-   make install
-   rm -rf /tmp/libsodium-1.0.12
+Please follow the instructions appropriate for your distribution.
 
-   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig
-   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-   ```
+## Building `libindy`
+### 1. Install Rust
+Installation via `rustup` is recommended. Follow
+[these instructions](https://www.rust-lang.org/install.html).
 
-1. Checkout and build the library:
+### 2. Install dependencies available in system repositories
 
-   ```
-   git checkout https://github.com/hyperledger/indy-sdk.git
-   cd ./indy-sdk
-   cargo build
-   ```
-1. Run integration tests:
-   * Start local nodes pool on `127.0.0.1:9701-9708` with Docker:
-     
-     ```     
-     docker build -f ci/indy-pool.dockerfile -t indy_pool .
-     docker run -itd -p 9701-9709:9701-9709 indy_pool
-     ```     
-     
-     In some environments, this approach with mapping of local ports to container ports
-     can't be applied. Dockerfile `ci/indy-pool.dockerfile` supports optional pool_ip param
-     that allows changing ip of pool nodes in generated pool configuration. The following
-     commands allow to start local nodes pool in custom docker network and access this pool by
-     custom ip in docker network:
-     
-     ```
-     docker network create --subnet 10.0.0.0/8 indy_pool_network
-     docker build --build-arg pool_ip=10.0.0.2 -f ci/indy-pool.dockerfile -t indy_pool .
-     docker run -d --ip="10.0.0.2" --net=indy_pool_network indy_pool
-     ```
-     
-     It can be usefull if we wants to launch integration tests inside another container attached to
-     the same docker network. 
-     
-   * Run tests
-     
-     ```
-     RUST_TEST_THREADS=1 cargo test
-     ```
-     
-     It is possible to change ip of test pool by providing of TEST_POOL_IP environment variable:
-     
-     ```
-     RUST_TEST_THREADS=1 TEST_POOL_IP=10.0.0.2 cargo test
-     ```
+For Amazon Linux 2017.03/CentOS/RHEL:
+```
+yum clean all
+yum upgrade -y
+yum groupinstall -y "Development Tools"
+yum install -y \
+   wget \
+   cmake \
+   pkgconfig \
+   openssl-devel \
+   sqlite-devel
+```
+
+For Fedora 26/27/28:
+```
+dnf clean all
+dnf upgrade -y
+dnf groupinstall -y "Development Tools"
+dnf install -y \
+   wget \
+   cmake \
+   pkgconfig \
+   openssl-devel \
+   sqlite-devel
+```
+
+### 3. Build and install a modern version of `libsodium` from source
+For Amazon Linux 2017.03 or other distributions without `libsodium` available in system repositories:
+```
+cd /tmp
+curl https://download.libsodium.org/libsodium/releases/libsodium-1.0.12.tar.gz | tar -xz
+cd /tmp/libsodium-1.0.12
+./configure
+make
+make install
+rm -rf /tmp/libsodium-1.0.12
+
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+```
+
+For Fedora 26/27/28, `libsodium-1.0.14` is already available as a system package:
+```
+dnf install libsodium libsodium-devel
+```
+
+### 4. Additional dependencies
+For Fedora 26/27/28, you may also need to install `zeromq` (`libzmq`) before being able to successfully
+build `libindy`:
+```
+dnf install zeromq zeromq-devel
+```
+If you discover that there are other dependencies not mentioned here, please open an issue.
+
+### 5. Checkout and build the library
+```
+git checkout https://github.com/hyperledger/indy-sdk.git
+cd ./indy-sdk/libindy
+cargo build
+```
+## Building `indy-cli`
+`indy-cli` is dependent on `libindy` and must be built before `indy-cli`.
+
+After building `libindy`, run the following commands from the `indy-sdk` directory:
+```
+cd indy-cli
+RUSTFLAGS="-L ../libindy/target/{BUILD_TYPE}" cargo build
+```
+In the above command, substitute `{BUILD_TYPE}` with `release` or `debug` as appropriate.
+
+In some instances, when `cargo` calls `rustc`, the linker can have difficult finding `libindy.so`
+even after specifying the directory containing it in `LD_LIBRARY_PATH`. Specifying `RUSTFLAGS` in
+the command above will tell `rustc` to also check `../libindy/target/{BUILD_TYPE}` for libraries.
+
+## Running integration tests
+### Starting up
+Start local nodes pool on `127.0.0.1:9701-9708` with Docker:
+
+```
+docker build -f ci/indy-pool.dockerfile -t indy_pool .
+docker run -itd -p 9701-9709:9701-9709 indy_pool
+```
+
+In some environments, this approach with mapping of local ports to container ports
+can't be applied. Dockerfile `ci/indy-pool.dockerfile` supports optional `pool_ip` param
+that allows changing ip of pool nodes in generated pool configuration. The following
+commands allow to start local nodes pool in custom docker network and access this pool by
+custom ip in docker network:
+
+```
+docker network create --subnet 10.0.0.0/8 indy_pool_network
+docker build --build-arg pool_ip=10.0.0.2 -f ci/indy-pool.dockerfile -t indy_pool .
+docker run -d --ip="10.0.0.2" --net=indy_pool_network indy_pool
+```
+
+This may be useful if you want to launch integration tests inside another container attached to
+the same docker network.
+
+### Run tests
+
+```
+RUST_TEST_THREADS=1 cargo test
+```
+
+It is possible to change ip of test pool by providing of TEST_POOL_IP environment variable:
+
+```
+RUST_TEST_THREADS=1 TEST_POOL_IP=10.0.0.2 cargo test
+```
 
 See [ci/amazon.dockerfile](https://github.com/hyperledger/indy-sdk/blob/master/libindy/ci/amazon.dockerfile) for example of Amazon Linux based environment creation in Docker.


### PR DESCRIPTION
This pull request adds more information to the rhel-build.md document for building components of indy-sdk on different RHEL-based distributions.

Minor changes were also made to the README to clarify some details as well.

Trailing whitespace was also purged from the README.