### PR TITLE
Fix issue with apt-key add when behind firewall.

### DIFF
--- a/ci/indy-pool.dockerfile
+++ b/ci/indy-pool.dockerfile
@@ -18,7 +18,7 @@ RUN pip3 install -U \
 	pip==9.0.3 \
 	setuptools
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88
+RUN wget -O- "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x68DB5E88" | apt-key add -
 ARG indy_stream=master
 RUN echo "deb https://repo.sovrin.org/deb xenial $indy_stream" >> /etc/apt/sources.list
 

--- a/doc/getting-started/getting-started.dockerfile
+++ b/doc/getting-started/getting-started.dockerfile
@@ -22,7 +22,7 @@ RUN pip3 install -U \
 	jupyter \
 	python3-indy==1.4.0-dev-586
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88 \
+RUN wget -O- "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x68DB5E88" | apt-key add -\
     && add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial master" \
     && apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
People behind a corporate firewall may have issue building the docker images because `apt-key add` may be blocked by the firewall. This fix replaces the call with something equivalent.

Signed-off-by: fabienpe <fabienpe@users.noreply.github.com>