### PR TITLE
Ledger check json

### DIFF
--- a/libindy/src/commands/did.rs
+++ b/libindy/src/commands/did.rs
@@ -22,6 +22,8 @@ use commands::{Command, CommandExecutor};
 use std::collections::HashMap;
 use utils::sequence::SequenceUtils;
 use utils::crypto::base58;
+use domain::ledger::nym::GetNymOperation;
+use domain::ledger::request::Request;
 
 pub enum DidCommand {
     CreateAndStoreMyDid(
@@ -614,12 +616,24 @@ impl DidCommandExecutor {
         let deferred_cmd_id = self._defer_command(deferred_cmd);
 
         // TODO we need passing of my_did as identifier
-        let get_nym_request = self.ledger_service.build_get_nym_request(did, did)
+
+        let operation = GetNymOperation::new(did.to_string());
+        let request = Request::new(did, operation);
+        let get_nym_request= serde_json::to_string(&request)
             .map_err(map_err_trace!())
             .map_err(|err|
                 CommonError::InvalidState(
                     // TODO: FIXME: Remove this unwrap by sending GetNymAck with the error.
                     format!("Invalid Get Nym Request: {}", err.description()))).unwrap();
+
+        /*
+                let get_nym_request = self.ledger_service.build_get_nym_request(did, did)
+                    .map_err(map_err_trace!())
+                    .map_err(|err|
+                        CommonError::InvalidState(
+                            // TODO: FIXME: Remove this unwrap by sending GetNymAck with the error.
+                            format!("Invalid Get Nym Request: {}", err.description()))).unwrap();
+        */
 
         CommandExecutor::instance()
             .send(Command::Ledger(LedgerCommand::SubmitRequest(

--- a/libindy/src/domain/ledger/request.rs
+++ b/libindy/src/domain/ledger/request.rs
@@ -1,5 +1,4 @@
 use serde;
-use serde_json;
 use time;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -37,7 +36,9 @@ pub struct Request<T: serde::Serialize> {
 }
 
 impl<T: serde::Serialize> Request<T> {
-    pub fn new(req_id: u64, identifier: &str, operation: T, protocol_version: usize) -> Request<T> {
+    pub fn new(identifier: &str, operation: T) -> Request<T> {
+        let req_id = time::get_time().sec as u64 * (1e9 as u64) + time::get_time().nsec as u64;
+        let protocol_version: usize = ProtocolVersion::get();
         Request {
             req_id,
             identifier: identifier.to_string(),
@@ -45,10 +46,5 @@ impl<T: serde::Serialize> Request<T> {
             protocol_version,
             signature: None
         }
-    }
-
-    pub fn build_request(identifier: &str, operation: T) -> Result<String, serde_json::Error> {
-        let req_id = time::get_time().sec as u64 * (1e9 as u64) + time::get_time().nsec as u64;
-        serde_json::to_string(&Request::new(req_id, identifier, operation, ProtocolVersion::get()))
     }
 }

--- a/libindy/src/services/ledger/mod.rs
+++ b/libindy/src/services/ledger/mod.rs
@@ -71,7 +71,8 @@ impl LedgerService {
             }
         }
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("NYM request json is invalid {:?}.", err)))?;
 
         info!("build_nym_request <<< request: {:?}", request);
@@ -84,7 +85,8 @@ impl LedgerService {
 
         let operation = GetNymOperation::new(dest.to_string());
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("GET_NYM request json is invalid {:?}.", err)))?;
 
         info!("build_get_nym_request <<< request: {:?}", request);
@@ -97,7 +99,8 @@ impl LedgerService {
 
         let operation = GetDdoOperation::new(dest.to_string());
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("Invalid get_ddo request json: {:?}", err)))?;
 
         info!("build_get_nym_request <<< request: {:?}", request);
@@ -122,7 +125,8 @@ impl LedgerService {
                                              raw.map(String::from),
                                              enc.map(String::from));
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("ATTRIB request json is invalid {:?}.", err)))?;
 
         info!("build_attrib_request <<< request: {:?}", request);
@@ -139,7 +143,8 @@ impl LedgerService {
         }
         let operation = GetAttribOperation::new(dest.to_string(), raw, hash, enc);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("GET_ATTRIB request json is invalid {:?}.", err)))?;
 
         info!("build_get_attrib_request <<< request: {:?}", request);
@@ -154,7 +159,8 @@ impl LedgerService {
 
         let operation = SchemaOperation::new(schema_data);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("SCHEMA request json is invalid {:?}.", err)))?;
 
         info!("build_schema_request <<< request: {:?}", request);
@@ -176,7 +182,8 @@ impl LedgerService {
         let data = GetSchemaOperationData::new(name, version);
         let operation = GetSchemaOperation::new(dest, data);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("GET_SCHEMA request json is invalid {:?}.", err)))?;
 
         info!("build_get_schema_request <<< request: {:?}", request);
@@ -189,7 +196,8 @@ impl LedgerService {
 
         let operation = CredDefOperation::new(cred_def);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("CRED_DEF request json is invalid {:?}.", err)))?;
 
         info!("build_cred_def_request <<< request: {:?}", request);
@@ -216,7 +224,8 @@ impl LedgerService {
 
         let operation = GetCredDefOperation::new(ref_, signature_type, origin, tag);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("GET_CRED_DEF request json is invalid {:?}.", err)))?;
 
         info!("build_get_cred_def_request <<< request: {:?}", request);
@@ -240,7 +249,8 @@ impl LedgerService {
 
         let operation = NodeOperation::new(dest.to_string(), data);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("NODE request json is invalid {:?}.", err)))?;
 
         info!("build_node_request <<< request: {:?}", request);
