### PR TITLE
Added support for Xamarin.iOS

### DIFF
--- a/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/AnonCreds.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/AnonCreds.cs
@@ -1,10 +1,11 @@
 ﻿using Hyperledger.Indy.BlobStorageApi;
-using Hyperledger.Indy.LedgerApi;
 using Hyperledger.Indy.Utils;
 using Hyperledger.Indy.WalletApi;
-using System;
 using System.Threading.Tasks;
 using static Hyperledger.Indy.AnonCredsApi.NativeMethods;
+#if __IOS__
+using ObjCRuntime;
+#endif
 
 namespace Hyperledger.Indy.AnonCredsApi
 {
@@ -16,7 +17,10 @@ namespace Hyperledger.Indy.AnonCredsApi
         /// <summary>
         /// Gets the callback to use when the IssuerCreateAndStoreClaimDefAsync command completes.
         /// </summary>
-        private static IssuerCreateSchemaCompletedDelegate _issuerCreateSchemaCallback = (xcommand_handle, err, schema_id, schema_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IssuerCreateSchemaCompletedDelegate))]
+#endif
+        private static void IssuerCreateSchemaCallback(int xcommand_handle, int err, string schema_id, string schema_json)
         {
             var taskCompletionSource = PendingCommands.Remove<IssuerCreateSchemaResult>(xcommand_handle);
 
@@ -24,12 +28,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(new IssuerCreateSchemaResult(schema_id, schema_json));
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the IssuerCreateAndStoreClaimDefAsync command completes.
         /// </summary>
-        private static IssuerCreateAndStoreCredentialDefCompletedDelegate _issuerCreateAndStoreClaimDefCallback = (xcommand_handle, err, claim_def_id, claim_def_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IssuerCreateAndStoreCredentialDefCompletedDelegate))]
+#endif
+        private static void IssuerCreateAndStoreClaimDefCallback(int xcommand_handle, int err, string claim_def_id, string claim_def_json)
         {
             var taskCompletionSource = PendingCommands.Remove<IssuerCreateAndStoreCredentialDefResult>(xcommand_handle);
 
@@ -37,12 +44,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(new IssuerCreateAndStoreCredentialDefResult(claim_def_id, claim_def_json));
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the IssuerCreateAndStoreClaimRevocRegAsync command completes.
         /// </summary>
-        private static IssuerCreateAndStoreRevocRegCompletedDelegate _issuerCreateAndStoreClaimRevocRegCallback = (xcommand_handle, err, revoc_reg_id, revoc_reg_def_json, revoc_reg_entry_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IssuerCreateAndStoreRevocRegCompletedDelegate))]
+#endif
+        private static void IssuerCreateAndStoreClaimRevocRegCallback(int xcommand_handle, int err, string revoc_reg_id, string revoc_reg_def_json, string revoc_reg_entry_json)
         {
             var taskCompletionSource = PendingCommands.Remove<IssuerCreateAndStoreRevocRegResult>(xcommand_handle);
 
@@ -50,12 +60,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(new IssuerCreateAndStoreRevocRegResult(revoc_reg_id, revoc_reg_def_json, revoc_reg_entry_json));
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the IssuerCreateClaimAsync command completes.
         /// </summary>
-        private static IssuerCreateCredentialOfferCompletedDelegate _issuerCreateCredentialOfferCallback = (xcommand_handle, err, cred_offer_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IssuerCreateCredentialOfferCompletedDelegate))]
+#endif
+        private static void IssuerCreateCredentialOfferCallback(int xcommand_handle, int err, string cred_offer_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -63,12 +76,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(cred_offer_json);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the IssuerCreateClaimAsync command completes.
         /// </summary>
-        private static IssuerCreateCredentialCompletedDelegate _issuerCreateCredentialCallback = (xcommand_handle, err, cred_json, cred_revoc_id, revoc_reg_delta_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IssuerCreateCredentialCompletedDelegate))]
+#endif
+        private static void IssuerCreateCredentialCallback(int xcommand_handle, int err, string cred_json, string cred_revoc_id, string revoc_reg_delta_json)
         {
             var taskCompletionSource = PendingCommands.Remove<IssuerCreateCredentialResult>(xcommand_handle);
 
@@ -78,13 +94,15 @@ namespace Hyperledger.Indy.AnonCredsApi
             var callbackResult = new IssuerCreateCredentialResult(cred_json, cred_revoc_id, revoc_reg_delta_json);
 
             taskCompletionSource.SetResult(callbackResult);
-        };
-
+        }
 
         /// <summary>
         /// Gets the callback to use when the IssuerRevokeCredentialAsync command completes.
         /// </summary>
-        private static IssuerRevokeCredentialCompletedDelegate _issuerRevokeCredentialCallback = (xcommand_handle, err, revoc_reg_delta_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IssuerRevokeCredentialCompletedDelegate))]
+#endif
+        private static void IssuerRevokeCredentialCallback(int xcommand_handle, int err, string revoc_reg_delta_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -92,12 +110,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(revoc_reg_delta_json);
-        };
+        }
 
         /// <summary>
         /// The issuer merge revocation registry deltas callback.
         /// </summary>
-        private static IssuerMergeRevocationRegistryDeltasCompletedDelegate _issuerMergeRevocationRegistryDeltasCallback = (xcommand_handle, err, merged_rev_reg_delta) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IssuerMergeRevocationRegistryDeltasCompletedDelegate))]
+#endif
+        private static void IssuerMergeRevocationRegistryDeltasCallback(int xcommand_handle, int err, string merged_rev_reg_delta)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -105,12 +126,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(merged_rev_reg_delta);
-        };
+        }
 
         /// <summary>
         /// The prover create master secret callback.
         /// </summary>
-        private static ProverCreateMasterSecretCompletedDelegate _proverCreateMasterSecretCallback = (xcommand_handle, err, out_master_secret_id) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverCreateMasterSecretCompletedDelegate))]
+#endif
+        private static void ProverCreateMasterSecretCallback(int xcommand_handle, int err, string out_master_secret_id)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -118,12 +142,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(out_master_secret_id);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the roverCreateAndStoreClaimReqAsync command completes.
         /// </summary>
