### PR TITLE
Added Missed Android Build Dependencies in ReadMe

### DIFF
--- a/doc/android-build.md
+++ b/doc/android-build.md
@@ -8,7 +8,7 @@
 
 ## Dependencies
 - The build scripts downloads the prebuilt dependencies while building. The prebuilt dependencies are available [here](https://github.com/evernym/indy-android-dependencies/tree/master/prebuilt)
-- If you want build the dependencies by yourself the instructions for that can be found [here](https://github.com/evernym/indy-android-dependencies)
+- If you want build the dependencies by yourself the instructions for that can be found [here](https://github.com/evernym/indy-android-dependencies) 
 
 ## How to build.
 - Run `indy-sdk/libindy/build-libindy-android.sh` to build libindy for arm, arm64 and x86

--- a/doc/android-build.md
+++ b/doc/android-build.md
@@ -21,11 +21,10 @@
 
 ## Usage 
 - Unzip the generated library.
-- Copy `lib/libindy.so` to the jniLibs folder of your android project
-    - `libindy.so` file is the dynamic library which is statically linked to its dependencies. This library can be loaded into apk without having dependencies along with it.
-    - `libindy_shared.so` file is the dynamic library which is dunamically linked to its dependencies. you need to pass the dependencies into apk.
 - Copy generated `indy-sdk/libindy/build_scripts/android/libindy_arm/libindy.so`, `indy-sdk/libindy/build_scripts/android/indy-android-dependencies/prebuild/sodium/libsodium_arm/lib/libsodium.so`, and `indy-sdk/libindy/build_scripts/android/indy-android-dependencies/prebuild/zmq/libzmq_arm/lib/libzmq.so` to the jniLibs/armeabi-v7a folder of your android project
 - Copy the corresponding files for jniLibs/arm64-v8a and jniLibs/x86 (similar to step above)
+    - `libindy.so` file is the dynamic library which is statically linked to its dependencies. This library can be loaded into apk without having dependencies along with it.
+    - `libindy_shared.so` file is the dynamic library which is dynamically linked to its dependencies. you need to pass the dependencies into apk.
 - In order to use the library in Android, you need to set the EXTERNAL_STORAGE environment variable and load the library using JNA
     
 `Os.setenv("EXTERNAL_STORAGE", getExternalFilesDir(null).getAbsolutePath(), true);`

--- a/doc/android-build.md
+++ b/doc/android-build.md
@@ -18,13 +18,19 @@
     - e.g  `android.build.sh -d arm` . The flag `-d` will download the dependencies automatically
     - e.g  `android.build.sh arm <PATH_TO_OPENSSL> <PATH_TO_SODIUM> <PATH_TO_ZMQ>`. If `-d` flag is not passed you have to give paths to dependencies
 
+
 ## Usage 
 - Unzip the generated library.
 - Copy `lib/libindy.so` to the jniLibs folder of your android project
     - `libindy.so` file is the dynamic library which is statically linked to its dependencies. This library can be loaded into apk without having dependencies along with it.
     - `libindy_shared.so` file is the dynamic library which is dunamically linked to its dependencies. you need to pass the dependencies into apk.
+- Copy generated `indy-sdk/libindy/build_scripts/android/libindy_arm/libindy.so`, `indy-sdk/libindy/build_scripts/android/indy-android-dependencies/prebuild/sodium/libsodium_arm/lib/libsodium.so`, and `indy-sdk/libindy/build_scripts/android/indy-android-dependencies/prebuild/zmq/libzmq_arm/lib/libzmq.so` to the jniLibs/armeabi-v7a folder of your android project
+- Copy the corresponding files for jniLibs/arm64-v8a and jniLibs/x86 (similar to step above)
+- In order to use the library in Android, you need to set the EXTERNAL_STORAGE environment variable and load the library using JNA
     
-- Load library using the JNA
+`Os.setenv("EXTERNAL_STORAGE", getExternalFilesDir(null).getAbsolutePath(), true);`
+
+`System.loadLibrary("indy");`
 
 
 ## Notes:
@@ -35,6 +41,11 @@ Add following line to AndroidManifest.xml
 `<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>`
 
 Android emulator generally use x86 images
+
+If you receive a JNA error, you may need to add additonal files into your jniLibs folder. 
+- Add the correct version of libjnidispatch.so to the corresponding subfolder in jniLibs -> https://github.com/java-native-access/jna/tree/master/lib/native
+- For example, android-aarch64.jar goes into the jniLibs/arm64-v8a subfolder
+- NOTE: You need to download the correct version of libjnidispatch.so (tag 4.5.1 in the jna repo is the version accepted by Indy SDK v1.5)
 
 ##Known Issues
 


### PR DESCRIPTION
I fixed the readme based on issues I faced while creating an Android project using the previous instructions