### PR TITLE
validate_did is static

### DIFF
--- a/libindy/src/commands/anoncreds/issuer.rs
+++ b/libindy/src/commands/anoncreds/issuer.rs
@@ -112,21 +112,18 @@ pub struct IssuerCommandExecutor {
     pub blob_storage_service: Rc<BlobStorageService>,
     pub pool_service: Rc<PoolService>,
     pub wallet_service: Rc<WalletService>,
-    pub crypto_service: Rc<CryptoService>
 }
 
 impl IssuerCommandExecutor {
     pub fn new(anoncreds_service: Rc<AnoncredsService>,
                pool_service: Rc<PoolService>,
                blob_storage_service: Rc<BlobStorageService>,
-               wallet_service: Rc<WalletService>,
-               crypto_service: Rc<CryptoService>) -> IssuerCommandExecutor {
+               wallet_service: Rc<WalletService>) -> IssuerCommandExecutor {
         IssuerCommandExecutor {
             anoncreds_service,
             pool_service,
             blob_storage_service,
             wallet_service,
-            crypto_service,
         }
     }
 
@@ -183,7 +180,7 @@ impl IssuerCommandExecutor {
                      attrs: AttributeNames) -> Result<(String, String), IndyError> {
         debug!("create_schema >>> issuer_did: {:?}, name: {:?}, version: {:?}, attrs: {:?}", issuer_did, name, version, attrs);
 
-        self.crypto_service.validate_did(issuer_did)?;
+        CryptoService::validate_did(issuer_did)?;
 
         let schema_id = Schema::schema_id(issuer_did, name, version);
 
@@ -213,7 +210,7 @@ impl IssuerCommandExecutor {
         debug!("create_and_store_credential_definition >>> wallet_handle: {:?}, issuer_did: {:?}, schema: {:?}, tag: {:?}, \
               type_: {:?}, config: {:?}", wallet_handle, issuer_did, schema, tag, type_, config);
 
-        self.crypto_service.validate_did(issuer_did)?;
+        CryptoService::validate_did(issuer_did)?;
 
         let default_cred_def_config = CredentialDefinitionConfig::default();
         let cred_def_config = config.unwrap_or(&default_cred_def_config);

--- a/libindy/src/commands/anoncreds/mod.rs
+++ b/libindy/src/commands/anoncreds/mod.rs
@@ -11,7 +11,6 @@ use services::anoncreds::AnoncredsService;
 use services::blob_storage::BlobStorageService;
 use services::pool::PoolService;
 use services::wallet::WalletService;
-use services::crypto::CryptoService;
 
 use std::rc::Rc;
 
@@ -31,14 +30,13 @@ impl AnoncredsCommandExecutor {
     pub fn new(anoncreds_service: Rc<AnoncredsService>,
                blob_storage_service: Rc<BlobStorageService>,
                pool_service: Rc<PoolService>,
-               wallet_service: Rc<WalletService>,
-               crypto_service: Rc<CryptoService>) -> AnoncredsCommandExecutor {
+               wallet_service: Rc<WalletService>) -> AnoncredsCommandExecutor {
         AnoncredsCommandExecutor {
             issuer_command_cxecutor: IssuerCommandExecutor::new(
                 anoncreds_service.clone(), pool_service.clone(),
-                blob_storage_service.clone(), wallet_service.clone(), crypto_service.clone()),
+                blob_storage_service.clone(), wallet_service.clone()),
             prover_command_cxecutor: ProverCommandExecutor::new(
-                anoncreds_service.clone(), wallet_service.clone(), crypto_service.clone(), blob_storage_service.clone()),
+                anoncreds_service.clone(), wallet_service.clone(), blob_storage_service.clone()),
             verifier_command_cxecutor: VerifierCommandExecutor::new(
                 anoncreds_service.clone()),
         }

--- a/libindy/src/commands/anoncreds/prover.rs
+++ b/libindy/src/commands/anoncreds/prover.rs
@@ -134,7 +134,6 @@ impl SearchForProofRequest {
 pub struct ProverCommandExecutor {
     anoncreds_service: Rc<AnoncredsService>,
     wallet_service: Rc<WalletService>,
-    crypto_service: Rc<CryptoService>,
     blob_storage_service: Rc<BlobStorageService>,
     searches: RefCell<HashMap<i32, Box<WalletSearch>>>,
     searches_for_proof_requests: RefCell<HashMap<i32, Box<HashMap<String, SearchForProofRequest>>>>,
@@ -143,12 +142,10 @@ pub struct ProverCommandExecutor {
 impl ProverCommandExecutor {
     pub fn new(anoncreds_service: Rc<AnoncredsService>,
                wallet_service: Rc<WalletService>,
-               crypto_service: Rc<CryptoService>,
                blob_storage_service: Rc<BlobStorageService>) -> ProverCommandExecutor {
         ProverCommandExecutor {
             anoncreds_service,
             wallet_service,
-            crypto_service,
             blob_storage_service,
             searches: RefCell::new(HashMap::new()),
             searches_for_proof_requests: RefCell::new(HashMap::new()),
@@ -263,7 +260,7 @@ impl ProverCommandExecutor {
         debug!("create_credential_request >>> wallet_handle: {:?}, prover_did: {:?}, cred_offer: {:?}, cred_def: {:?}, master_secret_id: {:?}",
                wallet_handle, prover_did, cred_offer, cred_def, master_secret_id);
 
-        self.crypto_service.validate_did(&prover_did)?;
+        CryptoService::validate_did(&prover_did)?;
 
         let master_secret: MasterSecret = self._wallet_get_master_secret(wallet_handle, &master_secret_id)?;
 

--- a/libindy/src/commands/did.rs
+++ b/libindy/src/commands/did.rs
@@ -217,7 +217,7 @@ impl DidCommandExecutor {
                           my_did: &str) -> Result<String, IndyError> {
         debug!("replace_keys_start >>> wallet_handle: {:?}, key_info_json: {:?}, my_did: {:?}", wallet_handle, secret!(key_info), my_did);
 
-        self.crypto_service.validate_did(my_did)?;
+        CryptoService::validate_did(my_did)?;
 
         let my_did = self._wallet_get_my_did(wallet_handle, my_did)?;
 
@@ -239,7 +239,7 @@ impl DidCommandExecutor {
                           my_did: &str) -> Result<(), IndyError> {
         debug!("replace_keys_apply >>> wallet_handle: {:?}, my_did: {:?}", wallet_handle, my_did);
 
-        self.crypto_service.validate_did(my_did)?;
+        CryptoService::validate_did(my_did)?;
 
         let my_did = self._wallet_get_my_did(wallet_handle, my_did)?;
         let my_temporary_did: TemporaryDid =
@@ -272,7 +272,7 @@ impl DidCommandExecutor {
     fn get_my_did_with_meta(&self, wallet_handle: i32, my_did: &str) -> Result<String, IndyError> {
         debug!("get_my_did_with_meta >>> wallet_handle: {:?}, my_did: {:?}", wallet_handle, my_did);
 
-        self.crypto_service.validate_did(&my_did)?;
+        CryptoService::validate_did(&my_did)?;
 
         let did = self.wallet_service.get_indy_object::<Did>(wallet_handle, &my_did, &RecordOptions::id_value())?;
         let metadata = self.wallet_service.get_indy_opt_object::<DidMetadata>(wallet_handle, &did.did, &RecordOptions::id_value())?;
@@ -334,7 +334,7 @@ impl DidCommandExecutor {
                    cb: Box<Fn(Result<String, IndyError>) + Send>) {
         debug!("key_for_did >>> pool_handle: {:?}, wallet_handle: {:?}, did: {:?}", pool_handle, wallet_handle, did);
 
-        try_cb!(self.crypto_service.validate_did(&did), cb);
+        try_cb!(CryptoService::validate_did(&did), cb);
 
         // Look to my did
         match self._wallet_get_my_did(wallet_handle, &did) {
@@ -367,7 +367,7 @@ impl DidCommandExecutor {
                          did: &str) -> Result<String, IndyError> {
         info!("key_for_local_did >>> wallet_handle: {:?}, did: {:?}", wallet_handle, did);
 
-        self.crypto_service.validate_did(&did)?;
+        CryptoService::validate_did(&did)?;
 
         // Look to my did
         match self._wallet_get_my_did(wallet_handle, did) {
@@ -393,7 +393,7 @@ impl DidCommandExecutor {
                             transport_key: &str) -> Result<(), IndyError> {
         debug!("set_endpoint_for_did >>> wallet_handle: {:?}, did: {:?}, address: {:?}, transport_key: {:?}", wallet_handle, did, address, transport_key);
 
-        self.crypto_service.validate_did(did)?;
+        CryptoService::validate_did(did)?;
         self.crypto_service.validate_key(transport_key)?;
 
         let endpoint = Endpoint::new(address.to_string(), Some(transport_key.to_string()));
@@ -411,7 +411,7 @@ impl DidCommandExecutor {
                             cb: Box<Fn(Result<(String, Option<String>), IndyError>) + Send>) {
         debug!("get_endpoint_for_did >>> wallet_handle: {:?}, pool_handle: {:?}, did: {:?}", wallet_handle, pool_handle, did);
 
-        try_cb!(self.crypto_service.validate_did(&did), cb);
+        try_cb!(CryptoService::validate_did(&did), cb);
 
         let endpoint =
             self.wallet_service.get_indy_object::<Endpoint>(wallet_handle, &did, &RecordOptions::id_value());
@@ -438,7 +438,7 @@ impl DidCommandExecutor {
                         metadata: String) -> Result<(), IndyError> {
         debug!("set_did_metadata >>> wallet_handle: {:?}, did: {:?}, metadata: {:?}", wallet_handle, did, metadata);
 
-        self.crypto_service.validate_did(did)?;
+        CryptoService::validate_did(did)?;
 
         let metadata = DidMetadata { value: metadata };
 
@@ -454,7 +454,7 @@ impl DidCommandExecutor {
                         did: &str) -> Result<String, IndyError> {
         debug!("get_did_metadata >>> wallet_handle: {:?}, did: {:?}", wallet_handle, did);
 
-        self.crypto_service.validate_did(did)?;
+        CryptoService::validate_did(did)?;
 
         let metadata = self.wallet_service.get_indy_object::<DidMetadata>(wallet_handle, did, &RecordOptions::id_value())?;
 
@@ -470,7 +470,7 @@ impl DidCommandExecutor {
                          verkey: String) -> Result<String, IndyError> {
         info!("abbreviate_verkey >>> did: {:?}, verkey: {:?}", did, verkey);
 
-        self.crypto_service.validate_did(&did)?;
+        CryptoService::validate_did(&did)?;
         self.crypto_service.validate_key(&verkey)?;
 
         let did = base58::decode(&did)?;

--- a/libindy/src/commands/ledger.rs
+++ b/libindy/src/commands/ledger.rs
@@ -509,8 +509,8 @@ impl LedgerCommandExecutor {
         debug!("build_nym_request >>> submitter_did: {:?}, target_did: {:?}, verkey: {:?}, alias: {:?}, role: {:?}",
                submitter_did, target_did, verkey, alias, role);
 
-        self.crypto_service.validate_did(submitter_did)?;
-        self.crypto_service.validate_did(target_did)?;
+        CryptoService::validate_did(submitter_did)?;
+        CryptoService::validate_did(target_did)?;
         if let Some(vk) = verkey {
             self.crypto_service.validate_key(vk)?;
         }
@@ -535,8 +535,8 @@ impl LedgerCommandExecutor {
         debug!("build_attrib_request >>> submitter_did: {:?}, target_did: {:?}, hash: {:?}, raw: {:?}, enc: {:?}",
                submitter_did, target_did, hash, raw, enc);
 
-        self.crypto_service.validate_did(submitter_did)?;
-        self.crypto_service.validate_did(target_did)?;
+        CryptoService::validate_did(submitter_did)?;
+        CryptoService::validate_did(target_did)?;
 
         let res = self.ledger_service.build_attrib_request(submitter_did,
                                                            target_did,
@@ -558,8 +558,8 @@ impl LedgerCommandExecutor {
         debug!("build_get_attrib_request >>> submitter_did: {:?}, target_did: {:?}, raw: {:?}, hash: {:?}, enc: {:?}",
                submitter_did, target_did, raw, hash, enc);
 
-        self.crypto_service.validate_did(submitter_did)?;
-        self.crypto_service.validate_did(target_did)?;
+        CryptoService::validate_did(submitter_did)?;
+        CryptoService::validate_did(target_did)?;
 
         let res = self.ledger_service.build_get_attrib_request(submitter_did,
                                                                target_did,
@@ -577,8 +577,8 @@ impl LedgerCommandExecutor {
                              target_did: &str) -> Result<String, IndyError> {
         debug!("build_get_nym_request >>> submitter_did: {:?}, target_did: {:?}", submitter_did, target_did);
 
-        self.crypto_service.validate_did(submitter_did)?;
-        self.crypto_service.validate_did(target_did)?;
+        CryptoService::validate_did(submitter_did)?;
+        CryptoService::validate_did(target_did)?;
 
         let res = self.ledger_service.build_get_nym_request(submitter_did,
                                                             target_did)?;
@@ -593,7 +593,7 @@ impl LedgerCommandExecutor {
                             schema: SchemaV1) -> Result<String, IndyError> {
         debug!("build_schema_request >>> submitter_did: {:?}, schema: {:?}", submitter_did, schema);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_schema_request(submitter_did, schema)?;
 
@@ -607,7 +607,7 @@ impl LedgerCommandExecutor {
                                 id: &str) -> Result<String, IndyError> {
         debug!("build_get_schema_request >>> submitter_did: {:?}, id: {:?}", submitter_did, id);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_get_schema_request(submitter_did, id)?;
 
@@ -633,7 +633,7 @@ impl LedgerCommandExecutor {
         debug!("build_cred_def_request >>> submitter_did: {:?}, cred_def: {:?}",
                submitter_did, cred_def);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_cred_def_request(submitter_did, cred_def)?;
 
@@ -647,7 +647,7 @@ impl LedgerCommandExecutor {
                                   id: &str) -> Result<String, IndyError> {
         debug!("build_get_cred_def_request >>> submitter_did: {:?}, id: {:?}", submitter_did, id);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_get_cred_def_request(submitter_did, id)?;
 
@@ -674,7 +674,7 @@ impl LedgerCommandExecutor {
         debug!("build_node_request >>> submitter_did: {:?}, target_did: {:?}, data: {:?}",
                submitter_did, target_did, data);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_node_request(submitter_did, target_did, data)?;
 
@@ -687,7 +687,7 @@ impl LedgerCommandExecutor {
                                         submitter_did: &str) -> Result<String, IndyError> {
         info!("build_get_validator_info_request >>> submitter_did: {:?}", submitter_did);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_get_validator_info_request(submitter_did)?;
 
@@ -703,7 +703,7 @@ impl LedgerCommandExecutor {
         debug!("build_get_txn_request >>> submitter_did: {:?}, ledger_type: {:?}, seq_no: {:?}",
                submitter_did, ledger_type, seq_no);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_get_txn_request(submitter_did, ledger_type, seq_no)?;
 
@@ -719,7 +719,7 @@ impl LedgerCommandExecutor {
         debug!("build_pool_config_request >>> submitter_did: {:?}, writes: {:?}, force: {:?}",
                submitter_did, writes, force);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_pool_config(submitter_did, writes, force)?;
 
@@ -732,7 +732,7 @@ impl LedgerCommandExecutor {
                                   datetime: Option<&str>) -> Result<String, IndyError> {
         debug!("build_pool_restart_request >>> submitter_did: {:?}, action: {:?}, datetime: {:?}", submitter_did, action, datetime);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_pool_restart(submitter_did, action, datetime)?;
 
@@ -757,7 +757,7 @@ impl LedgerCommandExecutor {
          timeout: {:?}, schedule: {:?}, justification: {:?}, reinstall: {:?}, force: {:?}, package: {:?}",
                submitter_did, name, version, action, sha256, timeout, schedule, justification, reinstall, force, package);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_pool_upgrade(submitter_did, name, version, action, sha256,
                                                          timeout, schedule, justification, reinstall, force, package)?;
@@ -772,7 +772,7 @@ impl LedgerCommandExecutor {
                                    data: RevocationRegistryDefinitionV1) -> Result<String, IndyError> {
         debug!("build_revoc_reg_def_request >>> submitter_did: {:?}, data: {:?}", submitter_did, data);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_revoc_reg_def_request(submitter_did, data)?;
 
@@ -786,7 +786,7 @@ impl LedgerCommandExecutor {
                                        id: &str) -> Result<String, IndyError> {
         debug!("build_get_revoc_reg_def_request >>> submitter_did: {:?}, id: {:?}", submitter_did, id);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_get_revoc_reg_def_request(submitter_did, id)?;
 
@@ -814,7 +814,7 @@ impl LedgerCommandExecutor {
         debug!("build_revoc_reg_entry_request >>> submitter_did: {:?}, revoc_reg_def_id: {:?}, revoc_def_type: {:?}, value: {:?}",
                submitter_did, revoc_reg_def_id, revoc_def_type, value);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_revoc_reg_entry_request(submitter_did, revoc_reg_def_id, revoc_def_type, value)?;
 
@@ -829,7 +829,7 @@ impl LedgerCommandExecutor {
                                    timestamp: i64) -> Result<String, IndyError> {
         debug!("build_get_revoc_reg_request >>> submitter_did: {:?}, revoc_reg_def_id: {:?}, timestamp: {:?}", submitter_did, revoc_reg_def_id, timestamp);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_get_revoc_reg_request(submitter_did, revoc_reg_def_id, timestamp)?;
 
@@ -856,7 +856,7 @@ impl LedgerCommandExecutor {
                                          to: i64) -> Result<String, IndyError> {
         debug!("build_get_revoc_reg_delta_request >>> submitter_did: {:?}, revoc_reg_def_id: {:?}, from: {:?}, to: {:?}", submitter_did, revoc_reg_def_id, from, to);
 
-        self.crypto_service.validate_did(submitter_did)?;
+        CryptoService::validate_did(submitter_did)?;
 
         let res = self.ledger_service.build_get_revoc_reg_delta_request(submitter_did, revoc_reg_def_id, from, to)?;
 

--- a/libindy/src/commands/mod.rs
+++ b/libindy/src/commands/mod.rs
@@ -81,7 +81,7 @@ impl CommandExecutor {
                 let pool_service = Rc::new(PoolService::new());
                 let wallet_service = Rc::new(WalletService::new());
 
-                let anoncreds_command_executor = AnoncredsCommandExecutor::new(anoncreds_service.clone(), blob_storage_service.clone(), pool_service.clone(), wallet_service.clone(), crypto_service.clone());
+                let anoncreds_command_executor = AnoncredsCommandExecutor::new(anoncreds_service.clone(), blob_storage_service.clone(), pool_service.clone(), wallet_service.clone());
                 let crypto_command_executor = CryptoCommandExecutor::new(wallet_service.clone(), crypto_service.clone());
                 let ledger_command_executor = LedgerCommandExecutor::new(pool_service.clone(), crypto_service.clone(), wallet_service.clone(), ledger_service.clone());
                 let pool_command_executor = PoolCommandExecutor::new(pool_service.clone());
@@ -90,7 +90,7 @@ impl CommandExecutor {
                 let pairwise_command_executor = PairwiseCommandExecutor::new(wallet_service.clone());
                 let blob_storage_command_executor = BlobStorageCommandExecutor::new(blob_storage_service.clone());
                 let non_secret_command_executor = NonSecretsCommandExecutor::new(wallet_service.clone());
-                let payments_command_executor = PaymentsCommandExecutor::new(payments_service.clone(), wallet_service.clone(), crypto_service.clone());
+                let payments_command_executor = PaymentsCommandExecutor::new(payments_service.clone(), wallet_service.clone());
 
                 loop {
                     match receiver.recv() {

--- a/libindy/src/commands/payments.rs
+++ b/libindy/src/commands/payments.rs
@@ -134,16 +134,14 @@ pub enum PaymentsCommand {
 pub struct PaymentsCommandExecutor {
     payments_service: Rc<PaymentsService>,
     wallet_service: Rc<WalletService>,
-    crypto_service: Rc<CryptoService>,
     pending_callbacks: RefCell<HashMap<i32, Box<Fn(Result<String, IndyError>) + Send>>>,
 }
 
 impl PaymentsCommandExecutor {
-    pub fn new(payments_service: Rc<PaymentsService>, wallet_service: Rc<WalletService>, crypto_service: Rc<CryptoService>) -> PaymentsCommandExecutor {
+    pub fn new(payments_service: Rc<PaymentsService>, wallet_service: Rc<WalletService>) -> PaymentsCommandExecutor {
         PaymentsCommandExecutor {
             payments_service,
             wallet_service,
-            crypto_service,
             pending_callbacks: RefCell::new(HashMap::new()),
         }
     }
@@ -335,7 +333,7 @@ impl PaymentsCommandExecutor {
     fn add_request_fees(&self, wallet_handle: i32, submitter_did: &str, req: &str, inputs: &str, outputs: &str, extra: Option<&str>, cb: Box<Fn(Result<(String, String), IndyError>) + Send>) {
         trace!("add_request_fees >>> wallet_handle: {:?}, submitter_did: {:?}, req: {:?}, inputs: {:?}, outputs: {:?}, extra: {:?}",
                wallet_handle, submitter_did, req, inputs, outputs, extra);
-        match self.crypto_service.validate_did(submitter_did).map_err(map_err_err!()) {
+        match CryptoService::validate_did(submitter_did).map_err(map_err_err!()) {
             Err(err) => return cb(Err(IndyError::from(err))),
             _ => ()
         }
@@ -388,7 +386,7 @@ impl PaymentsCommandExecutor {
 
     fn build_get_payment_sources_request(&self, wallet_handle: i32, submitter_did: &str, payment_address: &str, cb: Box<Fn(Result<(String, String), IndyError>) + Send>) {
         trace!("build_get_payment_sources_request >>> wallet_handle: {:?}, submitter_did: {:?}, payment_address: {:?}", wallet_handle, submitter_did, payment_address);
-        match self.crypto_service.validate_did(submitter_did).map_err(map_err_err!()) {
+        match CryptoService::validate_did(submitter_did).map_err(map_err_err!()) {
             Err(err) => return cb(Err(IndyError::from(err))),
             _ => ()
         }
@@ -433,7 +431,7 @@ impl PaymentsCommandExecutor {
 
     fn build_payment_req(&self, wallet_handle: i32, submitter_did: &str, inputs: &str, outputs: &str, extra: Option<&str>, cb: Box<Fn(Result<(String, String), IndyError>) + Send>) {
         trace!("build_payment_req >>> wallet_handle: {:?}, submitter_did: {:?}, inputs: {:?}, outputs: {:?}, extra: {:?}", wallet_handle, submitter_did, inputs, outputs, extra);
-        match self.crypto_service.validate_did(submitter_did).map_err(map_err_err!()) {
+        match CryptoService::validate_did(submitter_did).map_err(map_err_err!()) {
             Err(err) => return cb(Err(IndyError::from(err))),
             _ => ()
         }
@@ -482,7 +480,7 @@ impl PaymentsCommandExecutor {
 
     fn build_mint_req(&self, wallet_handle: i32, submitter_did: &str, outputs: &str, extra: Option<&str>, cb: Box<Fn(Result<(String, String), IndyError>) + Send>) {
         trace!("build_mint_req >>> wallet_handle: {:?}, submitter_did: {:?}, outputs: {:?}, extra: {:?}", wallet_handle, submitter_did, outputs, extra);
-        match self.crypto_service.validate_did(submitter_did).map_err(map_err_err!()) {
+        match CryptoService::validate_did(submitter_did).map_err(map_err_err!()) {
             Err(err) => return cb(Err(IndyError::from(err))),
             _ => ()
         }
@@ -514,7 +512,7 @@ impl PaymentsCommandExecutor {
 
     fn build_set_txn_fees_req(&self, wallet_handle: i32, submitter_did: &str, type_: &str, fees: &str, cb: Box<Fn(Result<String, IndyError>) + Send>) {
         trace!("build_set_txn_fees_req >>> wallet_handle: {:?}, submitter_did: {:?}, type_: {:?}, fees: {:?}", wallet_handle, submitter_did, type_, fees);
-        match self.crypto_service.validate_did(submitter_did).map_err(map_err_err!()) {
+        match CryptoService::validate_did(submitter_did).map_err(map_err_err!()) {
             Err(err) => return cb(Err(IndyError::from(err))),
             _ => ()
         }
@@ -541,7 +539,7 @@ impl PaymentsCommandExecutor {
 
     fn build_get_txn_fees_req(&self, wallet_handle: i32, submitter_did: &str, type_: &str, cb: Box<Fn(Result<String, IndyError>) + Send>) {
         trace!("build_get_txn_fees_req >>> wallet_handle: {:?}, submitter_did: {:?}, type_: {:?}", wallet_handle, submitter_did, type_);
-        match self.crypto_service.validate_did(submitter_did).map_err(map_err_err!()) {
+        match CryptoService::validate_did(submitter_did).map_err(map_err_err!()) {
             Err(err) => return cb(Err(IndyError::from(err))),
             _ => ()
         }
@@ -574,7 +572,7 @@ impl PaymentsCommandExecutor {
 
     fn build_verify_payment_request(&self, wallet_handle: i32, submitter_did: &str, receipt: &str, cb: Box<Fn(Result<(String, String), IndyError>) + Send>) {
         trace!("build_verify_payment_request >>> wallet_handle: {:?}, submitter_did: {:?}, receipt: {:?}", wallet_handle, submitter_did, receipt);
-        match self.crypto_service.validate_did(submitter_did).map_err(map_err_err!()) {
+        match CryptoService::validate_did(submitter_did).map_err(map_err_err!()) {
             Err(err) => return cb(Err(IndyError::from(err))),
             _ => ()
         }

--- a/libindy/src/services/crypto/mod.rs
+++ b/libindy/src/services/crypto/mod.rs
@@ -97,7 +97,7 @@ impl CryptoService {
         let (vk, sk) = crypto_type.create_key(seed.as_ref())?;
         let did = match my_did_info.did {
             Some(ref did) => {
-                self.validate_did(did)?;
+                CryptoService::validate_did(did)?;
                 base58::decode(did)?
             }
             _ if my_did_info.cid == Some(true) => vk[..].to_vec(),
@@ -394,7 +394,7 @@ impl CryptoService {
         Ok(())
     }
 
-    pub fn validate_did(&self, did: &str) -> Result<(), CryptoError> {
+    pub fn validate_did(did: &str) -> Result<(), CryptoError> {
         trace!("validate_did >>> did: {:?}", did);
 
         let did = base58::decode(did)?;


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

By turning validate_did into a static method the crypto_services variable is not needed any more and are deleted by this PR where possible.