-        private static ProverCreateCredentialReqCompletedDelegate _proverCreateCredentialReqCallback = (xcommand_handle, err, cred_req_json, cred_req_metadata_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverCreateCredentialReqCompletedDelegate))]
+#endif
+        private static void ProverCreateCredentialReqCallback(int xcommand_handle, int err, string cred_req_json, string cred_req_metadata_json)
         {
             var taskCompletionSource = PendingCommands.Remove<ProverCreateCredentialRequestResult>(xcommand_handle);
 
@@ -131,12 +158,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(new ProverCreateCredentialRequestResult(cred_req_json, cred_req_metadata_json));
-        };
+        }
 
         /// <summary>
         /// The prover store credential callback.
         /// </summary>
-        private static ProverStoreCredentialCompletedDelegate _proverStoreCredentialCallback = (xcommand_handle, err, out_cred_id) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverStoreCredentialCompletedDelegate))]
+#endif
+        private static void ProverStoreCredentialCallback(int xcommand_handle, int err, string out_cred_id)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -144,12 +174,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(out_cred_id);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the ProverGetClaimsAsync command completes.
         /// </summary>
-        private static ProverGetCredentialsCompletedDelegate _proverGetCredentialsCallback = (xcommand_handle, err, matched_credentials_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverGetCredentialsCompletedDelegate))]
+#endif
+        private static void ProverGetCredentialsCallback(int xcommand_handle, int err, string matched_credentials_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -157,12 +190,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(matched_credentials_json);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the ProverGetClaimsForProofAsync command completes.
         /// </summary>
-        private static ProverGetCredentialsForProofCompletedDelegate _proverGetClaimsForProofCallback = (xcommand_handle, err, claims_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverGetCredentialsForProofCompletedDelegate))]
+#endif
+        private static void ProverGetClaimsForProofCallback(int xcommand_handle, int err, string claims_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -170,12 +206,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(claims_json);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the ProverCreateProofAsync command completes.
         /// </summary>
-        private static ProverCreateProofCompletedDelegate _proverCreateProofCallback = (xcommand_handle, err, proof_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverCreateProofCompletedDelegate))]
+#endif
+        private static void ProverCreateProofCallback(int xcommand_handle, int err, string proof_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -183,12 +222,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(proof_json);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the VerifierVerifyProofAsync command completes.
         /// </summary>
-        private static VerifierVerifyProofCompletedDelegate _verifierVerifyProofCallback = (xcommand_handle, err, valid) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(VerifierVerifyProofCompletedDelegate))]
+#endif
+        private static void VerifierVerifyProofCallback(int xcommand_handle, int err, bool valid)
         {
             var taskCompletionSource = PendingCommands.Remove<bool>(xcommand_handle);
 
@@ -196,12 +238,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(valid);
-        };
+        }
 
         /// <summary>
         /// The create revocation state callback.
         /// </summary>
-        private static CreateRevocationStateCompletedDelegate _createRevocationStateCallback = (xcommand_handle, err, rev_state_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(CreateRevocationStateCompletedDelegate))]
+#endif
+        private static void CreateRevocationStateCallback(int xcommand_handle, int err, string rev_state_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -209,12 +254,15 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(rev_state_json);
-        };
+        }
 
         /// <summary>
         /// The update revocation state callback.
         /// </summary>
-        private static UpdateRevocationStateCompletedDelegate _updateRevocationStateCallback = (xcommand_handle, err, updated_rev_state_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(UpdateRevocationStateCompletedDelegate))]
+#endif
+        private static void UpdateRevocationStateCallback(int xcommand_handle, int err, string updated_rev_state_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -222,7 +270,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 return;
 
             taskCompletionSource.SetResult(updated_rev_state_json);
-        };
+        }
 
         /// <summary>
         /// Create credential schema entity that describes credential attributes list and allows credentials
@@ -260,7 +308,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 name,
                 version,
                 attrs,
-                _issuerCreateSchemaCallback
+                IssuerCreateSchemaCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -307,7 +355,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 tag,
                 type,
                 configJson,
-                _issuerCreateAndStoreClaimDefCallback
+                IssuerCreateAndStoreClaimDefCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -373,7 +421,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 credDefId,
                 configJson,
                 tailsWriter.Handle,
-                _issuerCreateAndStoreClaimRevocRegCallback
+                IssuerCreateAndStoreClaimRevocRegCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -410,7 +458,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 commandHandle,
                 wallet.Handle,
                 credDefId,
-                _issuerCreateCredentialOfferCallback
+                IssuerCreateCredentialOfferCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -474,7 +522,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 credValuesJson,
                 revRegId,
                 blobStorageReader?.Handle ?? -1,
-                _issuerCreateCredentialCallback
+                IssuerCreateCredentialCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -512,7 +560,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 blobStorageReader.Handle,
                 revRegId,
                 credRevocId,
-                _issuerRevokeCredentialCallback
+                IssuerRevokeCredentialCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -539,7 +587,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 commandHandle,
                 revRegDelta,
                 otherRevRegDelta,
-                _issuerMergeRevocationRegistryDeltasCallback
+                IssuerMergeRevocationRegistryDeltasCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -567,7 +615,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 commandHandle,
                 wallet.Handle,
                 masterSecretId,
-                _proverCreateMasterSecretCallback
+                ProverCreateMasterSecretCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -617,7 +665,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 credOfferJson,
                 credDefJson,
                 masterSecretId,
-                _proverCreateCredentialReqCallback
+                ProverCreateCredentialReqCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -654,7 +702,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 credJson,
                 credDefJson,
                 revRegDefJson,
-                _proverStoreCredentialCallback
+                ProverStoreCredentialCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -698,7 +746,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 commandHandle,
                 wallet.Handle,
                 filterJson,
