### PR TITLE
bump sodiumoxide to 0.0.16 crypto_stream_aes128ctr_xor

### DIFF
--- a/libindy/Cargo.toml
+++ b/libindy/Cargo.toml
@@ -53,7 +53,7 @@ serde_derive = "1.0"
 sha2 = "0.6.0"
 sha3 = "0.6.0"
 rmp-serde = "0.13.6"
-sodiumoxide = {version = "0.0.14", optional = true}
+sodiumoxide = {version = "0.0.16", optional = true}
 time = "0.1.36"
 zmq = "0.8.2"
 lazy_static = "1.0"


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

Some low level crypto functions were removed from libsodium but there are still rust bindings for them in sodiumoxide. Bumping the version 0.0.16 gets this in sync again.

Otherwise there is an unsatisfied link error when building libindy for aarch64-linux-android because crypto_stream_aes128ctr_xor is missing.