### PR TITLE
deployment config for nodejs wrapper

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -519,7 +519,9 @@ def nodejsWrapperPublishing(testEnv, isRelease) {
         def suffix = getSuffix(isRelease, "nodejs")
 
         testEnv.inside {
-            # TODO npm user for publishing ~/.npmrc
+            sh 'npm config set registry https://registry.npmjs.org/'
+            sh 'npm config set //registry.npmjs.org/:_authToken ${env.NPM_TOKEN}'
+
             sh 'npm version --no-git-tag-version "$version$suffix"'
             sh 'npm publish'
         }

--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -211,6 +211,19 @@ def linuxTesting(file, env_name, network_name, stashBuildResults) {
             }
         }
 
+        sh "cp libindy/target/release/libindy.so wrappers/nodejs"
+        dir('wrappers/nodejs') {
+            testEnv.inside("--ip=\"10.0.0.3\" --network=${network_name}") {
+                echo "${env_name} Libindy Test: Test nodejs wrapper"
+
+                sh '''
+                    npm run cp-include
+                    npm install
+                    LD_LIBRARY_PATH=./:${LD_LIBRARY_PATH} RUST_LOG=trace TEST_POOL_IP=10.0.0.2 npm test
+                '''
+            }
+        }
+
         sh "cp libindy/target/release/libindy.so cli"
         dir('cli') {
             testEnv.inside("--ip=\"10.0.0.3\" --network=${network_name}") {
@@ -390,6 +403,7 @@ def ubuntuPublishing() {
 
                 libindyDebPublishing(testEnv)
                 pythonWrapperPublishing(testEnv, false)
+                nodejsWrapperPublishing(testEnv, false)
                 javaWrapperPublishing(testEnv, false)
                 libindyCliDebPublishing(testEnv)
             }
@@ -499,6 +513,19 @@ def pythonWrapperPublishing(testEnv, isRelease) {
     }
 }
 
+def nodejsWrapperPublishing(testEnv, isRelease) {
+    dir('wrappers/nodejs') {
+        def version = getSrcVersion()
+        def suffix = getSuffix(isRelease, "nodejs")
+
+        testEnv.inside {
+            # TODO npm user for publishing ~/.npmrc
+            sh 'npm version --no-git-tag-version "$version$suffix"'
+            sh 'npm publish'
+        }
+    }
+}
+
 def javaWrapperPublishing(testEnv, isRelease) {
     dir('wrappers/java') {
         echo "Publish To Maven Test: Build docker image"
@@ -563,6 +590,9 @@ def publishingRCtoStable() {
 
                 echo 'Moving Ubuntu RC artifacts to Stable: python wrapper'
                 pythonWrapperPublishing(testEnv, true)
+
+                echo 'Moving Ubuntu RC artifacts to Stable: nodejs wrapper'
+                nodejsWrapperPublishing(testEnv, true)
 
                 echo 'Moving Ubuntu RC artifacts to Stable: java wrapper'
                 javaWrapperPublishing(testEnv, true)

--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -519,11 +519,12 @@ def nodejsWrapperPublishing(testEnv, isRelease) {
         def suffix = getSuffix(isRelease, "nodejs")
 
         testEnv.inside {
-            sh 'npm config set registry https://registry.npmjs.org/'
-            sh 'npm config set //registry.npmjs.org/:_authToken ${env.NPM_TOKEN}'
+            withCredentials([file(credentialsId: 'npm_credentials', variable: 'credentialsFile')]) {
+                sh 'cp $credentialsFile ~/.npmrc'
 
-            sh 'npm version --no-git-tag-version "$version$suffix"'
-            sh 'npm publish'
+                sh 'npm version --no-git-tag-version "$version$suffix"'
+                sh 'npm publish'
+            }
         }
     }
 }


### PR DESCRIPTION
We'll need a npm user to publish this. Maybe this one https://www.npmjs.com/~hyperledger-ci ?

Then store the auth token (npmrc) in the `npm_credentials` file. Similar to `pypi_credentials`