-                _proverGetCredentialsCallback
+                ProverGetCredentialsCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -794,7 +842,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 commandHandle,
                 wallet.Handle,
                 proofRequestJson,
-                _proverGetClaimsForProofCallback
+                ProverGetClaimsForProofCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -960,7 +1008,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 schemas,
                 credentialDefs,
                 revStates,
-                _proverCreateProofCallback);
+                ProverCreateProofCallback);
 
             CallbackHelper.CheckResult(commandResult);
 
@@ -1071,7 +1119,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 credentialDefs,
                 revocRegDefs,
                 revocRegs,
-                _verifierVerifyProofCallback
+                VerifierVerifyProofCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -1111,7 +1159,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 revRegDelta,
                 timestamp,
                 credRevId,
-                _createRevocationStateCallback
+                CreateRevocationStateCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -1155,7 +1203,7 @@ namespace Hyperledger.Indy.AnonCredsApi
                 revRegDelta,
                 timestamp,
                 credRevId,
-                _updateRevocationStateCallback
+                UpdateRevocationStateCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);

--- a/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/IssuerCreateCredentialResult.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/IssuerCreateCredentialResult.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Hyperledger.Indy.AnonCredsApi
+﻿namespace Hyperledger.Indy.AnonCredsApi
 {
     /// <summary>
     /// Result from calling IssuerCreateCredentialAsync.

--- a/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/NativeMethods.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/NativeMethods.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using static Hyperledger.Indy.Utils.CallbackHelper;
 
 namespace Hyperledger.Indy.AnonCredsApi
 {

--- a/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/BlobStorage.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/BlobStorage.cs
@@ -1,7 +1,9 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Hyperledger.Indy.Utils;
 using static Hyperledger.Indy.BlobStorageApi.NativeMethods;
+#if __IOS__
+using ObjCRuntime;
+#endif
 
 namespace Hyperledger.Indy.BlobStorageApi
 {
@@ -10,7 +12,10 @@ namespace Hyperledger.Indy.BlobStorageApi
     /// </summary>
     public static class BlobStorage
     {
-        private static BlobStorageCompletedDelegate _openReaderCallback = (xcommand_handle, err, handle) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(BlobStorageCompletedDelegate))]
+#endif
+        private static void OpenReaderCallback(int xcommand_handle, int err, int handle)
         {
             var taskCompletionSource = PendingCommands.Remove<BlobStorageReader>(xcommand_handle);
 
@@ -18,9 +23,11 @@ namespace Hyperledger.Indy.BlobStorageApi
                 return;
 
             taskCompletionSource.SetResult(new BlobStorageReader(handle));
-        };
-
-        private static BlobStorageCompletedDelegate _openWriterCallback = (xcommand_handle, err, handle) =>
+        }
+#if __IOS__
+        [MonoPInvokeCallback(typeof(BlobStorageCompletedDelegate))]
+#endif
+        private static void OpenWriterCallback(int xcommand_handle, int err, int handle)
         {
             var taskCompletionSource = PendingCommands.Remove<BlobStorageWriter>(xcommand_handle);
 
@@ -28,7 +35,7 @@ namespace Hyperledger.Indy.BlobStorageApi
                 return;
 
             taskCompletionSource.SetResult(new BlobStorageWriter(handle));
-        };
+        }
 
         /// <summary>
         /// Opens the BLOB storage reader async.
@@ -48,7 +55,7 @@ namespace Hyperledger.Indy.BlobStorageApi
                 commandHandle,
                 type,
                 configJson,
-                _openReaderCallback
+                OpenReaderCallback
                 );
 
             CallbackHelper.CheckResult(result);
@@ -74,7 +81,7 @@ namespace Hyperledger.Indy.BlobStorageApi
                 commandHandle,
                 type,
                 configJson,
-                _openWriterCallback
+                OpenWriterCallback
                 );
 
             CallbackHelper.CheckResult(result);

--- a/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/BlobStorageReader.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/BlobStorageReader.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace Hyperledger.Indy.BlobStorageApi
+﻿namespace Hyperledger.Indy.BlobStorageApi
 {
     /// <summary>
     /// BLOB storage reader.

--- a/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/BlobStorageWriter.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/BlobStorageWriter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace Hyperledger.Indy.BlobStorageApi
+﻿namespace Hyperledger.Indy.BlobStorageApi
 {
     /// <summary>
     /// BLOB storage writer.

--- a/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/NativeMethods.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/NativeMethods.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace Hyperledger.Indy.BlobStorageApi
 {

--- a/wrappers/dotnet/indy-sdk-dotnet/Consts.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/Consts.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using System.Runtime.InteropServices;
-
-namespace Hyperledger.Indy
+﻿namespace Hyperledger.Indy
 {
     /// <summary>
     /// PInvoke import of C-Callable SDK library functions and associated delegates.
     /// </summary>
     internal static class Consts
     {
+#if __IOS__
+        public const string NATIVE_LIB_NAME = "__Internal";
+#else
         public const string NATIVE_LIB_NAME = "indy";
+#endif
     }
 }

--- a/wrappers/dotnet/indy-sdk-dotnet/DidApi/Did.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/DidApi/Did.cs
@@ -2,21 +2,26 @@
 using Hyperledger.Indy.PoolApi;
 using Hyperledger.Indy.Utils;
 using Hyperledger.Indy.WalletApi;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using static Hyperledger.Indy.DidApi.NativeMethods;
+#if __IOS__
+using ObjCRuntime;
+#endif
 
 namespace Hyperledger.Indy.DidApi
 {
     /// <summary>
     /// Provides cryptographic functionality related to DIDs.
     /// </summary>
-    public static class Did 
+    public static class Did
     {
         /// <summary>
         /// Gets the callback to use when the command for CreateAndStoreMyDidResultAsync has completed.
         /// </summary>
-        private static CreateAndStoreMyDidCompletedDelegate _createAndStoreMyDidCallback = (xcommand_handle, err, did, verkey) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(CreateAndStoreMyDidCompletedDelegate))]
+#endif
+        private static void CreateAndStoreMyDidCallback(int xcommand_handle, int err, string did, string verkey)
         {
             var taskCompletionSource = PendingCommands.Remove<CreateAndStoreMyDidResult>(xcommand_handle);
 
@@ -26,12 +31,15 @@ namespace Hyperledger.Indy.DidApi
             var callbackResult = new CreateAndStoreMyDidResult(did, verkey);
 
             taskCompletionSource.SetResult(callbackResult);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the command for ReplaceKeysAsync has completed.
         /// </summary>
-        private static ReplaceKeysStartCompletedDelegate _replaceKeysCallback = (xcommand_handle, err, verkey) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ReplaceKeysStartCompletedDelegate))]
+#endif
+        private static void ReplaceKeysCallback(int xcommand_handle, int err, string verkey)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -39,12 +47,15 @@ namespace Hyperledger.Indy.DidApi
                 return;
 
             taskCompletionSource.SetResult(verkey);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the command for KeyForDidAsync has completed.
         /// </summary>
-        private static DidKeyForDidCompletedDelegate _keyForDidCompletedCallback = (xcommand_handle, err, key) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(DidKeyForDidCompletedDelegate))]
+#endif
+        private static void KeyForDidCompletedCallback(int xcommand_handle, int err, string key)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -52,12 +63,15 @@ namespace Hyperledger.Indy.DidApi
                 return;
 
             taskCompletionSource.SetResult(key);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the command for KeyForLocalDidAsync has completed.
         /// </summary>