@@ -253,7 +263,8 @@ impl LedgerService {
 
         let operation = GetValidatorInfoOperation::new();
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("GET_TXN request json is invalid {:?}.", err)))?;
 
         info!("build_get_validator_info_request <<< request: {:?}", request);
@@ -275,7 +286,8 @@ impl LedgerService {
 
         let operation = GetTxnOperation::new(seq_no, ledger_id);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("GET_TXN request json is invalid {:?}.", err)))?;
 
         info!("build_get_txn_request <<< request: {:?}", request);
@@ -288,7 +300,8 @@ impl LedgerService {
 
         let operation = PoolConfigOperation::new(writes, force);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("POOL_CONFIG request json is invalid {:?}.", err)))?;
 
         info!("build_pool_config <<< request: {:?}", request);
@@ -305,7 +318,8 @@ impl LedgerService {
 
         let operation = PoolRestartOperation::new(action, datetime.map(String::from));
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("Invalid pool_restart request json: {:?}", err)))?;
 
         info!("build_pool_restart <<< request: {:?}", request);
@@ -335,7 +349,8 @@ impl LedgerService {
 
         let operation = PoolUpgradeOperation::new(name, version, action, sha256, timeout, schedule, justification, reinstall, force, package);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("POOL_UPGRADE request json is invalid {:?}.", err)))?;
 
         info!("build_pool_upgrade <<< request: {:?}", request);
@@ -346,9 +361,10 @@ impl LedgerService {
     pub fn build_revoc_reg_def_request(&self, identifier: &str, rev_reg_def: RevocationRegistryDefinitionV1) -> Result<String, CommonError> {
         info!("build_revoc_reg_def_request >>> identifier: {:?}, rev_reg_def {:?}", identifier, rev_reg_def);
 
-        let rev_reg_def_operation = RevRegDefOperation::new(rev_reg_def);
+        let operation = RevRegDefOperation::new(rev_reg_def);
 
-        let request = Request::build_request(identifier, rev_reg_def_operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("REVOC_REG_DEF request json is invalid {:?}.", err)))?;
 
         info!("build_revoc_reg_def_request <<< request: {:?}", request);
@@ -361,7 +377,8 @@ impl LedgerService {
 
         let operation = GetRevRegDefOperation::new(id);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("GET_REVOC_REG_DEF request json is invalid {:?}.", err)))?;
 
         info!("build_get_revoc_reg_def_request <<< request: {:?}", request);
@@ -376,7 +393,8 @@ impl LedgerService {
 
         let operation = RevRegEntryOperation::new(revoc_def_type, revoc_reg_def_id, rev_reg_entry);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("REVOC_REG_ENTRY request json is invalid {:?}.", err)))?;
 
         info!("build_revoc_reg_entry_request <<< request: {:?}", request);
@@ -389,7 +407,8 @@ impl LedgerService {
 
         let operation = GetRevRegOperation::new(revoc_reg_def_id, timestamp);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("GET_REVOC_REG request json is invalid {:?}.", err)))?;
 
         info!("build_get_revoc_reg_request <<< request: {:?}", request);
@@ -402,7 +421,8 @@ impl LedgerService {
 
         let operation = GetRevRegDeltaOperation::new(revoc_reg_def_id, from, to);
 
-        let request = Request::build_request(identifier, operation)
+        let request = Request::new(identifier, operation);
+        let request = serde_json::to_string(&request)
             .map_err(|err| CommonError::InvalidState(format!("GET_REVOC_REG_DELTA request json is invalid {:?}.", err)))?;
 
         info!("build_get_revoc_reg_delta_request <<< request: {:?}", request);

--- a/libindy/src/utils/cstring.rs
+++ b/libindy/src/utils/cstring.rs
@@ -58,6 +58,27 @@ macro_rules! check_useful_opt_json {
     }
 }
 
+macro_rules! check_request {
+    ($x:ident) => {
+        let $x: Value = match serde_json::from_str(&$x) {
+            Ok(Some(val)) => val,
+            _ => {
+                trace!("indy_sign_and_submit_request: could not parse request as valid json: {:?}", $x);
+                return ErrorCode::CommonInvalidParam4;
+            }
+        };
+        if !$x.is_object() {
+        trace!("indy_sign_and_submit_request: request json is not an object: {:?}", $x);
+        return ErrorCode::CommonInvalidParam4;
+        }
+        if !$x["req_id"].is_null() {
+            trace!("indy_sign_and_submit_request: request json is not an object: {:?}", $x);
+            return ErrorCode::CommonInvalidParam4;
+        }
+    }
+}
+
+
 macro_rules! check_useful_json {
     ($x:ident, $e:expr, $t:ty) => {
         let $x = match CStringUtils::c_str_to_string($x) {


### PR DESCRIPTION
This PR has two parts.

1) check api parameters that are request json
1.1) more checks might still be added to check_request macro
1.2) This PR does not use check_useful_json with type Request<Value> because further down the line Value is use.
1.3) not all request parameters are checked because further down the line the parameter string is just submitted to the ledger without any Request-specific handling.

2) Request.rs was not Rust idiomatic
2.1) The Request new method was too similar to the normal constructor
2.2) Request::build_request did just to_string. The general goal is to have more specific types in the Indy code base. Not everything should be String but more specific so that developers know what legal content of parameters are. 
2.3) removed ledger_services.build_nym_request call in one place because I think ledger_services' methods that do not call out to the ledger should be called directly 