### PR TITLE
get rid of compiler warnings

### DIFF
--- a/libindy/src/commands/non_secrets.rs
+++ b/libindy/src/commands/non_secrets.rs
@@ -199,10 +199,13 @@ impl NonSecretsCommandExecutor {
 
         self._check_type(type_)?;
 
-        let tag_names: Vec<&str> = match serde_json::from_str(tag_names_json) {
-            Ok(tag_names) => tag_names,
-            Err(serde_json_err) => return Err(IndyError::WalletError(WalletError::InputError(format!("Invalid tag names input: {}", tag_names_json))))
-        };
+        //let tag_names: Vec<&str> = match serde_json::from_str(tag_names_json) {
+            //Ok(tag_names) => tag_names,
+            //Err(serde_json_err) => return Err(IndyError::WalletError(WalletError::InputError(format!("Invalid tag names input: {}", tag_names_json))))
+        //};
+        let tag_names: Vec<&str> = serde_json::from_str(tag_names_json)
+            .map_err(|err| IndyError::WalletError(WalletError::InputError(format!("Cannot deserialize tag names: {}", err))))?;
+        
         let res = self.wallet_service.delete_record_tags(wallet_handle, type_, id, &tag_names)?;
 
         trace!("delete_record_tags <<< res: {:?}", res);

--- a/libindy/src/services/wallet/encryption.rs
+++ b/libindy/src/services/wallet/encryption.rs
@@ -14,7 +14,6 @@ use services::wallet::WalletRecord;
 use super::wallet::Keys;
 use super::storage::{Tag, TagName, StorageEntity};
 
-use errors::common::CommonError;
 use errors::wallet::WalletError;
 
 pub(super) fn derive_key(input: &[u8], salt: &[u8; 32]) -> Result<ChaCha20Poly1305IETFKey, WalletError> {

--- a/libindy/src/services/wallet/export_import.rs
+++ b/libindy/src/services/wallet/export_import.rs
@@ -9,7 +9,7 @@ use utils::crypto::hash::Hash;
 use utils::crypto::chacha20poly1305_ietf::{ChaCha20Poly1305IETF, NONCE_LENGTH, ChaCha20Poly1305IETFNonce};
 use utils::crypto::pwhash_argon2i13::PwhashArgon2i13;
 use utils::byte_array::_clone_into_array;
-use services::wallet::encryption::{decrypt_merged, decrypt, encrypt_as_not_searchable, derive_key};
+use services::wallet::encryption::{decrypt, derive_key};
 
 use errors::common::CommonError;
 
@@ -373,11 +373,10 @@ mod tests {
     use serde_json;
     use ::utils::crypto::chacha20poly1305_ietf::{ChaCha20Poly1305IETF, ChaCha20Poly1305IETFKey};
     use ::utils::environment::EnvironmentUtils;
-    use ::utils::test::TestUtils;
     use services::wallet::storage::WalletStorageType;
     use services::wallet::storage::default::SQLiteStorageType;
     use services::wallet::wallet::{Keys, Wallet};
-    use services::wallet::encryption::{decrypt_merged, decrypt, encrypt_as_not_searchable};
+    use services::wallet::encryption::{decrypt_merged};
     use super::*;
 
     fn _wallet_path() -> std::path::PathBuf {
@@ -423,7 +422,7 @@ mod tests {
     }
 
     fn _create_export_file() -> Box<io::Write> {
-        let mut path = EnvironmentUtils::tmp_file_path("export_directory");
+        let path = EnvironmentUtils::tmp_file_path("export_directory");
         if path.exists() {
             std::fs::remove_dir_all(path.clone()).unwrap();
         }
@@ -733,7 +732,7 @@ mod tests {
             tags.insert(format!("tag_name_{}_2", i), format!("tag_value_{}_2", i));
             tags.insert(format!("~tag_name_{}_3", i), format!("tag_value_{}_3", i));
             let tags_len = serde_json::to_string(&tags).unwrap().len();
-            total_item_length += (4 + name.len() + value.len() + tags_len);
+            total_item_length += 4 + name.len() + value.len() + tags_len;
             wallet.add("type", &name, &value, &tags).unwrap();
         }
         let total_unencrypted_length = total_item_length + item_count * 20;
@@ -860,7 +859,7 @@ mod tests {
                 tags.insert(format!("tag_name_{}_2", i), format!("tag_value_{}_2", i));
                 tags.insert(format!("~tag_name_{}_3", i), format!("tag_value_{}_3", i));
                 let tags_len = serde_json::to_string(&tags).unwrap().len();
-                total_item_length += (4 + name.len() + value.len() + tags_len);
+                total_item_length += 4 + name.len() + value.len() + tags_len;
                 wallet.add("type", &name, &value, &tags).unwrap();
             }
             let total_unencrypted_length = total_item_length + item_count * 20;

--- a/libindy/src/services/wallet/mod.rs
+++ b/libindy/src/services/wallet/mod.rs
@@ -15,7 +15,6 @@ use std::fs;
 use std::fs::{OpenOptions, File, DirBuilder};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::mem;
 use named_type::NamedType;
 use std::rc::Rc;
 
@@ -26,7 +25,7 @@ use errors::wallet::WalletError;
 use errors::common::CommonError;
 use utils::environment::EnvironmentUtils;
 use utils::sequence::SequenceUtils;
-use utils::crypto::chacha20poly1305_ietf::{ChaCha20Poly1305IETF, ChaCha20Poly1305IETFKey};
+use utils::crypto::chacha20poly1305_ietf::{ChaCha20Poly1305IETFKey};
 
 use self::export_import::{export, import};
 use self::storage::{WalletStorage, WalletStorageType};
@@ -34,7 +33,6 @@ use self::storage::default::SQLiteStorageType;
 use self::storage::plugged::PluggedStorageType;
 use self::wallet::{Wallet, Keys};
 use self::indy_crypto::utils::json::{JsonDecodable, JsonEncodable};
-use self::sodiumoxide::utils::memzero;
 use self::encryption::derive_key;
 use utils::crypto::pwhash_argon2i13::PwhashArgon2i13;
 
@@ -577,7 +575,7 @@ impl WalletService {
         match self.open_wallet(name, None, credentials) {
             Err(err) => {
                 // Ignores the error, since there is nothing that can be done
-                self.delete_wallet(name, credentials);
+                let _ = self.delete_wallet(name, credentials);
                 Err(err)
             }
             Ok(wallet_handle) => {
@@ -587,7 +585,7 @@ impl WalletService {
                         match import(wallet, reader, &import_config.key) {
                             Ok(_) => Ok(()),
                             err @ Err(_) => {
-                                self.delete_wallet(name, credentials);
+                                let _ = self.delete_wallet(name, credentials);
                                 err
                             }
                         }

--- a/libindy/src/services/wallet/storage/default/mod.rs
+++ b/libindy/src/services/wallet/storage/default/mod.rs
@@ -12,12 +12,10 @@ use serde_json;
 use self::owning_ref::OwningHandle;
 use std::rc::Rc;
 
-use utils::crypto::chacha20poly1305_ietf::ChaCha20Poly1305IETF;
 use utils::environment::EnvironmentUtils;
 use errors::wallet::WalletStorageError;
 use errors::common::CommonError;
 use services::wallet::language;
-use sodiumoxide::utils::memzero;
 
 use super::{StorageIterator, WalletStorageType, WalletStorage, StorageEntity, EncryptedValue, Tag, TagName};
 use super::super::{RecordOptions, SearchOptions};
@@ -735,8 +733,6 @@ mod tests {
     use super::super::Tag;
     use std::collections::HashMap;
     use std::env;
-    use ::utils::crypto::chacha20poly1305_ietf::ChaCha20Poly1305IETF;
-
 
     fn _create_and_open_test_storage() -> Box<WalletStorage> {
         _prepare_path();

--- a/libindy/src/services/wallet/storage/plugged/mod.rs
+++ b/libindy/src/services/wallet/storage/plugged/mod.rs
@@ -813,7 +813,6 @@ mod tests {
     use std::sync::RwLock;
     use self::rand::{thread_rng, Rng};
     use std::clone::Clone;
-    use ::utils::crypto::chacha20poly1305_ietf::ChaCha20Poly1305IETF;
 
     impl PartialEq for StorageEntity {
         fn eq(&self, other: &StorageEntity) -> bool {

--- a/libindy/src/services/wallet/wallet.rs
+++ b/libindy/src/services/wallet/wallet.rs
@@ -1,11 +1,8 @@
 extern crate sodiumoxide;
 
-use std;
 use std::collections::HashMap;
-use std::io::{Write,Read};
 use std::rc::Rc;
 
-use serde_json;
 use utils::crypto::chacha20poly1305_ietf::{TAG_LENGTH, KEY_LENGTH, NONCE_LENGTH, ChaCha20Poly1305IETF,ChaCha20Poly1305IETFKey};
 use utils::crypto::hmacsha256::{HMACSHA256, HMACSHA256Key};
 
@@ -13,7 +10,6 @@ use errors::wallet::WalletError;
 use errors::common::CommonError;
 
 use super::storage;
-use super::storage::StorageEntity;
 use super::iterator::WalletIterator;
 use super::encryption::*;
 use super::query_encryption::encrypt_query;

--- a/libindy/src/utils/crypto/chacha20poly1305_ietf/sodium.rs
+++ b/libindy/src/utils/crypto/chacha20poly1305_ietf/sodium.rs
@@ -1,12 +1,10 @@
 extern crate sodiumoxide;
 use sodiumoxide::crypto::aead::chacha20poly1305_ietf;
-use sodiumoxide::crypto::auth::hmacsha256;
 
 use errors::common::CommonError;
 
 use sodiumoxide::utils::increment_le;
 use utils::byte_array::_clone_into_array;
-use utils::crypto::hmacsha256::{HMACSHA256, HMACSHA256Key};
 
 pub const NONCE_LENGTH: usize = chacha20poly1305_ietf::NONCEBYTES;
 pub const KEY_LENGTH: usize = chacha20poly1305_ietf::KEYBYTES;
@@ -55,7 +53,7 @@ impl ChaCha20Poly1305IETF {
         ChaCha20Poly1305IETFNonce { nonce: chacha20poly1305_ietf::Nonce(_clone_into_array(&bytes[..chacha20poly1305_ietf::NONCEBYTES])) }
     }
 
-    pub fn increment_nonce(mut nonce: &mut ChaCha20Poly1305IETFNonce) {
+    pub fn increment_nonce(nonce: &mut ChaCha20Poly1305IETFNonce) {
         increment_le(&mut nonce.nonce.0);
     }
 
@@ -101,7 +99,6 @@ mod tests {
     fn encrypt_decrypt_works() {
         let data = randombytes::randombytes(100);
         let key = ChaCha20Poly1305IETF::generate_key();
-        let hmac_key = HMACSHA256::generate_key();
 
         let (c, nonce) = ChaCha20Poly1305IETF::generate_nonce_and_encrypt(&data, &key);
         let u = ChaCha20Poly1305IETF::decrypt(&c, &key, &nonce).unwrap();


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

This PR gets rid of most compiler warnings. Two remain:

1. using a deprecated function 'finish'

```
warning: use of deprecated item 'openssl::hash::Hasher::finish': use finish2 instead
   --> src/services/wallet/export_import.rs:256:15
    |
256 |     Ok(hasher.finish()?)
    |               ^^^^^^
    |
    = note: #[warn(deprecated)] on by default

```

2. unused const

warning: associated const is never used: `TAGBYTES`
  --> src/utils/crypto/hmacsha256/sodium.rs:21:5
   |
21 |     pub const TAGBYTES: usize = hmacsha256::TAGBYTES;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(dead_code)] on by default