-        private static DidKeyForLocalDidCompletedDelegate _keyForLocalDidCompletedCallback = (xcommand_handle, err, key) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(DidKeyForLocalDidCompletedDelegate))]
+#endif
+        private static void KeyForLocalDidCompletedCallback(int xcommand_handle, int err, string key)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -65,12 +79,15 @@ namespace Hyperledger.Indy.DidApi
                 return;
 
             taskCompletionSource.SetResult(key);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the command for GetEndpointForDidAsync has completed.
         /// </summary>
-        private static DidGetEndpointForDidCompletedDelegate _getEndpointForDidCompletedCallback = (xcommand_handle, err, endpoint, transport_vk) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(DidGetEndpointForDidCompletedDelegate))]
+#endif
+        private static void GetEndpointForDidCompletedCallback(int xcommand_handle, int err, string endpoint, string transport_vk)
         {
             var taskCompletionSource = PendingCommands.Remove<EndpointForDidResult>(xcommand_handle);
 
@@ -80,12 +97,15 @@ namespace Hyperledger.Indy.DidApi
             var result = new EndpointForDidResult(endpoint, transport_vk);
 
             taskCompletionSource.SetResult(result);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the command for GetDidMetadataAsync has completed.
         /// </summary>
-        private static DidGetDidMetadataCompletedDelegate _getDidMetadataCompletedCallback = (xcommand_handle, err, metadata) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(DidGetDidMetadataCompletedDelegate))]
+#endif
+        private static void GetDidMetadataCompletedCallback(int xcommand_handle, int err, string metadata)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -93,12 +113,15 @@ namespace Hyperledger.Indy.DidApi
                 return;
 
             taskCompletionSource.SetResult(metadata);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the command for GetMyDidWithMetaAsync has completed.
         /// </summary>
-        private static GetMyDidWithMetaCompletedDelegate _getMyDidWithMetaCompletedCallback = (xcommand_handle, err, didWithMeta) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(GetMyDidWithMetaCompletedDelegate))]
+#endif
+        private static void GetMyDidWithMetaCompletedCallback(int xcommand_handle, int err, string didWithMeta)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -106,12 +129,15 @@ namespace Hyperledger.Indy.DidApi
                 return;
 
             taskCompletionSource.SetResult(didWithMeta);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the command for GetMyDidWithMetaAsync has completed.
         /// </summary>
-        private static ListMyDidsWithMetaCompletedDelegate _listMyDidsWithMetaCompletedCallback = (xcommand_handle, err, dids) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ListMyDidsWithMetaCompletedDelegate))]
+#endif
+        private static void ListMyDidsWithMetaCompletedCallback(int xcommand_handle, int err, string dids)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -119,12 +145,15 @@ namespace Hyperledger.Indy.DidApi
                 return;
 
             taskCompletionSource.SetResult(dids);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the command for AbbreviateVerkeyAsync has completed.
         /// </summary>
-        private static AbbreviateVerkeyCompletedDelegate _abbreviateVerkeyCompletedCallback = (xcommand_handle, err, verkey) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(AbbreviateVerkeyCompletedDelegate))]
+#endif
+        private static void AbbreviateVerkeyCompletedCallback(int xcommand_handle, int err, string verkey)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -132,7 +161,7 @@ namespace Hyperledger.Indy.DidApi
                 return;
 
             taskCompletionSource.SetResult(verkey);
-        };
+        }
 
         /// <summary>
         /// Creates signing and encryption keys in specified wallet for a new DID owned by the caller.
@@ -180,7 +209,7 @@ namespace Hyperledger.Indy.DidApi
                 commandHandle,
                 wallet.Handle,
                 didJson,
-                _createAndStoreMyDidCallback);
+                CreateAndStoreMyDidCallback);
 
             CallbackHelper.CheckResult(commandResult);
 
@@ -225,7 +254,7 @@ namespace Hyperledger.Indy.DidApi
                 wallet.Handle,
                 did,
                 identityJson,
-                _replaceKeysCallback);
+                ReplaceKeysCallback);
 
             CallbackHelper.CheckResult(commandResult);
 
@@ -300,7 +329,7 @@ namespace Hyperledger.Indy.DidApi
 
             return taskCompletionSource.Task;
         }
-        
+
         /// <summary>
         /// Gets the verification key for the specified DID.
         /// </summary>
@@ -332,7 +361,7 @@ namespace Hyperledger.Indy.DidApi
                 pool.Handle,
                 wallet.Handle,
                 did,
-                _keyForDidCompletedCallback
+                KeyForDidCompletedCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -368,7 +397,7 @@ namespace Hyperledger.Indy.DidApi
                 commandHandle,
                 wallet.Handle,
                 did,
-                _keyForLocalDidCompletedCallback
+                KeyForLocalDidCompletedCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -436,7 +465,7 @@ namespace Hyperledger.Indy.DidApi
                 wallet.Handle,
                 pool.Handle,
                 did,
-                _getEndpointForDidCompletedCallback
+                GetEndpointForDidCompletedCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -497,7 +526,7 @@ namespace Hyperledger.Indy.DidApi
                 commandHandle,
                 wallet.Handle,
                 did,
-                _getDidMetadataCompletedCallback
+                GetDidMetadataCompletedCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -523,7 +552,7 @@ namespace Hyperledger.Indy.DidApi
                 commandHandle,
                 wallet.Handle,
                 myDid,
-                _getMyDidWithMetaCompletedCallback
+                GetMyDidWithMetaCompletedCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -546,7 +575,7 @@ namespace Hyperledger.Indy.DidApi
             var commandResult = NativeMethods.indy_list_my_dids_with_meta(
                 commandHandle,
                 wallet.Handle,
-                _listMyDidsWithMetaCompletedCallback
+                ListMyDidsWithMetaCompletedCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -572,7 +601,7 @@ namespace Hyperledger.Indy.DidApi
                 commandHandle,
                 did,
                 fullVerkey,
-                _abbreviateVerkeyCompletedCallback
+                AbbreviateVerkeyCompletedCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);

--- a/wrappers/dotnet/indy-sdk-dotnet/DidApi/EndpointForDidResult.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/DidApi/EndpointForDidResult.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Hyperledger.Indy.DidApi
+﻿namespace Hyperledger.Indy.DidApi
 {
     /// <summary>
     /// Result of getting the endpoint for a DID.

--- a/wrappers/dotnet/indy-sdk-dotnet/ErrorCode.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/ErrorCode.cs
@@ -124,6 +124,11 @@
         /// </summary>
         WalletAlreadyOpenedError = 206,
 
+        /// <summary>
+        /// No value with the specified key exists in the wallet from which it was requested.
+        /// </summary>
+        WalletItemNotFoundError = 212,
+
         // Ledger errors
 
         /// <summary>

--- a/wrappers/dotnet/indy-sdk-dotnet/IndyException.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/IndyException.cs
@@ -96,8 +96,10 @@ namespace Hyperledger.Indy
                     return new ClaimRevokedException();
                 case ErrorCode.SignusUnknownCryptoError:
                     return new UnknownCryptoException();
+                case ErrorCode.WalletItemNotFoundError:
+                    return new WalletItemNotFoundException();
                 default:
-                    var message = string.Format("An unmapped error with the code '{0}' was returned by the SDK.", sdkErrorCode);
+                    var message = $"An unmapped error with the code '{sdkErrorCode}' was returned by the SDK.";
                     return new IndyException(message, sdkErrorCode);
             }      
         }

--- a/wrappers/dotnet/indy-sdk-dotnet/LedgerApi/NativeMethods.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/LedgerApi/NativeMethods.cs
@@ -169,7 +169,7 @@ namespace Hyperledger.Indy.LedgerApi
         /// <summary>
         /// Parse registry response completed delegate.
         /// </summary>
-        internal delegate void ParseRegistryResponseCompletedDelegate(int xcommand_handle, int err, string id, string object_json, long timestamp);
+        internal delegate void ParseRegistryResponseCompletedDelegate(int xcommand_handle, int err, string id, string object_json, ulong timestamp);
 
         /// <summary>
         /// Indies the build cred def request.

--- a/wrappers/dotnet/indy-sdk-dotnet/LedgerApi/ParseRegistryResponseResult.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/LedgerApi/ParseRegistryResponseResult.cs
@@ -21,7 +21,7 @@
         /// Gets the timestamp.
         /// </summary>
         /// <value>The timestamp.</value>
-        public long Timestamp { get; private set; }
+        public ulong Timestamp { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Hyperledger.Indy.LedgerApi.ParseRegistryResponseResult"/> class.
@@ -29,7 +29,7 @@
         /// <param name="id">Identifier.</param>
         /// <param name="objectJson">Object json.</param>
         /// <param name="timestamp">Timestamp.</param>
-        internal ParseRegistryResponseResult(string id, string objectJson, long timestamp)
+        internal ParseRegistryResponseResult(string id, string objectJson, ulong timestamp)
         {
             Id = id;
             ObjectJson = objectJson;

--- a/wrappers/dotnet/indy-sdk-dotnet/NonSecretsApi/NoRecordsException.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/NonSecretsApi/NoRecordsException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace Hyperledger.Indy.NonSecretsApi
+﻿namespace Hyperledger.Indy.NonSecretsApi
 {
     /// <summary>
     /// No records exception.

--- a/wrappers/dotnet/indy-sdk-dotnet/NonSecretsApi/WalletSearch.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/NonSecretsApi/WalletSearch.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Hyperledger.Indy.Utils;
 using Hyperledger.Indy.WalletApi;

--- a/wrappers/dotnet/indy-sdk-dotnet/PairwiseApi/Pairwise.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/PairwiseApi/Pairwise.cs
@@ -1,10 +1,10 @@
 ﻿using Hyperledger.Indy.Utils;
 using Hyperledger.Indy.WalletApi;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using static Hyperledger.Indy.PairwiseApi.NativeMethods;
+#if __IOS__
+using ObjCRuntime;
+#endif
 
 namespace Hyperledger.Indy.PairwiseApi
 {
@@ -21,7 +21,10 @@ namespace Hyperledger.Indy.PairwiseApi
         /// <summary>
         /// Gets the callback to use when the IsExistsAsync command completes.
         /// </summary>
-        private static IsPairwiseExistsCompletedDelegate _isPairwiseExistsCallback = (xcommand_handle, err, exists) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IsPairwiseExistsCompletedDelegate))]
+#endif
+        private static void IsPairwiseExistsCallback(int xcommand_handle, int err, bool exists)
         {
             var taskCompletionSource = PendingCommands.Remove<bool>(xcommand_handle);
 
@@ -29,12 +32,15 @@ namespace Hyperledger.Indy.PairwiseApi
                 return;
 
             taskCompletionSource.SetResult(exists);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the ListAsync command completes.
         /// </summary>
-        private static ListPairwiseCompletedDelegate _listPairwiseCallback = (xcommand_handle, err, list_pairwise) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ListPairwiseCompletedDelegate))]
+#endif
+        private static void ListPairwiseCallback(int xcommand_handle, int err, string list_pairwise)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -42,12 +48,15 @@ namespace Hyperledger.Indy.PairwiseApi
                 return;
 
             taskCompletionSource.SetResult(list_pairwise);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use when the GetAsync command completes.
         /// </summary>
-        private static GetPairwiseCompletedDelegate _getPairwiseCallback = (xcommand_handle, err, get_pairwise_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(GetPairwiseCompletedDelegate))]
+#endif
+        private static void GetPairwiseCallback(int xcommand_handle, int err, string get_pairwise_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -55,7 +64,7 @@ namespace Hyperledger.Indy.PairwiseApi
                 return;
 
             taskCompletionSource.SetResult(get_pairwise_json);
-        };
+        }
 
         /// <summary>
         /// Gets whether or not a pairwise record exists in the provided wallet for the specified DID .
@@ -76,7 +85,7 @@ namespace Hyperledger.Indy.PairwiseApi
                 commandHandle,
                 wallet.Handle,
                 theirDid,
-                _isPairwiseExistsCallback);
+                IsPairwiseExistsCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -145,7 +154,7 @@ namespace Hyperledger.Indy.PairwiseApi
             int result = NativeMethods.indy_list_pairwise(
                 commandHandle,
                 wallet.Handle,
-                _listPairwiseCallback);
+                ListPairwiseCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -186,7 +195,7 @@ namespace Hyperledger.Indy.PairwiseApi
                 commandHandle,
                 wallet.Handle,
                 theirDid,
-                _getPairwiseCallback);
+                GetPairwiseCallback);
 
             CallbackHelper.CheckResult(result);
 

--- a/wrappers/dotnet/indy-sdk-dotnet/PaymentsApi/PaymentMethod.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/PaymentsApi/PaymentMethod.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Hyperledger.Indy.Utils;
-using Hyperledger.Indy.WalletApi;
 using static Hyperledger.Indy.PaymentsApi.NativeMethods;
 
 namespace Hyperledger.Indy.PaymentsApi

--- a/wrappers/dotnet/indy-sdk-dotnet/PaymentsApi/PaymentResult.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/PaymentsApi/PaymentResult.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace Hyperledger.Indy.PaymentsApi
+﻿namespace Hyperledger.Indy.PaymentsApi
 {
     /// <summary>
     /// Payment result.

--- a/wrappers/dotnet/indy-sdk-dotnet/PaymentsApi/Payments.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/PaymentsApi/Payments.cs
@@ -1,9 +1,11 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Hyperledger.Indy.Utils;
 using Hyperledger.Indy.WalletApi;
 using static Hyperledger.Indy.PaymentsApi.NativeMethods;
 using static Hyperledger.Indy.Utils.CallbackHelper;
+#if __IOS__
+using ObjCRuntime;
+#endif
 
 namespace Hyperledger.Indy.PaymentsApi
 {
@@ -12,7 +14,10 @@ namespace Hyperledger.Indy.PaymentsApi
     /// </summary>
     public class Payments
     {
-        static CreatePaymentAddressDelegate _createPaymentAddressCallback = (xcommand_handle, err, payment_address) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(CreatePaymentAddressDelegate))]
+#endif
+        static void CreatePaymentAddressCallback(int xcommand_handle, int err, string payment_address)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -20,9 +25,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(payment_address);
-        };
+        }
 
-        static ListPaymentAddressesDelegate _listPaymentAddressesCallback = (xcommand_handle, err, payment_addressed_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ListPaymentAddressesDelegate))]
+#endif
+        static void ListPaymentAddressesCallback(int xcommand_handle, int err, string payment_addressed_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -30,19 +38,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(payment_addressed_json);
-        };
+        }
 
-        static IndyMethodCompletedDelegate _registerPaymentMethodCallback = (xcommand_handle, err) =>
-        {
-            var taskCompletionSource = PendingCommands.Remove<bool>(xcommand_handle);
-
-            if (!CallbackHelper.CheckCallback(taskCompletionSource, err))
-                return;
-
-            taskCompletionSource.SetResult(true);
-        };
-
-        static AddRequestFeesDelegate _addRequestFeesCallback = (xcommand_handle, err, req_with_fees_json, payment_method) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(AddRequestFeesDelegate))]
+#endif
+        static void AddRequestFeesCallback(int xcommand_handle, int err, string req_with_fees_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -50,9 +51,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(new PaymentResult(req_with_fees_json, payment_method));
-        };
+        }
 
-        static ParseResponseWithFeesDelegate _parseResponseWithFeesCallback = (xcommand_handle, err, utxo_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ParseResponseWithFeesDelegate))]
+#endif
+        static void ParseResponseWithFeesCallback(int xcommand_handle, int err, string utxo_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -60,9 +64,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(utxo_json);
-        };
+        }
 
-        static BuildGetUtxoRequstDelegate _buildGetUtxoRequestCallback = (xcommand_handle, err, get_utxo_txn_json, payment_method) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(BuildGetUtxoRequstDelegate))]
+#endif
+        static void BuildGetUtxoRequestCallback(int xcommand_handle, int err, string get_utxo_txn_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -70,9 +77,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(new PaymentResult(get_utxo_txn_json, payment_method));
-        };
+        }
 
-        static ParseGetUtxoResponseDelegate _parseGetUtxoResponseCallback = (xcommand_handle, err, utxo_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ParseGetUtxoResponseDelegate))]
+#endif
+        static void ParseGetUtxoResponseCallback(int xcommand_handle, int err, string utxo_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -80,9 +90,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(utxo_json);
-        };
+        }
 
-        static BuildPaymentRequestDelegate _buildPaymentRequestCallback = (xcommand_handle, err, payment_req_json, payment_method) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(BuildPaymentRequestDelegate))]
+#endif
+        static void BuildPaymentRequestCallback(int xcommand_handle, int err, string payment_req_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -90,9 +103,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(new PaymentResult(payment_req_json, payment_method));
-        };
+        }
 
-        static ParsePaymentResponseDelegate _parsePaymentResponseCallback = (xcommand_handle, err, utxo_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ParsePaymentResponseDelegate))]
+#endif
+        static void ParsePaymentResponseCallback(int xcommand_handle, int err, string utxo_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -100,9 +116,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(utxo_json);
-        };
+        }
 
-        static BuildMintReqDelegate _buildMintRequestCallback = (xcommand_handle, err, mint_req_json, payment_method) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(BuildMintReqDelegate))]
+#endif
+        static void BuildMintRequestCallback(int xcommand_handle, int err, string mint_req_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -110,9 +129,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(new PaymentResult(mint_req_json, payment_method));
-        };
+        }
 
-        static BuildSetTxnFeesReqDelegate _buildSetTxnFeesReqCallback = (xcommand_handle, err, set_txn_fees_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(BuildSetTxnFeesReqDelegate))]
+#endif
+        static void BuildSetTxnFeesReqCallback(int xcommand_handle, int err, string set_txn_fees_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -120,9 +142,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(set_txn_fees_json);
-        };
+        }
 
-        static BuildGetTxnFeesReqDelegate _buildGetTxnFeesReqCallback = (xcommand_handle, err, get_txn_fees_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(BuildGetTxnFeesReqDelegate))]
+#endif
+        static void BuildGetTxnFeesReqCallback(int xcommand_handle, int err, string get_txn_fees_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -130,9 +155,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(get_txn_fees_json);
-        };
+        }
 
-        static ParseGetTxnFeesResponseDelegate _parseGetTxnFeesResponseCallback = (xcommand_handle, err, get_txn_fees_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ParseGetTxnFeesResponseDelegate))]
+#endif
+        static void ParseGetTxnFeesResponseCallback(int xcommand_handle, int err, string get_txn_fees_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -140,9 +168,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(get_txn_fees_json);
-        };
+        }
 
-        static BuildVerifyPaymentRequestDelegate _buildVerifyPaymentRequestCallback = (xcommand_handle, err, verify_txn_json, payment_method) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(BuildVerifyPaymentRequestDelegate))]
+#endif
+        static void BuildVerifyPaymentRequestCallback(int xcommand_handle, int err, string verify_txn_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -150,9 +181,12 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(new PaymentResult(verify_txn_json, payment_method));
-        };
+        }
 
-        static ParseVerifyPaymentResponseDelegate _parseVerifyPaymentResponseDelegate = (xcommand_handle, err, txn_json) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ParseVerifyPaymentResponseDelegate))]
+#endif
+        static void ParseVerifyPaymentResponseDelegate(int xcommand_handle, int err, string txn_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -160,8 +194,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 return;
 
             taskCompletionSource.SetResult(txn_json);
-        };
-
+        }
 
         /// <summary>
         /// Create the payment address for this payment method.
@@ -196,7 +229,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 wallet.Handle,
                 paymentMethod,
                 config,
-                _createPaymentAddressCallback);
+                CreatePaymentAddressCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -221,7 +254,7 @@ namespace Hyperledger.Indy.PaymentsApi
             var result = NativeMethods.indy_list_payment_addresses(
                 commandHandle,
                 wallet.Handle,
-                _listPaymentAddressesCallback);
+                ListPaymentAddressesCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -263,7 +296,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 implementation.ParseGetTxnFeesResponseCallback,
                 implementation.BuildVerifyPaymentRequestCallback,
                 implementation.ParseVerifyPaymentResponseCallback,
-                _registerPaymentMethodCallback);
+                CallbackHelper.TaskCompletingNoValueCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -318,7 +351,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 reqJson,
                 inputsJson,
                 outputsJson,
-                _addRequestFeesCallback);
+                AddRequestFeesCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -353,7 +386,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 commandHandle,
                 paymentMethod,
                 responseJson,
-                _parseResponseWithFeesCallback);
+                ParseResponseWithFeesCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -372,7 +405,7 @@ namespace Hyperledger.Indy.PaymentsApi
         /// <param name="wallet">Wallet.</param>
         /// <param name="submittedDid">DID of request sender</param>
         /// <param name="paymentAddress">target payment address</param>
-        public static Task<PaymentResult> BuildGetUtxoRequestAsync(Wallet wallet, string submittedDid, string paymentAddress)
+        public static Task<PaymentResult> BuildGetPaymentSourcesAsync(Wallet wallet, string submittedDid, string paymentAddress)
         {
             ParamGuard.NotNullOrWhiteSpace(submittedDid, "submittedDid");
             ParamGuard.NotNullOrWhiteSpace(paymentAddress, "paymentAddress");
@@ -385,7 +418,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 wallet.Handle,
                 submittedDid,
                 paymentAddress,
-                _buildGetUtxoRequestCallback);
+                BuildGetUtxoRequestCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -408,7 +441,7 @@ namespace Hyperledger.Indy.PaymentsApi
         /// <param name="paymentMethod">Payment method.</param>
         /// <param name="responseJson">response for Indy request for getting UTXO list
         ///   Note: this param will be used to determine payment_method</param>
-        public static Task<string> ParseGetUtxoResponseAsync(string paymentMethod, string responseJson)
+        public static Task<string> ParseGetPaymentSourcesAsync(string paymentMethod, string responseJson)
         {
             ParamGuard.NotNullOrWhiteSpace(responseJson, "responseJson");
 
@@ -419,7 +452,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 commandHandle,
                 paymentMethod,
                 responseJson,
-                _parseGetUtxoResponseCallback);
+                ParseGetUtxoResponseCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -468,7 +501,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 inputsJson,
                 outputsJson,
                 extra,
-                _buildPaymentRequestCallback);
+                BuildPaymentRequestCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -503,7 +536,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 commandHandle,
                 paymentMethod,
                 responseJson,
-                _parsePaymentResponseCallback);
+                ParsePaymentResponseCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -542,7 +575,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 submitterDid,
                 outputsJson,
                 extra,
-                _buildMintRequestCallback);
+                BuildMintRequestCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -582,7 +615,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 submitterDid,
                 paymentMethod,
                 feesJson,
-                _buildSetTxnFeesReqCallback);
+                BuildSetTxnFeesReqCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -613,7 +646,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 wallet.Handle,
                 submitterDid,
                 paymentMethod,
-                _buildGetTxnFeesReqCallback);
+                BuildGetTxnFeesReqCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -646,7 +679,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 commandHandle,
                 paymentMethod,
                 responseJson,
-                _parseGetTxnFeesResponseCallback);
+                ParseGetTxnFeesResponseCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -674,7 +707,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 wallet.Handle,
                 submitterDid,
                 receipt,
-                _buildVerifyPaymentRequestCallback);
+                BuildVerifyPaymentRequestCallback);
 
             CallbackHelper.CheckResult(result);
 
@@ -707,7 +740,7 @@ namespace Hyperledger.Indy.PaymentsApi
                 commandHandle,
                 paymentMethod,
                 responseJson,
-                _parseVerifyPaymentResponseDelegate);
+                ParseVerifyPaymentResponseDelegate);
 
             CallbackHelper.CheckResult(result);
 

--- a/wrappers/dotnet/indy-sdk-dotnet/Utils/CallbackHelper.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/Utils/CallbackHelper.cs
@@ -1,5 +1,8 @@
 ﻿using System.Threading.Tasks;
-using static Hyperledger.Indy.Consts;
+
+#if __IOS__
+using ObjCRuntime;
+#endif
 
 namespace Hyperledger.Indy.Utils
 {
@@ -15,7 +18,10 @@ namespace Hyperledger.Indy.Utils
         /// <summary>
         /// Gets the callback to use for completing tasks that don't return a value.
         /// </summary>
-        public static IndyMethodCompletedDelegate TaskCompletingNoValueCallback = (xcommand_handle, err) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IndyMethodCompletedDelegate))]
+#endif
+        public static void TaskCompletingNoValueCallback(int xcommand_handle, int err)
         {
             var taskCompletionSource = PendingCommands.Remove<bool>(xcommand_handle);
 
@@ -23,15 +29,18 @@ namespace Hyperledger.Indy.Utils
                 return;
 
             taskCompletionSource.SetResult(true);
-        };
+        }
 
         /// <summary>
         /// Gets the callback to use for functions that don't return a value and are not associated with a task.
         /// </summary>
-        public static IndyMethodCompletedDelegate NoValueCallback = (xcommand_handle, err) =>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(IndyMethodCompletedDelegate))]
+#endif
+        public static void NoValueCallback(int xcommand_handle, int err)
         {
             CheckCallback(err);
-        };
+        }
 
         /// <summary>
         /// Checks the result from a Sovrin function call.

--- a/wrappers/dotnet/indy-sdk-dotnet/Utils/PendingCommands.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/Utils/PendingCommands.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;

--- a/wrappers/dotnet/indy-sdk-dotnet/WalletApi/WalletItemNotFoundException.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/WalletApi/WalletItemNotFoundException.cs
@@ -1,0 +1,16 @@
+﻿namespace Hyperledger.Indy.WalletApi
+{
+    /// <summary>
+    /// Exception thrown when value with the specified key doesn't exists in the wallet from which it was requested.
+    /// </summary>
+    /// <seealso cref="Hyperledger.Indy.IndyException" />
+    public class WalletItemNotFoundException : IndyException
+    {
+        private const string message =
+            "No value with the specified key exists in the wallet from which it was requested.";
+
+        internal WalletItemNotFoundException() : base(message, (int)ErrorCode.WalletItemNotFoundError)
+        {
+        }
+    }
+}

--- a/wrappers/dotnet/indy-sdk-dotnet/WalletApi/WalletType.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/WalletApi/WalletType.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using static Hyperledger.Indy.Consts;
 using static Hyperledger.Indy.WalletApi.NativeMethods;
 
 namespace Hyperledger.Indy.WalletApi

--- a/wrappers/dotnet/indy-sdk-dotnet/indy-sdk-dotnet.csproj
+++ b/wrappers/dotnet/indy-sdk-dotnet/indy-sdk-dotnet.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.46">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;xamarinios10</TargetFrameworks>
     <AssemblyName>Hyperledger.Indy.Sdk</AssemblyName>
     <RootNamespace>Hyperledger.Indy</RootNamespace>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Version>1.4.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.6.2</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Authors>Symon Rottem</Authors>
+    <Authors>Symon Rottem, Tomislav Markovski</Authors>
     <Company>Hyperledger Indy</Company>
     <Product>Hyperledger Indy SDK</Product>
     <Description>.NET wrapper for the Hyperledger Indy SDK.
@@ -19,8 +19,8 @@ Please note that to function the C-Callable Hyperledger Indy SDK and its depende
     <PackageTags>hyperledger indy sdk</PackageTags>
     <PackageLicenseUrl>https://github.com/hyperledger/indy-sdk/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl></PackageIconUrl>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
-    <FileVersion>1.4.0.0</FileVersion>
+    <AssemblyVersion>1.6.2</AssemblyVersion>
+    <FileVersion>1.6.2</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Support for Xamarin.iOS targets for the dotnet wrapper. Updated the project file with multitargets to support `xamarinios10` target.
Callback methods are updated with runtime specific attributes that allow the JIT to resolve them properly when running the dotnet SDK on a ARM architectures.
Version bump.

Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>