### PR TITLE
Prevent GC from collecting native method pointers. Updated missing APIs

### DIFF
--- a/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/AnonCreds.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/AnonCreds.cs
@@ -1,6 +1,7 @@
 ﻿using Hyperledger.Indy.BlobStorageApi;
 using Hyperledger.Indy.Utils;
 using Hyperledger.Indy.WalletApi;
+using System;
 using System.Threading.Tasks;
 using static Hyperledger.Indy.AnonCredsApi.NativeMethods;
 #if __IOS__
@@ -20,7 +21,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(IssuerCreateSchemaCompletedDelegate))]
 #endif
-        private static void IssuerCreateSchemaCallback(int xcommand_handle, int err, string schema_id, string schema_json)
+        private static void IssuerCreateSchemaCallbackMethod(int xcommand_handle, int err, string schema_id, string schema_json)
         {
             var taskCompletionSource = PendingCommands.Remove<IssuerCreateSchemaResult>(xcommand_handle);
 
@@ -29,6 +30,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(new IssuerCreateSchemaResult(schema_id, schema_json));
         }
+        private static IssuerCreateSchemaCompletedDelegate IssuerCreateSchemaCallback = IssuerCreateSchemaCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the IssuerCreateAndStoreClaimDefAsync command completes.
@@ -36,7 +38,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(IssuerCreateAndStoreCredentialDefCompletedDelegate))]
 #endif
-        private static void IssuerCreateAndStoreClaimDefCallback(int xcommand_handle, int err, string claim_def_id, string claim_def_json)
+        private static void IssuerCreateAndStoreClaimDefCallbackMethod(int xcommand_handle, int err, string claim_def_id, string claim_def_json)
         {
             var taskCompletionSource = PendingCommands.Remove<IssuerCreateAndStoreCredentialDefResult>(xcommand_handle);
 
@@ -45,6 +47,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(new IssuerCreateAndStoreCredentialDefResult(claim_def_id, claim_def_json));
         }
+        private static IssuerCreateAndStoreCredentialDefCompletedDelegate IssuerCreateAndStoreClaimDefCallback = IssuerCreateAndStoreClaimDefCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the IssuerCreateAndStoreClaimRevocRegAsync command completes.
@@ -52,7 +55,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(IssuerCreateAndStoreRevocRegCompletedDelegate))]
 #endif
-        private static void IssuerCreateAndStoreClaimRevocRegCallback(int xcommand_handle, int err, string revoc_reg_id, string revoc_reg_def_json, string revoc_reg_entry_json)
+        private static void IssuerCreateAndStoreClaimRevocRegCallbackMethod(int xcommand_handle, int err, string revoc_reg_id, string revoc_reg_def_json, string revoc_reg_entry_json)
         {
             var taskCompletionSource = PendingCommands.Remove<IssuerCreateAndStoreRevocRegResult>(xcommand_handle);
 
@@ -61,6 +64,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(new IssuerCreateAndStoreRevocRegResult(revoc_reg_id, revoc_reg_def_json, revoc_reg_entry_json));
         }
+        private static IssuerCreateAndStoreRevocRegCompletedDelegate IssuerCreateAndStoreClaimRevocRegCallback = IssuerCreateAndStoreClaimRevocRegCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the IssuerCreateClaimAsync command completes.
@@ -68,7 +72,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(IssuerCreateCredentialOfferCompletedDelegate))]
 #endif
-        private static void IssuerCreateCredentialOfferCallback(int xcommand_handle, int err, string cred_offer_json)
+        private static void IssuerCreateCredentialOfferCallbackMethod(int xcommand_handle, int err, string cred_offer_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -77,6 +81,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(cred_offer_json);
         }
+        private static IssuerCreateCredentialOfferCompletedDelegate IssuerCreateCredentialOfferCallback = IssuerCreateCredentialOfferCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the IssuerCreateClaimAsync command completes.
@@ -84,7 +89,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(IssuerCreateCredentialCompletedDelegate))]
 #endif
-        private static void IssuerCreateCredentialCallback(int xcommand_handle, int err, string cred_json, string cred_revoc_id, string revoc_reg_delta_json)
+        private static void IssuerCreateCredentialCallbackMethod(int xcommand_handle, int err, string cred_json, string cred_revoc_id, string revoc_reg_delta_json)
         {
             var taskCompletionSource = PendingCommands.Remove<IssuerCreateCredentialResult>(xcommand_handle);
 
@@ -95,6 +100,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(callbackResult);
         }
+        private static IssuerCreateCredentialCompletedDelegate IssuerCreateCredentialCallback = IssuerCreateCredentialCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the IssuerRevokeCredentialAsync command completes.
@@ -102,7 +108,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(IssuerRevokeCredentialCompletedDelegate))]
 #endif
-        private static void IssuerRevokeCredentialCallback(int xcommand_handle, int err, string revoc_reg_delta_json)
+        private static void IssuerRevokeCredentialCallbackMethod(int xcommand_handle, int err, string revoc_reg_delta_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -111,6 +117,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(revoc_reg_delta_json);
         }
+        private static IssuerRevokeCredentialCompletedDelegate IssuerRevokeCredentialCallback = IssuerRevokeCredentialCallbackMethod;
 
         /// <summary>
         /// The issuer merge revocation registry deltas callback.
@@ -134,7 +141,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ProverCreateMasterSecretCompletedDelegate))]
 #endif
-        private static void ProverCreateMasterSecretCallback(int xcommand_handle, int err, string out_master_secret_id)
+        private static void ProverCreateMasterSecretCallbackMethod(int xcommand_handle, int err, string out_master_secret_id)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -143,6 +150,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(out_master_secret_id);
         }
+        private static ProverCreateMasterSecretCompletedDelegate ProverCreateMasterSecretCallback = ProverCreateMasterSecretCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the roverCreateAndStoreClaimReqAsync command completes.
@@ -150,7 +158,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ProverCreateCredentialReqCompletedDelegate))]
 #endif
-        private static void ProverCreateCredentialReqCallback(int xcommand_handle, int err, string cred_req_json, string cred_req_metadata_json)
+        private static void ProverCreateCredentialReqCallbackMethod(int xcommand_handle, int err, string cred_req_json, string cred_req_metadata_json)
         {
             var taskCompletionSource = PendingCommands.Remove<ProverCreateCredentialRequestResult>(xcommand_handle);
 
@@ -159,6 +167,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(new ProverCreateCredentialRequestResult(cred_req_json, cred_req_metadata_json));
         }
+        private static ProverCreateCredentialReqCompletedDelegate ProverCreateCredentialReqCallback = ProverCreateCredentialReqCallbackMethod;
 
         /// <summary>
         /// The prover store credential callback.
@@ -166,7 +175,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ProverStoreCredentialCompletedDelegate))]
 #endif
-        private static void ProverStoreCredentialCallback(int xcommand_handle, int err, string out_cred_id)
+        private static void ProverStoreCredentialCallbackMethod(int xcommand_handle, int err, string out_cred_id)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -175,6 +184,25 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(out_cred_id);
         }
+        private static ProverStoreCredentialCompletedDelegate ProverStoreCredentialCallback = ProverStoreCredentialCallbackMethod;
+
+        /// <summary>
+        /// Gets the callback to use when the ProverGetClaimsAsync command completes.
+        /// </summary>
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverGetCredentialCompletedDelegate))]
+#endif
+        private static void ProverGetCredentialCallbackMethod(int xcommand_handle, int err, string credentials_json)
+        {
+            var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
+
+            if (!CallbackHelper.CheckCallback(taskCompletionSource, err))
+                return;
+
+            taskCompletionSource.SetResult(credentials_json);
+        }
+        private static ProverGetCredentialCompletedDelegate ProverGetCredentialCallback = ProverGetCredentialCallbackMethod;
+
 
         /// <summary>
         /// Gets the callback to use when the ProverGetClaimsAsync command completes.
@@ -182,7 +210,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ProverGetCredentialsCompletedDelegate))]
 #endif
-        private static void ProverGetCredentialsCallback(int xcommand_handle, int err, string matched_credentials_json)
+        private static void ProverGetCredentialsCallbackMethod(int xcommand_handle, int err, string matched_credentials_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -191,6 +219,65 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(matched_credentials_json);
         }
+        private static ProverGetCredentialsCompletedDelegate ProverGetCredentialsCallback = ProverGetCredentialsCallbackMethod;
+
+
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverSearchCredentialsCompletedDelegate))]
+#endif
+        private static void ProverSearchCredentialsCallbackMethod(int xcommand_handle, int err, IntPtr search_handle, int total_count)
+        {
+            var taskCompletionSource = PendingCommands.Remove<CredentialSearch>(xcommand_handle);
+
+            if (!CallbackHelper.CheckCallback(taskCompletionSource, err))
+                return;
+
+            taskCompletionSource.SetResult(new CredentialSearch(search_handle, total_count, false));
+        }
+        private static ProverSearchCredentialsCompletedDelegate ProverSearchCredentialsCallback = ProverSearchCredentialsCallbackMethod;
+
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverFetchCredentialsCompletedDelegate))]
+#endif
+        private static void ProverFetchCredentialsCallbackMethod(int xcommand_handle, int err, string credentials_json)
+        {
+            var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
+
+            if (!CallbackHelper.CheckCallback(taskCompletionSource, err))
+                return;
+
+            taskCompletionSource.SetResult(credentials_json);
+        }
+        private static ProverFetchCredentialsCompletedDelegate ProverFetchCredentialsCallback = ProverFetchCredentialsCallbackMethod;
+
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverSearchCredentialsForProofReqCompletedDelegate))]
+#endif
+        private static void ProverSearchCredentialsForProofRequestCallbackMethod(int xcommand_handle, int err, IntPtr search_handle)
+        {
+            var taskCompletionSource = PendingCommands.Remove<CredentialSearch>(xcommand_handle);
+
+            if (!CallbackHelper.CheckCallback(taskCompletionSource, err))
+                return;
+
+            taskCompletionSource.SetResult(new CredentialSearch(search_handle, null, false));
+        }
+        private static ProverSearchCredentialsForProofReqCompletedDelegate ProverSearchCredentialsForProofRequestCallback = ProverSearchCredentialsForProofRequestCallbackMethod;
+
+#if __IOS__
+        [MonoPInvokeCallback(typeof(ProverFetchCredentialsForProofReqCompletedDelegate))]
+#endif
+        private static void ProverFetchCredentialsForProofRequestCallbackMethod(int xcommand_handle, int err, string credentials_json)
+        {
+            var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
+
+            if (!CallbackHelper.CheckCallback(taskCompletionSource, err))
+                return;
+
+            taskCompletionSource.SetResult(credentials_json);
+        }
+        private static ProverFetchCredentialsForProofReqCompletedDelegate ProverFetchCredentialsForProofRequestCallback = ProverFetchCredentialsForProofRequestCallbackMethod;
+
 
         /// <summary>
         /// Gets the callback to use when the ProverGetClaimsForProofAsync command completes.
@@ -198,7 +285,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ProverGetCredentialsForProofCompletedDelegate))]
 #endif
-        private static void ProverGetClaimsForProofCallback(int xcommand_handle, int err, string claims_json)
+        private static void ProverGetClaimsForProofCallbackMethod(int xcommand_handle, int err, string claims_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -207,6 +294,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(claims_json);
         }
+        private static ProverGetCredentialsForProofCompletedDelegate ProverGetClaimsForProofCallback = ProverGetClaimsForProofCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the ProverCreateProofAsync command completes.
@@ -214,7 +302,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ProverCreateProofCompletedDelegate))]
 #endif
-        private static void ProverCreateProofCallback(int xcommand_handle, int err, string proof_json)
+        private static void ProverCreateProofCallbackMethod(int xcommand_handle, int err, string proof_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -223,6 +311,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(proof_json);
         }
+        private static ProverCreateProofCompletedDelegate ProverCreateProofCallback = ProverCreateProofCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the VerifierVerifyProofAsync command completes.
@@ -230,7 +319,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(VerifierVerifyProofCompletedDelegate))]
 #endif
-        private static void VerifierVerifyProofCallback(int xcommand_handle, int err, bool valid)
+        private static void VerifierVerifyProofCallbackMethod(int xcommand_handle, int err, bool valid)
         {
             var taskCompletionSource = PendingCommands.Remove<bool>(xcommand_handle);
 
@@ -239,6 +328,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(valid);
         }
+        private static VerifierVerifyProofCompletedDelegate VerifierVerifyProofCallback = VerifierVerifyProofCallbackMethod;
 
         /// <summary>
         /// The create revocation state callback.
@@ -246,7 +336,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(CreateRevocationStateCompletedDelegate))]
 #endif
-        private static void CreateRevocationStateCallback(int xcommand_handle, int err, string rev_state_json)
+        private static void CreateRevocationStateCallbackMethod(int xcommand_handle, int err, string rev_state_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -255,6 +345,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(rev_state_json);
         }
+        private static CreateRevocationStateCompletedDelegate CreateRevocationStateCallback = CreateRevocationStateCallbackMethod;
 
         /// <summary>
         /// The update revocation state callback.
@@ -262,7 +353,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(UpdateRevocationStateCompletedDelegate))]
 #endif
-        private static void UpdateRevocationStateCallback(int xcommand_handle, int err, string updated_rev_state_json)
+        private static void UpdateRevocationStateCallbackMethod(int xcommand_handle, int err, string updated_rev_state_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -271,6 +362,7 @@ namespace Hyperledger.Indy.AnonCredsApi
 
             taskCompletionSource.SetResult(updated_rev_state_json);
         }
+        private static UpdateRevocationStateCompletedDelegate UpdateRevocationStateCallback = UpdateRevocationStateCallbackMethod;
 
         /// <summary>
         /// Create credential schema entity that describes credential attributes list and allows credentials
@@ -711,6 +803,39 @@ namespace Hyperledger.Indy.AnonCredsApi
         }
 
         /// <summary>
+        /// Gets human readable credential by the given id.
+        /// </summary>
+        /// <returns>credential json:
+        ///     {
+        ///         "referent": string, // cred_id in the wallet
+        ///         "attrs": {"key1":"raw_value1", "key2":"raw_value2"},
+        ///         "schema_id": string,
+        ///         "cred_def_id": string,
+        ///         "rev_reg_id": Optional&lt;string>,
+        ///         "cred_rev_id": Optional&lt;string>
+        ///     }</returns>
+        /// <param name="wallet">Wallet.</param>
+        /// <param name="credentialId">Identifier by which requested credential is stored in the wallet.</param>
+        public static Task<string> ProverGetCredentialAsync(Wallet wallet, string credentialId)
+        {
+            ParamGuard.NotNull(wallet, "wallet");
+            ParamGuard.NotNullOrWhiteSpace(credentialId, "credentialId");
+
+            var taskCompletionSource = new TaskCompletionSource<string>();
+            var commandHandle = PendingCommands.Add(taskCompletionSource);
+
+            var commandResult = NativeMethods.indy_prover_get_credential(
+                commandHandle,
+                wallet.Handle,
+                credentialId,
+                ProverGetCredentialCallback);
+
+            CallbackHelper.CheckResult(commandResult);
+
+            return taskCompletionSource.Task;
+        }
+
+        /// <summary>
         /// Gets human readable credentials according to the filter.
         /// If filter is NULL, then all credentials are returned.
         /// Credentials can be filtered by Issuer, credential_def and/or Schema.
@@ -734,6 +859,7 @@ namespace Hyperledger.Indy.AnonCredsApi
         ///            "issuer_did": string, (Optional)
         ///            "cred_def_id": string, (Optional)
         ///        }</param>
+        [Obsolete("This method is obsolete since 1.6.1. Please use ProverSearchCredentialsAsync")]
         public static Task<string> ProverGetCredentialsAsync(Wallet wallet, string filterJson)
         {
             ParamGuard.NotNull(wallet, "wallet");
@@ -747,6 +873,100 @@ namespace Hyperledger.Indy.AnonCredsApi
                 wallet.Handle,
                 filterJson,
                 ProverGetCredentialsCallback
+                );
+
+            CallbackHelper.CheckResult(commandResult);
+
+            return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Search for credentials stored in wallet.
+        /// Credentials can be filtered by tags created during saving of credential.
+        ///
+        /// Instead of immediately returning of fetched credentials
+        /// this call returns search_handle that can be used later
+        /// to fetch records by small batches (with indy_prover_fetch_credentials).
+        /// </summary>
+        /// <returns>The search credentials async.</returns>
+        /// <param name="wallet">Wallet.</param>
+        /// <param name="queryJson">Wql query filter for credentials searching based on tags.
+        /// where query: indy-sdk/doc/design/011-wallet-query-language/README.md
+        /// </param>
+        public static Task<CredentialSearch> ProverSearchCredentialsAsync(Wallet wallet, string queryJson)
+        {
+            ParamGuard.NotNull(wallet, "wallet");
+            ParamGuard.NotNullOrWhiteSpace(queryJson, "queryJson");
+
+            var taskCompletionSource = new TaskCompletionSource<CredentialSearch>();
+            var commandHandle = PendingCommands.Add(taskCompletionSource);
+
+            var commandResult = NativeMethods.indy_prover_search_credentials(
+                commandHandle,
+                wallet.Handle,
+                queryJson,
+                ProverSearchCredentialsCallback
+                );
+
+            CallbackHelper.CheckResult(commandResult);
+
+            return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Fetch next credentials for search.
+        /// </summary>
+        /// <returns>
+        /// credentials_json: List of human readable credentials:
+        /// <code>
+        ///     [{
+        ///         "referent": string, // cred_id in the wallet
+        ///         "attrs": {"key1":"raw_value1", "key2":"raw_value2"},
+        ///         "schema_id": string,
+        ///         "cred_def_id": string,
+        ///         "rev_reg_id": Optional&lt;string>,
+        ///         "cred_rev_id": Optional&lt;string>
+        ///     }]
+        /// NOTE: The list of length less than the requested count means credentials search iterator is completed.
+        /// </code>
+        /// </returns>
+        /// <param name="search">Search.</param>
+        /// <param name="count">Count.</param>
+        public static Task<string> ProverFetchCredentialsAsync(CredentialSearch search, int count)
+        {
+            ParamGuard.NotNull(search, "search");
+
+            var taskCompletionSource = new TaskCompletionSource<string>();
+            var commandHandle = PendingCommands.Add(taskCompletionSource);
+
+            var commandResult = NativeMethods.indy_prover_fetch_credentials(
+                commandHandle,
+                search.Handle,
+                count,
+                ProverFetchCredentialsCallback
+                );
+
+            CallbackHelper.CheckResult(commandResult);
+
+            return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Close credentials search (make search handle invalid)
+        /// </summary>
+        /// <returns>The close credentials search async.</returns>
+        /// <param name="search">Search.</param>
+        public static Task ProverCloseCredentialsSearchAsync(CredentialSearch search)
+        {
+            ParamGuard.NotNull(search, "search");
+
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+            var commandHandle = PendingCommands.Add(taskCompletionSource);
+
+            var commandResult = NativeMethods.indy_prover_close_credentials_search(
+                commandHandle,
+                search.Handle,
+                CallbackHelper.TaskCompletingNoValueCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);
@@ -830,6 +1050,7 @@ namespace Hyperledger.Indy.AnonCredsApi
         ///     }
         /// filter: see filter_json above
         /// </param>
+        [Obsolete("This methos is obsolete since 1.6.1. Please use ProverSearchCredentialsForProofRequestAsync.")]
         public static Task<string> ProverGetCredentialsForProofReqAsync(Wallet wallet, string proofRequestJson)
         {
             ParamGuard.NotNull(wallet, "wallet");
@@ -843,6 +1064,137 @@ namespace Hyperledger.Indy.AnonCredsApi
                 wallet.Handle,
                 proofRequestJson,
                 ProverGetClaimsForProofCallback
+                );
+
+            CallbackHelper.CheckResult(commandResult);
+
+            return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Search for credentials matching the given proof request.
+        ///
+        /// Instead of immediately returning of fetched credentials
+        /// this call returns search_handle that can be used later
+        /// to fetch records by small batches (with indy_prover_fetch_credentials_for_proof_req).
+        /// </summary>
+        /// <returns><see cref="CredentialSearch"/> that can be used later to fetch records by small batches (with <see cref="ProverFetchCredentialsForProofRequestCallback"/>).</returns>
+        /// <param name="wallet">Wallet.</param>
+        /// <param name="proofRequestJson">
+        /// proof request json
+        ///     {
+        ///         "name": string,
+        ///         "version": string,
+        ///         "nonce": string,
+        ///         "requested_attributes": { // set of requested attributes
+        ///              "&lt;attr_referent>": &lt;attr_info>, // see below
+        ///              ...,
+        ///         },
+        ///         "requested_predicates": { // set of requested predicates
+        ///              "&lt;predicate_referent>": &lt;predicate_info>, // see below
+        ///              ...,
+        ///          },
+        ///         "non_revoked": Optional&lt;&lt;non_revoc_interval>>, // see below,
+        ///                        // If specified prover must proof non-revocation
+        ///                        // for date in this interval for each attribute
+        ///                        // (can be overridden on attribute level)
+        ///     }.
+        /// </param>
+        /// <param name="extraQueryJson">extra_query_json:(Optional) List of extra queries that will be applied to correspondent attribute/predicate:
+        ///     {
+        ///         "&lt;attr_referent>": &lt;wql query>,
+        ///         "&lt;predicate_referent>": &lt;wql query>,
+        ///     }
+        /// where wql query: indy-sdk/doc/design/011-wallet-query-language/README.md.</param>
+        public static Task<CredentialSearch> ProverSearchCredentialsForProofRequestAsync(Wallet wallet, string proofRequestJson, string extraQueryJson = "{}")
+        {
+            ParamGuard.NotNull(wallet, "wallet");
+            ParamGuard.NotNullOrWhiteSpace(proofRequestJson, "proofRequestJson");
+
+            var taskCompletionSource = new TaskCompletionSource<CredentialSearch>();
+            var commandHandle = PendingCommands.Add(taskCompletionSource);
+
+            var commandResult = NativeMethods.indy_prover_search_credentials_for_proof_req(
+                commandHandle,
+                wallet.Handle,
+                proofRequestJson,
+                extraQueryJson,
+                ProverSearchCredentialsForProofRequestCallback
+                );
+
+            CallbackHelper.CheckResult(commandResult);
+
+            return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Fetch next credentials for the requested item using proof request search
+        /// handle (created by indy_prover_search_credentials_for_proof_req).
+        /// </summary>
+        /// <returns>
+        /// credentials_json: List of credentials for the given proof request.
+        ///     [{
+        ///         cred_info: &lt;credential_info>,
+        ///         interval: Optional&lt;non_revoc_interval>
+        ///     }]
+        /// where
+        /// credential_info:
+        ///     {
+        ///         "referent": &lt;string>,
+        ///         "attrs": {"attr_name" : "attr_raw_value"},
+        ///         "schema_id": string,
+        ///         "cred_def_id": string,
+        ///         "rev_reg_id": Optional&lt;int>,
+        ///         "cred_rev_id": Optional&lt;int>,
+        ///     }
+        /// non_revoc_interval:
+        ///     {
+        ///         "from": Optional&lt;int>, // timestamp of interval beginning
+        ///         "to": Optional&lt;int>, // timestamp of interval ending
+        ///     }
+        /// NOTE: The list of length less than the requested count means that search iterator
+        /// correspondent to the requested &lt;item_referent> is completed.
+        /// </returns>
+        /// <param name="search">Search.</param>
+        /// <param name="itemReferent">Referent of attribute/predicate in the proof request.</param>
+        /// <param name="count">Count of credentials to fetch.</param>
+        public static Task<string> ProverFetchCredentialsForProofRequestAsync(CredentialSearch search, string itemReferent, int count)
+        {
+            ParamGuard.NotNull(search, "search");
+            ParamGuard.NotNullOrWhiteSpace(itemReferent, "itemReferent");
+
+            var taskCompletionSource = new TaskCompletionSource<string>();
+            var commandHandle = PendingCommands.Add(taskCompletionSource);
+
+            var commandResult = NativeMethods.indy_prover_fetch_credentials_for_proof_req(
+                commandHandle,
+                search.Handle,
+                itemReferent,
+                count,
+                ProverFetchCredentialsForProofRequestCallback
+                );
+
+            CallbackHelper.CheckResult(commandResult);
+
+            return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Close credentials search for proof request (make search handle invalid)
+        /// </summary>
+        /// <returns></returns>
+        /// <param name="search">Search.</param>
+        public static Task ProverCloseCredentialsSearchForProofRequestAsync(CredentialSearch search)
+        {
+            ParamGuard.NotNull(search, "search");
+
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+            var commandHandle = PendingCommands.Add(taskCompletionSource);
+
+            var commandResult = NativeMethods.indy_prover_close_credentials_search_for_proof_req(
+                commandHandle,
+                search.Handle,
+                CallbackHelper.TaskCompletingNoValueCallback
                 );
 
             CallbackHelper.CheckResult(commandResult);

--- a/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/CredentialSearch.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/CredentialSearch.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Threading.Tasks;
+using Hyperledger.Indy.Utils;
+using Hyperledger.Indy.WalletApi;
+
+namespace Hyperledger.Indy.AnonCredsApi
+{
+    /// <summary>
+    /// Represents a credential search object
+    /// </summary>
+    public class CredentialSearch : IDisposable
+    {
+        /// <summary>
+        /// Gets the handle.
+        /// </summary>
+        /// <value>The handle.</value>
+        public IntPtr Handle { get; }
+
+        /// <summary>
+        /// Gets the total count of items.
+        /// This field is <c>null</c> when search was created using <see cref="AnonCreds.ProverSearchCredentialsForProofRequestAsync(Wallet, string, string)"/>
+        /// </summary>
+        /// <value>The total count.</value>
+        public int? TotalCount { get; }
+
+        internal bool ProofRequest { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Hyperledger.Indy.AnonCredsApi.CredentialSearch"/> class.
+        /// </summary>
+        /// <param name="handle">Handle.</param>
+        /// <param name="total_count">Total count.</param>
+        /// <param name="proofRequest">If set to <c>true</c> proof request.</param>
+        internal CredentialSearch(IntPtr handle, int? total_count, bool proofRequest)
+        {
+            ProofRequest = proofRequest;
+            TotalCount = total_count;
+            Handle = handle;
+        }
+
+        /// <summary>
+        /// Fetch next credentials for search.
+        /// </summary>
+        /// <returns>The async.</returns>
+        /// <param name="count">The item count to fetch.</param>
+        /// <param name="itemReferent">Item referent (optional).
+        /// Required only when search was opened using <see cref="AnonCreds.ProverSearchCredentialsForProofRequestAsync(Wallet, string, string)"/>
+        /// </param>
+        public Task<string> NextAsync(int count, string itemReferent = null)
+        {
+            if (ProofRequest)
+            {
+                return AnonCreds.ProverFetchCredentialsForProofRequestAsync(this, itemReferent, count);
+            }
+            return AnonCreds.ProverFetchCredentialsAsync(this, count);
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        /// <summary>
+        /// Dispose the specified disposing.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> disposing.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                }
+
+                if (ProofRequest)
+                {
+                    NativeMethods.indy_prover_close_credentials_search_for_proof_req(
+                        -1,
+                        Handle,
+                        CallbackHelper.NoValueCallback);
+                }
+                else
+                {
+                    NativeMethods.indy_prover_close_credentials_search(
+                        -1,
+                        Handle,
+                        CallbackHelper.NoValueCallback);
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:Hyperledger.Indy.NonSecretsApi.WalletSearch"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~CredentialSearch()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Releases all resource used by the <see cref="T:Hyperledger.Indy.NonSecretsApi.WalletSearch"/> object.
+        /// </summary>
+        /// <remarks>Call <see cref="Dispose()"/> when you are finished using the
+        /// <see cref="T:Hyperledger.Indy.NonSecretsApi.WalletSearch"/>. The <see cref="Dispose()"/> method leaves the
+        /// <see cref="T:Hyperledger.Indy.NonSecretsApi.WalletSearch"/> in an unusable state. After calling
+        /// <see cref="Dispose()"/>, you must release all references to the
+        /// <see cref="T:Hyperledger.Indy.NonSecretsApi.WalletSearch"/> so the garbage collector can reclaim the memory
+        /// that the <see cref="T:Hyperledger.Indy.NonSecretsApi.WalletSearch"/> was occupying.</remarks>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/NativeMethods.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/AnonCredsApi/NativeMethods.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using Hyperledger.Indy.Utils;
+using static Hyperledger.Indy.Utils.CallbackHelper;
 
 namespace Hyperledger.Indy.AnonCredsApi
 {
@@ -49,14 +51,14 @@ namespace Hyperledger.Indy.AnonCredsApi
         /// <param name="issuer_did">a DID of the issuer signing claim_def transaction to the Ledger</param>
         /// <param name="schema_json">schema as a json</param>
         /// <param name="tag">Allows to distinct between credential definitions for the same issuer and schema</param>
-        /// <param name="type_">Signature type (optional). Currently only 'CL' is supported.</param>
+        /// <param name="signature_type">Signature type (optional). Currently only 'CL' is supported.</param>
         /// <param name="config_json">type-specific configuration of credential definition as json:
         /// - 'CL':
         ///   - support_revocation: whether to request non-revocation credential (optional, default false)</param>
         /// <param name="cb">The function that will be called when the asynchronous call is complete.</param>
         /// <returns>0 if the command was initiated successfully.  Any non-zero result indicates an error.</returns>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_issuer_create_and_store_credential_def(int command_handle, IntPtr wallet_handle, string issuer_did, string schema_json, string tag, string type_, string config_json, IssuerCreateAndStoreCredentialDefCompletedDelegate cb);
+        internal static extern int indy_issuer_create_and_store_credential_def(int command_handle, IntPtr wallet_handle, string issuer_did, string schema_json, string tag, string signature_type, string config_json, IssuerCreateAndStoreCredentialDefCompletedDelegate cb);
 
         /// <summary>
         /// Delegate for the function called back to by the indy_issuer_create_and_store_claim_def function.
@@ -74,18 +76,15 @@ namespace Hyperledger.Indy.AnonCredsApi
         /// <param name="command_handle">Command handle.</param>
         /// <param name="wallet_handle">Wallet handle.</param>
         /// <param name="issuer_did">Issuer did.</param>
-        /// <param name="type_">Type.</param>
+        /// <param name="revoc_def_type">Type.</param>
         /// <param name="tag">Tag.</param>
         /// <param name="cred_def_id">Cred def identifier.</param>
         /// <param name="config_json">Config json.</param>
         /// <param name="tails_writer_handle">Tails writer handle.</param>
         /// <param name="cb">Cb.</param>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_issuer_create_and_store_revoc_reg(int command_handle, IntPtr wallet_handle, string issuer_did, string type_, string tag, string cred_def_id, string config_json, int tails_writer_handle, IssuerCreateAndStoreRevocRegCompletedDelegate cb);
+        internal static extern int indy_issuer_create_and_store_revoc_reg(int command_handle, IntPtr wallet_handle, string issuer_did, string revoc_def_type, string tag, string cred_def_id, string config_json, int tails_writer_handle, IssuerCreateAndStoreRevocRegCompletedDelegate cb);
 
-        /// <summary>
-        /// Issuer create and store revoc reg completed delegate.
-        /// </summary>
         internal delegate void IssuerCreateAndStoreRevocRegCompletedDelegate(int xcommand_handle, int err, string revoc_reg_id, string revoc_reg_def_json, string revoc_reg_entry_json);
 
         /// <summary>
@@ -94,17 +93,11 @@ namespace Hyperledger.Indy.AnonCredsApi
         /// <returns>The issuer create credential offer.</returns>
         /// <param name="command_handle">Command handle.</param>
         /// <param name="wallet_handle">Wallet handle.</param>
-        /// <param name="credDefId">Cred def identifier.</param>
+        /// <param name="cred_def_id">Cred def identifier.</param>
         /// <param name="cb">Cb.</param>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_issuer_create_credential_offer(int command_handle, IntPtr wallet_handle, string credDefId, IssuerCreateCredentialOfferCompletedDelegate cb);
+        internal static extern int indy_issuer_create_credential_offer(int command_handle, IntPtr wallet_handle, string cred_def_id, IssuerCreateCredentialOfferCompletedDelegate cb);
 
-        /// <summary>
-        ///  Delegate for the function called back to by the indy_issuer_create_claim_offer function.
-        /// </summary>
-        /// <param name="xcommand_handle">The handle for the command that initiated the callback.</param>
-        /// <param name="err">The outcome of execution of the command.</param>
-        /// <param name="cred_offer_json">Claimn offer json</param>
         internal delegate void IssuerCreateCredentialOfferCompletedDelegate(int xcommand_handle, int err, string cred_offer_json);
 
         /// <summary>
@@ -122,21 +115,21 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_issuer_create_credential(int command_handle, IntPtr wallet_handle, string cred_offer_json, string cred_req_json, string cred_values_json, string rev_reg_id, int blob_storage_reader_handle, IssuerCreateCredentialCompletedDelegate cb);
 
-        /// <summary>
-        /// Issuer create credential completed delegate.
-        /// </summary>
         internal delegate void IssuerCreateCredentialCompletedDelegate(int xcommand_handle, int err, string cred_json, string cred_revoc_id, string revoc_reg_delta_json);
 
-
+        /// <summary>
+        /// Revoke a credential identified by a cred_revoc_id (returned by indy_issuer_create_credential).
+        /// </summary>
+        /// <returns>The issuer revoke credential.</returns>
+        /// <param name="command_handle">Command handle.</param>
+        /// <param name="wallet_handle">Wallet handle.</param>
+        /// <param name="blob_storage_reader_cfg_handle">BLOB storage reader cfg handle.</param>
+        /// <param name="rev_reg_id">Rev reg identifier.</param>
+        /// <param name="cred_revoc_id">Cred revoc identifier.</param>
+        /// <param name="cb">Cb.</param>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_issuer_revoke_credential(int command_handle, IntPtr wallet_handle, int blob_storage_reader_cfg_handle, string rev_reg_id, string cred_revoc_id, IssuerRevokeCredentialCompletedDelegate cb);
 
-        /// <summary>
-        /// Delegate for the function called back to by the indy_issuer_revoke_credential function.
-        /// </summary>
-        /// <param name="xcommand_handle">The handle for the command that initiated the callback.</param>
-        /// <param name="err">The outcome of execution of the command.</param>
-        /// <param name="revoc_reg_delta_json">Revocation registry update json with a revoked claim</param>
         internal delegate void IssuerRevokeCredentialCompletedDelegate(int xcommand_handle, int err, string revoc_reg_delta_json);
 
         /// <summary>
@@ -150,9 +143,6 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_issuer_merge_revocation_registry_deltas(int command_handle, string rev_reg_delta_json, string other_rev_reg_delta_json, IssuerMergeRevocationRegistryDeltasCompletedDelegate cb);
 
-        /// <summary>
-        /// Issuer merge revocation registry deltas completed delegate.
-        /// </summary>
         internal delegate void IssuerMergeRevocationRegistryDeltasCompletedDelegate(int xcommand_handle, int err, string merged_rev_reg_delta);
 
         /// <summary>
@@ -166,9 +156,6 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_prover_create_master_secret(int command_handle, IntPtr wallet_handle, string master_secret_id, ProverCreateMasterSecretCompletedDelegate cb);
 
-        /// <summary>
-        /// Prover create master secret completed delegate.
-        /// </summary>
         internal delegate void ProverCreateMasterSecretCompletedDelegate(int xcommand_handle, int err, string out_master_secret_id);
 
         /// <summary>
@@ -185,9 +172,6 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_prover_create_credential_req(int command_handle, IntPtr wallet_handle, string prover_did, string cred_offer_json, string cred_def_json, string master_secret_id, ProverCreateCredentialReqCompletedDelegate cb);
 
-        /// <summary>
-        /// Prover create credential req completed delegate.
-        /// </summary>
         internal delegate void ProverCreateCredentialReqCompletedDelegate(int xcommand_handle, int err, string cred_req_json, string cred_req_metadata);
 
         /// <summary>
@@ -204,10 +188,21 @@ namespace Hyperledger.Indy.AnonCredsApi
         /// <param name="cb">Cb.</param>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_prover_store_credential(int command_handle, IntPtr wallet_handle, string cred_id, string cred_req_metadata_json, string cred_json, string cred_def_json, string rev_reg_def_json, ProverStoreCredentialCompletedDelegate cb);
-        /// <summary>
-        /// Prover store credential completed delegate.
-        /// </summary>
+
         internal delegate void ProverStoreCredentialCompletedDelegate(int xcommand_handle, int err, string out_cred_id);
+
+        /// <summary>
+        /// Gets human readable credential by the given id.
+        /// </summary>
+        /// <returns>The prover get credential.</returns>
+        /// <param name="command_handle">Command handle.</param>
+        /// <param name="wallet_handle">Wallet handle.</param>
+        /// <param name="cred_id">Cred identifier.</param>
+        /// <param name="cb">Cb.</param>
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_prover_get_credential(int command_handle, IntPtr wallet_handle, string cred_id, ProverGetCredentialCompletedDelegate cb);
+
+        internal delegate void ProverGetCredentialCompletedDelegate(int xcommand_handle, int err, string credential_json);
 
         /// <summary>
         /// Gets human readable claims according to the filter.
@@ -220,13 +215,44 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_prover_get_credentials(int command_handle, IntPtr wallet_handle, string filter_json, ProverGetCredentialsCompletedDelegate cb);
 
-        /// <summary>
-        /// Delegate for the function called back to by the indy_prover_get_claims function.
-        /// </summary>
-        /// <param name="xcommand_handle">The handle for the command that initiated the callback.</param>
-        /// <param name="err">The outcome of execution of the command.</param>
-        /// <param name="matched_credentials_json">claims json</param>
         internal delegate void ProverGetCredentialsCompletedDelegate(int xcommand_handle, int err, string matched_credentials_json);
+
+        /// <summary>
+        /// Search for credentials stored in wallet.
+        /// Credentials can be filtered by tags created during saving of credential.
+        /// </summary>
+        /// <returns>The prover search credentials.</returns>
+        /// <param name="command_handle">Command handle.</param>
+        /// <param name="wallet_handle">Wallet handle.</param>
+        /// <param name="query_json">Query json.</param>
+        /// <param name="cb">Cb.</param>
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_prover_search_credentials(int command_handle, IntPtr wallet_handle, string query_json, ProverSearchCredentialsCompletedDelegate cb);
+
+        internal delegate void ProverSearchCredentialsCompletedDelegate(int xcommand_handle, int err, IntPtr search_handle, int total_count);
+
+        /// <summary>
+        /// Fetch next credentials for search.
+        /// </summary>
+        /// <returns>The prover fetch credentials.</returns>
+        /// <param name="command_handle">Command handle.</param>
+        /// <param name="search_handle">Search handle.</param>
+        /// <param name="count">Count.</param>
+        /// <param name="cb">Cb.</param>
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_prover_fetch_credentials(int command_handle, IntPtr search_handle, int count, ProverFetchCredentialsCompletedDelegate cb);
+
+        internal delegate void ProverFetchCredentialsCompletedDelegate(int xcommand_handle, int err, string credentials_json);
+
+        /// <summary>
+        /// Close credentials search (make search handle invalid)
+        /// </summary>
+        /// <returns>The prover close credentials search.</returns>
+        /// <param name="command_handle">Command handle.</param>
+        /// <param name="search_handle">Search handle.</param>
+        /// <param name="cb">Cb.</param>
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_prover_close_credentials_search(int command_handle, IntPtr search_handle, IndyMethodCompletedDelegate cb);
 
         /// <summary>
         /// Gets human readable claims matching the given proof request.
@@ -239,13 +265,37 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_prover_get_credentials_for_proof_req(int command_handle, IntPtr wallet_handle, string proof_request_json, ProverGetCredentialsForProofCompletedDelegate cb);
 
-        /// <summary>
-        /// Delegate for the function called back to by the indy_prover_get_claims_for_proof_req function.
-        /// </summary>
-        /// <param name="xcommand_handle">The handle for the command that initiated the callback.</param>
-        /// <param name="err">The outcome of execution of the command.</param>
-        /// <param name="credentials_json">json with claims for the given pool request.</param>
         internal delegate void ProverGetCredentialsForProofCompletedDelegate(int xcommand_handle, int err, string credentials_json);
+
+        /// <summary>
+        /// Search for credentials matching the given proof request.
+        /// </summary>
+        /// <returns>The prover search credentials for proof req.</returns>
+        /// <param name="command_handle">Command handle.</param>
+        /// <param name="wallet_handle">Wallet handle.</param>
+        /// <param name="proof_request_json">Proof request json.</param>
+        /// <param name="extra_query_json">Extra query json.</param>
+        /// <param name="cb">Cb.</param>
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_prover_search_credentials_for_proof_req(int command_handle, IntPtr wallet_handle, string proof_request_json, string extra_query_json, ProverSearchCredentialsForProofReqCompletedDelegate cb);
+
+        internal delegate void ProverSearchCredentialsForProofReqCompletedDelegate(int xcommand_handle, int err, IntPtr search_handle);
+
+
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_prover_fetch_credentials_for_proof_req(int command_handle, IntPtr search_handle, string item_referent, int count, ProverFetchCredentialsForProofReqCompletedDelegate cb);
+
+        internal delegate void ProverFetchCredentialsForProofReqCompletedDelegate(int xcommand_handle, int err, string credentials_json);
+
+        /// <summary>
+        /// Close credentials search (make search handle invalid)
+        /// </summary>
+        /// <returns>The prover close credentials search.</returns>
+        /// <param name="command_handle">Command handle.</param>
+        /// <param name="search_handle">Search handle.</param>
+        /// <param name="cb">Cb.</param>
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_prover_close_credentials_search_for_proof_req(int command_handle, IntPtr search_handle, IndyMethodCompletedDelegate cb);
 
         /// <summary>
         /// Indies the prover create proof.
@@ -263,12 +313,6 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_prover_create_proof(int command_handle, IntPtr wallet_handle, string proof_req_json, string requested_credentials_json, string master_secret_id, string schemas_json, string credential_defs_json, string rev_states_json, ProverCreateProofCompletedDelegate cb);
 
-        /// <summary>
-        /// Delegate for the function called back to by the indy_prover_create_proof function.
-        /// </summary>
-        /// <param name="xcommand_handle">The handle for the command that initiated the callback.</param>
-        /// <param name="err">The outcome of execution of the command.</param>
-        /// <param name="proof_json">Proof json.</param>
         internal delegate void ProverCreateProofCompletedDelegate(int xcommand_handle, int err, string proof_json);
 
         /// <summary>
@@ -286,12 +330,6 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_verifier_verify_proof(int command_handle, string proof_request_json, string proof_json, string schemas_json, string credential_defs_json, string rev_reg_defs_json, string rev_regs_json, VerifierVerifyProofCompletedDelegate cb);
 
-        /// <summary>
-        /// Delegate for the function called back to by the indy_verifier_verify_proof function.
-        /// </summary>
-        /// <param name="xcommand_handle">The handle for the command that initiated the callback.</param>
-        /// <param name="err">The outcome of execution of the command.</param>
-        /// <param name="valid">true if the proof is valid, otherwise false</param>
         internal delegate void VerifierVerifyProofCompletedDelegate(int xcommand_handle, int err, bool valid);
 
         /// <summary>
@@ -308,9 +346,6 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_create_revocation_state(int command_handle, int blob_storage_reader_handle, string rev_reg_def_json, string rev_reg_delta_json, long timestamp, string cred_rev_id, CreateRevocationStateCompletedDelegate cb);
 
-        /// <summary>
-        /// Create revocation state completed delegate.
-        /// </summary>
         internal delegate void CreateRevocationStateCompletedDelegate(int xcommand_handle, int err, string rev_state_json);
 
         /// <summary>
@@ -328,9 +363,6 @@ namespace Hyperledger.Indy.AnonCredsApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_update_revocation_state(int command_handle, int blob_storage_reader_handle, string rev_state_json, string rev_reg_def_json, string rev_reg_delta_json, long timestamp, string cred_rev_id, UpdateRevocationStateCompletedDelegate cb);
 
-        /// <summary>
-        /// Update revocation state completed delegate.
-        /// </summary>
         internal delegate void UpdateRevocationStateCompletedDelegate(int xcommand_handle, int err, string updated_rev_state_json);
     }
 }

--- a/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/BlobStorage.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/BlobStorageApi/BlobStorage.cs
@@ -15,7 +15,7 @@ namespace Hyperledger.Indy.BlobStorageApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(BlobStorageCompletedDelegate))]
 #endif
-        private static void OpenReaderCallback(int xcommand_handle, int err, int handle)
+        private static void OpenReaderCallbackMethod(int xcommand_handle, int err, int handle)
         {
             var taskCompletionSource = PendingCommands.Remove<BlobStorageReader>(xcommand_handle);
 
@@ -24,10 +24,12 @@ namespace Hyperledger.Indy.BlobStorageApi
 
             taskCompletionSource.SetResult(new BlobStorageReader(handle));
         }
+        private static BlobStorageCompletedDelegate OpenReaderCallback = OpenReaderCallbackMethod;
+
 #if __IOS__
         [MonoPInvokeCallback(typeof(BlobStorageCompletedDelegate))]
 #endif
-        private static void OpenWriterCallback(int xcommand_handle, int err, int handle)
+        private static void OpenWriterCallbackMethod(int xcommand_handle, int err, int handle)
         {
             var taskCompletionSource = PendingCommands.Remove<BlobStorageWriter>(xcommand_handle);
 
@@ -36,6 +38,7 @@ namespace Hyperledger.Indy.BlobStorageApi
 
             taskCompletionSource.SetResult(new BlobStorageWriter(handle));
         }
+        private static BlobStorageCompletedDelegate OpenWriterCallback = OpenWriterCallbackMethod;
 
         /// <summary>
         /// Opens the BLOB storage reader async.

--- a/wrappers/dotnet/indy-sdk-dotnet/CryptoApi/Crypto.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/CryptoApi/Crypto.cs
@@ -22,7 +22,7 @@ namespace Hyperledger.Indy.CryptoApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(CreateKeyCompletedDelegate))]
 #endif
-        private static void CreateKeyCompletedCallback(int xcommand_handle, int err, string verkey)
+        private static void CreateKeyCompletedCallbackMethod(int xcommand_handle, int err, string verkey)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -31,6 +31,7 @@ namespace Hyperledger.Indy.CryptoApi
 
             taskCompletionSource.SetResult(verkey);
         }
+        private static CreateKeyCompletedDelegate CreateKeyCompletedCallback = CreateKeyCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the indy_get_key_metadata command has completed.
@@ -38,7 +39,7 @@ namespace Hyperledger.Indy.CryptoApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(GetKeyMetadataCompletedDelegate))]
 #endif
-        private static void GetKeyMetadataCompletedCallback(int xcommand_handle, int err, string metadata)
+        private static void GetKeyMetadataCompletedCallbackMethod(int xcommand_handle, int err, string metadata)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -47,6 +48,7 @@ namespace Hyperledger.Indy.CryptoApi
 
             taskCompletionSource.SetResult(metadata);
         }
+        private static GetKeyMetadataCompletedDelegate GetKeyMetadataCompletedCallback = GetKeyMetadataCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the indy_crypto_sign command has completed.
@@ -54,7 +56,7 @@ namespace Hyperledger.Indy.CryptoApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(SignCompletedDelegate))]
 #endif
-        private static void CryptoSignCompletedCallback(int xcommand_handle, int err, IntPtr signature_raw, int signature_len)
+        private static void CryptoSignCompletedCallbackMethod(int xcommand_handle, int err, IntPtr signature_raw, int signature_len)
         {
             var taskCompletionSource = PendingCommands.Remove<byte[]>(xcommand_handle);
 
@@ -66,6 +68,7 @@ namespace Hyperledger.Indy.CryptoApi
 
             taskCompletionSource.SetResult(signatureBytes);
         }
+        private static SignCompletedDelegate CryptoSignCompletedCallback = CryptoSignCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the indy_crypto_verify command  has completed.
@@ -73,7 +76,7 @@ namespace Hyperledger.Indy.CryptoApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(VerifyCompletedDelegate))]
 #endif
-        private static void CryptoVerifyCompletedCallback(int xcommand_handle, int err, bool valid)
+        private static void CryptoVerifyCompletedCallbackMethod(int xcommand_handle, int err, bool valid)
         {
             var taskCompletionSource = PendingCommands.Remove<bool>(xcommand_handle);
 
@@ -82,6 +85,7 @@ namespace Hyperledger.Indy.CryptoApi
 
             taskCompletionSource.SetResult(valid);
         }
+        private static VerifyCompletedDelegate CryptoVerifyCompletedCallback = CryptoVerifyCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when indy_crypto_auth_crypt or indy_crypto_anon_crypt has completed
@@ -89,7 +93,7 @@ namespace Hyperledger.Indy.CryptoApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(EncryptCompletedDelegate))]
 #endif
-        private static void CryptoEncryptCompletedCallback(int xcommand_handle, int err, IntPtr encrypted_msg, int encrypted_len)
+        private static void CryptoEncryptCompletedCallbackMethod(int xcommand_handle, int err, IntPtr encrypted_msg, int encrypted_len)
         {
             var taskCompletionSource = PendingCommands.Remove<byte[]>(xcommand_handle);
 
@@ -101,6 +105,7 @@ namespace Hyperledger.Indy.CryptoApi
 
             taskCompletionSource.SetResult(messageBytes);
         }
+        private static EncryptCompletedDelegate CryptoEncryptCompletedCallback = CryptoEncryptCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when indy_crypto_auth_decrypt has completed
@@ -108,7 +113,7 @@ namespace Hyperledger.Indy.CryptoApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(AuthDecryptCompletedDelegate))]
 #endif
-        private static void CryptoAuthDecryptCompletedCallback(int command_handle, int err, string their_vk, IntPtr msg_data, int msg_len)
+        private static void CryptoAuthDecryptCompletedCallbackMethod(int command_handle, int err, string their_vk, IntPtr msg_data, int msg_len)
         {
             var taskCompletionSource = PendingCommands.Remove<AuthDecryptResult>(command_handle);
 
@@ -122,7 +127,7 @@ namespace Hyperledger.Indy.CryptoApi
 
             taskCompletionSource.SetResult(result);
         }
-
+        private static AuthDecryptCompletedDelegate CryptoAuthDecryptCompletedCallback = CryptoAuthDecryptCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the indy_crypto_box_seal_open command has completed.
@@ -130,7 +135,7 @@ namespace Hyperledger.Indy.CryptoApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(AnonDecryptCompletedDelegate))]
 #endif
-        private static void CryptoAnonDecryptCompletedCallback(int command_handle, int err, IntPtr msg_data, int msg_len)
+        private static void CryptoAnonDecryptCompletedCallbackMethod(int command_handle, int err, IntPtr msg_data, int msg_len)
         {
             var taskCompletionSource = PendingCommands.Remove<byte[]>(command_handle);
 
@@ -142,6 +147,7 @@ namespace Hyperledger.Indy.CryptoApi
 
             taskCompletionSource.SetResult(decryptedMsgBytes);
         }
+        private static AnonDecryptCompletedDelegate CryptoAnonDecryptCompletedCallback = CryptoAnonDecryptCompletedCallbackMethod;
 
         /// <summary>
         /// Creates a key in the provided wallet.
@@ -431,7 +437,7 @@ namespace Hyperledger.Indy.CryptoApi
 
             CallbackHelper.CheckResult(commandResult);
 
-            return taskCompletionSource.Task; 
+            return taskCompletionSource.Task;
         }
 
         /// <summary>

--- a/wrappers/dotnet/indy-sdk-dotnet/CryptoApi/NativeMethods.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/CryptoApi/NativeMethods.cs
@@ -61,13 +61,13 @@ namespace Hyperledger.Indy.CryptoApi
         /// </summary>
         /// <param name="command_handle">command handle to map callback to user context.</param>
         /// <param name="wallet_handle">wallet handler (created by open_wallet).</param>
-        /// <param name="my_vk">id (verkey) of my key. The key must be created by calling indy_create_key or indy_create_and_store_my_did</param>
+        /// <param name="signer_vk">id (verkey) of my key. The key must be created by calling indy_create_key or indy_create_and_store_my_did</param>
         /// <param name="message_raw">a pointer to first byte of message to be signed</param>
         /// <param name="message_len">a message length</param>
         /// <param name="cb">Callback that takes command result as parameter.</param>
         /// <returns>0 if the command was initiated successfully.  Any non-zero result indicates an error.</returns>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_crypto_sign(int command_handle, IntPtr wallet_handle, string my_vk, byte[] message_raw, int message_len, SignCompletedDelegate cb);
+        internal static extern int indy_crypto_sign(int command_handle, IntPtr wallet_handle, string signer_vk, byte[] message_raw, int message_len, SignCompletedDelegate cb);
 
         /// <summary>
         /// Delegate to be used on completion of calls to indy_crypto_sign.
@@ -82,7 +82,7 @@ namespace Hyperledger.Indy.CryptoApi
         /// Verify a signature with a verkey.
         /// </summary>
         /// <param name="command_handle">command handle to map callback to user context.</param>
-        /// <param name="their_vk">verkey to use</param>
+        /// <param name="signer_vk">verkey to use</param>
         /// <param name="message_raw">a pointer to first byte of message to be signed</param>
         /// <param name="message_len">message length</param>
         /// <param name="signature_raw">a pointer to first byte of signature to be verified</param>
@@ -90,7 +90,7 @@ namespace Hyperledger.Indy.CryptoApi
         /// <param name="cb">Callback that takes command result as parameter.</param>
         /// <returns>0 if the command was initiated successfully.  Any non-zero result indicates an error.</returns>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_crypto_verify(int command_handle, string their_vk, byte[] message_raw, int message_len, byte[] signature_raw, int signature_len, VerifyCompletedDelegate cb);
+        internal static extern int indy_crypto_verify(int command_handle, string signer_vk, byte[] message_raw, int message_len, byte[] signature_raw, int signature_len, VerifyCompletedDelegate cb);
 
         /// <summary>
         /// Delegate to be used on completion of calls to indy_crypto_verify.
@@ -106,13 +106,13 @@ namespace Hyperledger.Indy.CryptoApi
         /// <returns>The crypto auth crypt.</returns>
         /// <param name="command_handle">command handle to map callback to user context.</param>
         /// <param name="wallet_handle">wallet handler (created by open_wallet).</param>
-        /// <param name="my_vk">id (verkey) of my key.</param>
-        /// <param name="their_vk">id (verkey) of their key</param>
+        /// <param name="sender_vk">id (verkey) of my key.</param>
+        /// <param name="recipient_vk">id (verkey) of their key</param>
         /// <param name="msg_data">a pointer to first byte of message that to be encrypted</param>
         /// <param name="msg_len">message length</param>
         /// <param name="cb">Callback that takes command result as parameter.</param>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_crypto_auth_crypt(int command_handle, IntPtr wallet_handle, string my_vk, string their_vk, byte[] msg_data, int msg_len, EncryptCompletedDelegate cb);
+        internal static extern int indy_crypto_auth_crypt(int command_handle, IntPtr wallet_handle, string sender_vk, string recipient_vk, byte[] msg_data, int msg_len, EncryptCompletedDelegate cb);
 
         /// <summary>
         /// Delegate to be used on completion of calls to indy_crypto_auth_crypt and indy_crypto_anon_crypt
@@ -125,42 +125,42 @@ namespace Hyperledger.Indy.CryptoApi
         /// <returns>sender verkey and decrypted message</returns>
         /// <param name="command_handle">command handle to map callback to user context.</param>
         /// <param name="wallet_handle">wallet handler (created by open_wallet).</param>
-        /// <param name="my_vk">id (verkey) of my key.</param>
+        /// <param name="recipient_vk">id (verkey) of my key.</param>
         /// <param name="encrypted_msg">Encrypted message.</param>
         /// <param name="encrypted_len">Encrypted length.</param>
         /// <param name="cb">Callback that takes command result as parameter.</param>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_crypto_auth_decrypt(int command_handle, IntPtr wallet_handle, string my_vk, byte[] encrypted_msg, int encrypted_len, AuthDecryptCompletedDelegate cb);
+        internal static extern int indy_crypto_auth_decrypt(int command_handle, IntPtr wallet_handle, string recipient_vk, byte[] encrypted_msg, int encrypted_len, AuthDecryptCompletedDelegate cb);
 
         /// <summary>
         /// Delegate to be used on completion of calls to indy_crypto_auth_decrypt
         /// </summary>
-        internal delegate void AuthDecryptCompletedDelegate(int command_handle, int err, string their_vk, IntPtr msg_data, int msg_len);
+        internal delegate void AuthDecryptCompletedDelegate(int command_handle, int err, string sender_vk, IntPtr msg_data, int msg_len);
 
         /// <summary>
         /// Encrypts a message by anonymous-encryption scheme.
         /// </summary>
         /// <returns>an encrypted message</returns>
         /// <param name="command_handle">command handle to map callback to user context.</param>
-        /// <param name="their_vk">id (verkey) of their key</param>
+        /// <param name="recipient_vk">id (verkey) of their key</param>
         /// <param name="msg_data">message data to be encrypted</param>
         /// <param name="msg_len">message length.</param>
         /// <param name="cb">Callback that takes command result as parameter.</param>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_crypto_anon_crypt(int command_handle, string their_vk, byte[] msg_data, int msg_len, EncryptCompletedDelegate cb);
+        internal static extern int indy_crypto_anon_crypt(int command_handle, string recipient_vk, byte[] msg_data, int msg_len, EncryptCompletedDelegate cb);
 
         /// <summary>
         /// Decrypts a message by anonymous-encryption scheme.
         /// </summary>
         /// <param name="command_handle">command handle to map callback to user context.</param>
         /// <param name="wallet_handle">wallet handler (created by open_wallet).</param>
-        /// <param name="my_vk">id (verkey) of my key. The key must be created by calling indy_create_key or indy_create_and_store_my_did</param>
+        /// <param name="recipient_vk">id (verkey) of my key. The key must be created by calling indy_create_key or indy_create_and_store_my_did</param>
         /// <param name="encrypted_msg">a pointer to first byte of message that to be decrypted</param>
         /// <param name="encrypted_len">message length</param>
         /// <param name="cb">Callback that takes command result as parameter.</param>
         /// <returns>0 if the command was initiated successfully.  Any non-zero result indicates an error.</returns>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_crypto_anon_decrypt(int command_handle, IntPtr wallet_handle, string my_vk, byte[] encrypted_msg, int encrypted_len, AnonDecryptCompletedDelegate cb);
+        internal static extern int indy_crypto_anon_decrypt(int command_handle, IntPtr wallet_handle, string recipient_vk, byte[] encrypted_msg, int encrypted_len, AnonDecryptCompletedDelegate cb);
 
         /// <summary>
         /// Delegate to be used on completion of calls to indy_crypto_anon_decrypt.

--- a/wrappers/dotnet/indy-sdk-dotnet/DidApi/Did.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/DidApi/Did.cs
@@ -21,7 +21,7 @@ namespace Hyperledger.Indy.DidApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(CreateAndStoreMyDidCompletedDelegate))]
 #endif
-        private static void CreateAndStoreMyDidCallback(int xcommand_handle, int err, string did, string verkey)
+        private static void CreateAndStoreMyDidCallbackMethod(int xcommand_handle, int err, string did, string verkey)
         {
             var taskCompletionSource = PendingCommands.Remove<CreateAndStoreMyDidResult>(xcommand_handle);
 
@@ -32,6 +32,7 @@ namespace Hyperledger.Indy.DidApi
 
             taskCompletionSource.SetResult(callbackResult);
         }
+        private static CreateAndStoreMyDidCompletedDelegate CreateAndStoreMyDidCallback = CreateAndStoreMyDidCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the command for ReplaceKeysAsync has completed.
@@ -39,7 +40,7 @@ namespace Hyperledger.Indy.DidApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ReplaceKeysStartCompletedDelegate))]
 #endif
-        private static void ReplaceKeysCallback(int xcommand_handle, int err, string verkey)
+        private static void ReplaceKeysCallbackMethod(int xcommand_handle, int err, string verkey)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -48,6 +49,7 @@ namespace Hyperledger.Indy.DidApi
 
             taskCompletionSource.SetResult(verkey);
         }
+        private static ReplaceKeysStartCompletedDelegate ReplaceKeysCallback = ReplaceKeysCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the command for KeyForDidAsync has completed.
@@ -55,7 +57,7 @@ namespace Hyperledger.Indy.DidApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(DidKeyForDidCompletedDelegate))]
 #endif
-        private static void KeyForDidCompletedCallback(int xcommand_handle, int err, string key)
+        private static void KeyForDidCompletedCallbackMethod(int xcommand_handle, int err, string key)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -64,6 +66,7 @@ namespace Hyperledger.Indy.DidApi
 
             taskCompletionSource.SetResult(key);
         }
+        private static DidKeyForDidCompletedDelegate KeyForDidCompletedCallback = KeyForDidCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the command for KeyForLocalDidAsync has completed.
@@ -71,7 +74,7 @@ namespace Hyperledger.Indy.DidApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(DidKeyForLocalDidCompletedDelegate))]
 #endif
-        private static void KeyForLocalDidCompletedCallback(int xcommand_handle, int err, string key)
+        private static void KeyForLocalDidCompletedCallbackMethod(int xcommand_handle, int err, string key)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -80,6 +83,7 @@ namespace Hyperledger.Indy.DidApi
 
             taskCompletionSource.SetResult(key);
         }
+        private static DidKeyForLocalDidCompletedDelegate KeyForLocalDidCompletedCallback = KeyForLocalDidCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the command for GetEndpointForDidAsync has completed.
@@ -87,7 +91,7 @@ namespace Hyperledger.Indy.DidApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(DidGetEndpointForDidCompletedDelegate))]
 #endif
-        private static void GetEndpointForDidCompletedCallback(int xcommand_handle, int err, string endpoint, string transport_vk)
+        private static void GetEndpointForDidCompletedCallbackMethod(int xcommand_handle, int err, string endpoint, string transport_vk)
         {
             var taskCompletionSource = PendingCommands.Remove<EndpointForDidResult>(xcommand_handle);
 
@@ -98,6 +102,7 @@ namespace Hyperledger.Indy.DidApi
 
             taskCompletionSource.SetResult(result);
         }
+        private static DidGetEndpointForDidCompletedDelegate GetEndpointForDidCompletedCallback = GetEndpointForDidCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the command for GetDidMetadataAsync has completed.
@@ -105,7 +110,7 @@ namespace Hyperledger.Indy.DidApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(DidGetDidMetadataCompletedDelegate))]
 #endif
-        private static void GetDidMetadataCompletedCallback(int xcommand_handle, int err, string metadata)
+        private static void GetDidMetadataCompletedCallbackMethod(int xcommand_handle, int err, string metadata)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -114,6 +119,7 @@ namespace Hyperledger.Indy.DidApi
 
             taskCompletionSource.SetResult(metadata);
         }
+        private static DidGetDidMetadataCompletedDelegate GetDidMetadataCompletedCallback = GetDidMetadataCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the command for GetMyDidWithMetaAsync has completed.
@@ -121,7 +127,7 @@ namespace Hyperledger.Indy.DidApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(GetMyDidWithMetaCompletedDelegate))]
 #endif
-        private static void GetMyDidWithMetaCompletedCallback(int xcommand_handle, int err, string didWithMeta)
+        private static void GetMyDidWithMetaCompletedCallbackMethod(int xcommand_handle, int err, string didWithMeta)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -130,6 +136,7 @@ namespace Hyperledger.Indy.DidApi
 
             taskCompletionSource.SetResult(didWithMeta);
         }
+        private static GetMyDidWithMetaCompletedDelegate GetMyDidWithMetaCompletedCallback = GetMyDidWithMetaCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the command for GetMyDidWithMetaAsync has completed.
@@ -137,7 +144,7 @@ namespace Hyperledger.Indy.DidApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ListMyDidsWithMetaCompletedDelegate))]
 #endif
-        private static void ListMyDidsWithMetaCompletedCallback(int xcommand_handle, int err, string dids)
+        private static void ListMyDidsWithMetaCompletedCallbackMethod(int xcommand_handle, int err, string dids)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -146,6 +153,7 @@ namespace Hyperledger.Indy.DidApi
 
             taskCompletionSource.SetResult(dids);
         }
+        private static ListMyDidsWithMetaCompletedDelegate ListMyDidsWithMetaCompletedCallback = ListMyDidsWithMetaCompletedCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the command for AbbreviateVerkeyAsync has completed.
@@ -153,7 +161,7 @@ namespace Hyperledger.Indy.DidApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(AbbreviateVerkeyCompletedDelegate))]
 #endif
-        private static void AbbreviateVerkeyCompletedCallback(int xcommand_handle, int err, string verkey)
+        private static void AbbreviateVerkeyCompletedCallbackMethod(int xcommand_handle, int err, string verkey)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -162,6 +170,7 @@ namespace Hyperledger.Indy.DidApi
 
             taskCompletionSource.SetResult(verkey);
         }
+        private static AbbreviateVerkeyCompletedDelegate AbbreviateVerkeyCompletedCallback = AbbreviateVerkeyCompletedCallbackMethod;
 
         /// <summary>
         /// Creates signing and encryption keys in specified wallet for a new DID owned by the caller.

--- a/wrappers/dotnet/indy-sdk-dotnet/DidApi/NativeMethods.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/DidApi/NativeMethods.cs
@@ -12,11 +12,11 @@ namespace Hyperledger.Indy.DidApi
         /// </summary>
         /// <param name="command_handle">The handle for the command that will be passed to the callback.</param>
         /// <param name="wallet_handle">wallet handle (created by open_wallet)</param>
-        /// <param name="did_json">Identity information as json.</param>
+        /// <param name="did_info">Identity information as json.</param>
         /// <param name="cb">The function that will be called when the asynchronous call is complete.</param>
         /// <returns>0 if the command was initiated successfully.  Any non-zero result indicates an error.</returns>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_create_and_store_my_did(int command_handle, IntPtr wallet_handle, string did_json, CreateAndStoreMyDidCompletedDelegate cb);
+        internal static extern int indy_create_and_store_my_did(int command_handle, IntPtr wallet_handle, string did_info, CreateAndStoreMyDidCompletedDelegate cb);
 
         /// <summary>
         /// Delegate to be used on completion of calls to indy_create_and_store_my_did.
@@ -34,11 +34,11 @@ namespace Hyperledger.Indy.DidApi
         /// <param name="command_handle">The handle for the command that will be passed to the callback.</param>
         /// <param name="wallet_handle">wallet handle (created by open_wallet).</param>
         /// <param name="did">Id of Identity stored in secured Wallet.</param>
-        /// <param name="identity_json">Identity information as json.</param>
+        /// <param name="key_info">Identity information as json.</param>
         /// <param name="cb">The function that will be called when the asynchronous call is complete.</param>
         /// <returns>0 if the command was initiated successfully.  Any non-zero result indicates an error.</returns>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern int indy_replace_keys_start(int command_handle, IntPtr wallet_handle, string did, string identity_json, ReplaceKeysStartCompletedDelegate cb);
+        internal static extern int indy_replace_keys_start(int command_handle, IntPtr wallet_handle, string did, string key_info, ReplaceKeysStartCompletedDelegate cb);
 
         /// <summary>
         /// Delegate to be used on completion of calls to indy_replace_keys_start.

--- a/wrappers/dotnet/indy-sdk-dotnet/LedgerApi/Ledger.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/LedgerApi/Ledger.cs
@@ -48,7 +48,7 @@ namespace Hyperledger.Indy.LedgerApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(SubmitRequestCompletedDelegate))]
 #endif
-        private static void SubmitRequestCallback(int xcommand_handle, int err, string response_json)
+        private static void SubmitRequestCallbackMethod(int xcommand_handle, int err, string response_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -57,6 +57,7 @@ namespace Hyperledger.Indy.LedgerApi
 
             taskCompletionSource.SetResult(response_json);
         }
+        private static SubmitRequestCompletedDelegate SubmitRequestCallback = SubmitRequestCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when a command that builds a request completes.
@@ -64,7 +65,7 @@ namespace Hyperledger.Indy.LedgerApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(BuildRequestCompletedDelegate))]
 #endif
-        private static void BuildRequestCallback(int xcommand_handle, int err, string request_json)
+        private static void BuildRequestCallbackMethod(int xcommand_handle, int err, string request_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -73,11 +74,12 @@ namespace Hyperledger.Indy.LedgerApi
 
             taskCompletionSource.SetResult(request_json);
         }
+        private static BuildRequestCompletedDelegate BuildRequestCallback = BuildRequestCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(ParseResponseCompletedDelegate))]
 #endif
-        private static void ParseResponseCallback(int xcommand_handle, int err, string id, string object_json)
+        private static void ParseResponseCallbackMethod(int xcommand_handle, int err, string id, string object_json)
         {
             var taskCompletionSource = PendingCommands.Remove<ParseResponseResult>(xcommand_handle);
 
@@ -86,11 +88,12 @@ namespace Hyperledger.Indy.LedgerApi
 
             taskCompletionSource.SetResult(new ParseResponseResult(id, object_json));
         }
+        private static ParseResponseCompletedDelegate ParseResponseCallback = ParseResponseCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(ParseRegistryResponseCompletedDelegate))]
 #endif
-        private static void ParseRegistryResponseCallback(int xcommand_handle, int err, string id, string object_json, ulong timestamp)
+        private static void ParseRegistryResponseCallbackMethod(int xcommand_handle, int err, string id, string object_json, ulong timestamp)
         {
             var taskCompletionSource = PendingCommands.Remove<ParseRegistryResponseResult>(xcommand_handle);
 
@@ -99,6 +102,7 @@ namespace Hyperledger.Indy.LedgerApi
 
             taskCompletionSource.SetResult(new ParseRegistryResponseResult(id, object_json, timestamp));
         }
+        private static ParseRegistryResponseCompletedDelegate ParseRegistryResponseCallback = ParseRegistryResponseCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the command for SignRequestAsync has completed.
@@ -106,7 +110,7 @@ namespace Hyperledger.Indy.LedgerApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(SignRequestCompletedDelegate))]
 #endif
-        private static void SignRequestCallback(int xcommand_handle, int err, string signed_request_json)
+        private static void SignRequestCallbackMethod(int xcommand_handle, int err, string signed_request_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -115,6 +119,7 @@ namespace Hyperledger.Indy.LedgerApi
 
             taskCompletionSource.SetResult(signed_request_json);
         }
+        private static SignRequestCompletedDelegate SignRequestCallback = SignRequestCallbackMethod;
 
         /// <summary>
         /// Signs a request message.

--- a/wrappers/dotnet/indy-sdk-dotnet/LedgerApi/NativeMethods.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/LedgerApi/NativeMethods.cs
@@ -46,6 +46,24 @@ namespace Hyperledger.Indy.LedgerApi
         internal static extern int indy_submit_request(int command_handle, IntPtr pool_handle, string request_json, SubmitRequestCompletedDelegate cb);
 
         /// <summary>
+        /// Send action to particular nodes of validator pool.
+        ///
+        /// The list of requests can be send:
+        ///     POOL_RESTART
+        ///     GET_VALIDATOR_INFO
+        /// </summary>
+        /// <returns>The submit action.</returns>
+        /// <param name="command_handle">Command handle.</param>
+        /// <param name="pool_handle">Pool handle.</param>
+        /// <param name="request_json">Request json.</param>
+        /// <param name="nodes">Nodes.</param>
+        /// <param name="timeout">Timeout.</param>
+        /// <param name="cb">Cb.</param>
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_submit_action(int command_handle, IntPtr pool_handle, string request_json, string nodes, int timeout, SubmitRequestCompletedDelegate cb);
+
+
+        /// <summary>
         /// Signs a request.
         /// </summary>
         /// <param name="command_handle">The handle for the command that will be passed to the callback.</param>
@@ -56,6 +74,22 @@ namespace Hyperledger.Indy.LedgerApi
         /// <returns>0 if the command was initiated successfully.  Any non-zero result indicates an error.</returns>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_sign_request(int command_handle, IntPtr wallet_handle, string submitter_did, string request_json, SignRequestCompletedDelegate cb);
+
+        /// <summary>
+        /// Multi signs request message.
+        ///
+        /// Adds submitter information to passed request json, signs it with submitter
+        /// sign key (see wallet_sign).
+        /// </summary>
+        /// <returns>The multi sign request.</returns>
+        /// <param name="command_handle">Command handle.</param>
+        /// <param name="wallet_handle">Wallet handle.</param>
+        /// <param name="submitter_did">Submitter did.</param>
+        /// <param name="request_json">Request json.</param>
+        /// <param name="cb">Cb.</param>
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_multi_sign_request(int command_handle, IntPtr wallet_handle, string submitter_did, string request_json, SignRequestCompletedDelegate cb);
+
 
         /// <summary>
         /// Delegate to be used on completion of calls to indy_sign_request.
@@ -161,14 +195,8 @@ namespace Hyperledger.Indy.LedgerApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_parse_get_schema_response(int command_handle, string get_schema_response, ParseResponseCompletedDelegate cb);
 
-        /// <summary>
-        /// Parse response completed delegate.
-        /// </summary>
-        internal delegate void ParseResponseCompletedDelegate(int xcommand_handle, int err, string schema_id, string schema_json);
+        internal delegate void ParseResponseCompletedDelegate(int xcommand_handle, int err, string object_id, string object_json);
 
-        /// <summary>
-        /// Parse registry response completed delegate.
-        /// </summary>
         internal delegate void ParseRegistryResponseCompletedDelegate(int xcommand_handle, int err, string id, string object_json, ulong timestamp);
 
         /// <summary>

--- a/wrappers/dotnet/indy-sdk-dotnet/NonSecretsApi/NonSecrets.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/NonSecretsApi/NonSecrets.cs
@@ -20,7 +20,7 @@ namespace Hyperledger.Indy.NonSecretsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(GetRecordCompletedDelegate))]
 #endif
-        static void GetRecordCallback(int xcommand_handle, int err, string value)
+        private static void GetRecordCallbackMethod(int xcommand_handle, int err, string value)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -29,11 +29,12 @@ namespace Hyperledger.Indy.NonSecretsApi
 
             taskCompletionSource.SetResult(value);
         }
+        private static GetRecordCompletedDelegate GetRecordCallback = GetRecordCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(OpenWalletSearchCompletedDelegate))]
 #endif
-        static void OpenSearchCallback(int xcommand_handle, int err, IntPtr search_handle)
+        private static void OpenSearchCallbackMethod(int xcommand_handle, int err, IntPtr search_handle)
         {
             var taskCompletionSource = PendingCommands.Remove<WalletSearch>(xcommand_handle);
 
@@ -42,11 +43,12 @@ namespace Hyperledger.Indy.NonSecretsApi
 
             taskCompletionSource.SetResult(new WalletSearch(search_handle));
         }
+        private static OpenWalletSearchCompletedDelegate OpenSearchCallback = OpenSearchCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(FetchNextRecordCompletedDelegate))]
 #endif
-        static void FetchNextCallback(int xcommand_handle, int err, string records_json)
+        private static void FetchNextCallbackMethod(int xcommand_handle, int err, string records_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -55,6 +57,7 @@ namespace Hyperledger.Indy.NonSecretsApi
 
             taskCompletionSource.SetResult(records_json);
         }
+        private static FetchNextRecordCompletedDelegate FetchNextCallback = FetchNextCallbackMethod;
 
         #endregion
 

--- a/wrappers/dotnet/indy-sdk-dotnet/PairwiseApi/Pairwise.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/PairwiseApi/Pairwise.cs
@@ -24,7 +24,7 @@ namespace Hyperledger.Indy.PairwiseApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(IsPairwiseExistsCompletedDelegate))]
 #endif
-        private static void IsPairwiseExistsCallback(int xcommand_handle, int err, bool exists)
+        private static void IsPairwiseExistsCallbackMethod(int xcommand_handle, int err, bool exists)
         {
             var taskCompletionSource = PendingCommands.Remove<bool>(xcommand_handle);
 
@@ -33,6 +33,7 @@ namespace Hyperledger.Indy.PairwiseApi
 
             taskCompletionSource.SetResult(exists);
         }
+        private static IsPairwiseExistsCompletedDelegate IsPairwiseExistsCallback = IsPairwiseExistsCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the ListAsync command completes.
@@ -40,7 +41,7 @@ namespace Hyperledger.Indy.PairwiseApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ListPairwiseCompletedDelegate))]
 #endif
-        private static void ListPairwiseCallback(int xcommand_handle, int err, string list_pairwise)
+        private static void ListPairwiseCallbackMethod(int xcommand_handle, int err, string list_pairwise)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -49,6 +50,7 @@ namespace Hyperledger.Indy.PairwiseApi
 
             taskCompletionSource.SetResult(list_pairwise);
         }
+        private static ListPairwiseCompletedDelegate ListPairwiseCallback = ListPairwiseCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use when the GetAsync command completes.
@@ -56,7 +58,7 @@ namespace Hyperledger.Indy.PairwiseApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(GetPairwiseCompletedDelegate))]
 #endif
-        private static void GetPairwiseCallback(int xcommand_handle, int err, string get_pairwise_json)
+        private static void GetPairwiseCallbackMethod(int xcommand_handle, int err, string get_pairwise_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -65,6 +67,7 @@ namespace Hyperledger.Indy.PairwiseApi
 
             taskCompletionSource.SetResult(get_pairwise_json);
         }
+        private static GetPairwiseCompletedDelegate GetPairwiseCallback = GetPairwiseCallbackMethod;
 
         /// <summary>
         /// Gets whether or not a pairwise record exists in the provided wallet for the specified DID .

--- a/wrappers/dotnet/indy-sdk-dotnet/PaymentsApi/Payments.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/PaymentsApi/Payments.cs
@@ -17,7 +17,7 @@ namespace Hyperledger.Indy.PaymentsApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(CreatePaymentAddressDelegate))]
 #endif
-        static void CreatePaymentAddressCallback(int xcommand_handle, int err, string payment_address)
+        static void CreatePaymentAddressCallbackMethod(int xcommand_handle, int err, string payment_address)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -26,11 +26,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(payment_address);
         }
+        static CreatePaymentAddressDelegate CreatePaymentAddressCallback = CreatePaymentAddressCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(ListPaymentAddressesDelegate))]
 #endif
-        static void ListPaymentAddressesCallback(int xcommand_handle, int err, string payment_addressed_json)
+        static void ListPaymentAddressesCallbackMethod(int xcommand_handle, int err, string payment_addressed_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -39,11 +40,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(payment_addressed_json);
         }
+        static ListPaymentAddressesDelegate ListPaymentAddressesCallback = ListPaymentAddressesCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(AddRequestFeesDelegate))]
 #endif
-        static void AddRequestFeesCallback(int xcommand_handle, int err, string req_with_fees_json, string payment_method)
+        static void AddRequestFeesCallbackMethod(int xcommand_handle, int err, string req_with_fees_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -52,11 +54,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(new PaymentResult(req_with_fees_json, payment_method));
         }
+        static AddRequestFeesDelegate AddRequestFeesCallback = AddRequestFeesCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(ParseResponseWithFeesDelegate))]
 #endif
-        static void ParseResponseWithFeesCallback(int xcommand_handle, int err, string utxo_json)
+        static void ParseResponseWithFeesCallbackMethod(int xcommand_handle, int err, string utxo_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -65,11 +68,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(utxo_json);
         }
+        static ParseResponseWithFeesDelegate ParseResponseWithFeesCallback = ParseResponseWithFeesCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(BuildGetUtxoRequstDelegate))]
 #endif
-        static void BuildGetUtxoRequestCallback(int xcommand_handle, int err, string get_utxo_txn_json, string payment_method)
+        static void BuildGetUtxoRequestCallbackMethod(int xcommand_handle, int err, string get_utxo_txn_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -78,11 +82,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(new PaymentResult(get_utxo_txn_json, payment_method));
         }
+        static BuildGetUtxoRequstDelegate BuildGetUtxoRequestCallback = BuildGetUtxoRequestCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(ParseGetUtxoResponseDelegate))]
 #endif
-        static void ParseGetUtxoResponseCallback(int xcommand_handle, int err, string utxo_json)
+        static void ParseGetUtxoResponseCallbackMethod(int xcommand_handle, int err, string utxo_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -91,11 +96,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(utxo_json);
         }
+        static ParseGetUtxoResponseDelegate ParseGetUtxoResponseCallback = ParseGetUtxoResponseCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(BuildPaymentRequestDelegate))]
 #endif
-        static void BuildPaymentRequestCallback(int xcommand_handle, int err, string payment_req_json, string payment_method)
+        static void BuildPaymentRequestCallbackMethod(int xcommand_handle, int err, string payment_req_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -104,11 +110,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(new PaymentResult(payment_req_json, payment_method));
         }
+        static BuildPaymentRequestDelegate BuildPaymentRequestCallback = BuildPaymentRequestCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(ParsePaymentResponseDelegate))]
 #endif
-        static void ParsePaymentResponseCallback(int xcommand_handle, int err, string utxo_json)
+        static void ParsePaymentResponseCallbackMethod(int xcommand_handle, int err, string utxo_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -117,11 +124,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(utxo_json);
         }
+        static ParsePaymentResponseDelegate ParsePaymentResponseCallback = ParsePaymentResponseCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(BuildMintReqDelegate))]
 #endif
-        static void BuildMintRequestCallback(int xcommand_handle, int err, string mint_req_json, string payment_method)
+        static void BuildMintRequestCallbackMethod(int xcommand_handle, int err, string mint_req_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -130,11 +138,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(new PaymentResult(mint_req_json, payment_method));
         }
+        static BuildMintReqDelegate BuildMintRequestCallback = BuildMintRequestCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(BuildSetTxnFeesReqDelegate))]
 #endif
-        static void BuildSetTxnFeesReqCallback(int xcommand_handle, int err, string set_txn_fees_json)
+        static void BuildSetTxnFeesReqCallbackMethod(int xcommand_handle, int err, string set_txn_fees_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -143,11 +152,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(set_txn_fees_json);
         }
+        static BuildSetTxnFeesReqDelegate BuildSetTxnFeesReqCallback = BuildSetTxnFeesReqCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(BuildGetTxnFeesReqDelegate))]
 #endif
-        static void BuildGetTxnFeesReqCallback(int xcommand_handle, int err, string get_txn_fees_json)
+        static void BuildGetTxnFeesReqCallbackMethod(int xcommand_handle, int err, string get_txn_fees_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -156,11 +166,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(get_txn_fees_json);
         }
+        static BuildGetTxnFeesReqDelegate BuildGetTxnFeesReqCallback = BuildGetTxnFeesReqCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(ParseGetTxnFeesResponseDelegate))]
 #endif
-        static void ParseGetTxnFeesResponseCallback(int xcommand_handle, int err, string get_txn_fees_json)
+        static void ParseGetTxnFeesResponseCallbackMethod(int xcommand_handle, int err, string get_txn_fees_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -169,11 +180,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(get_txn_fees_json);
         }
+        static ParseGetTxnFeesResponseDelegate ParseGetTxnFeesResponseCallback = ParseGetTxnFeesResponseCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(BuildVerifyPaymentRequestDelegate))]
 #endif
-        static void BuildVerifyPaymentRequestCallback(int xcommand_handle, int err, string verify_txn_json, string payment_method)
+        static void BuildVerifyPaymentRequestCallbackMethod(int xcommand_handle, int err, string verify_txn_json, string payment_method)
         {
             var taskCompletionSource = PendingCommands.Remove<PaymentResult>(xcommand_handle);
 
@@ -182,11 +194,12 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(new PaymentResult(verify_txn_json, payment_method));
         }
+        static BuildVerifyPaymentRequestDelegate BuildVerifyPaymentRequestCallback = BuildVerifyPaymentRequestCallbackMethod;
 
 #if __IOS__
         [MonoPInvokeCallback(typeof(ParseVerifyPaymentResponseDelegate))]
 #endif
-        static void ParseVerifyPaymentResponseDelegate(int xcommand_handle, int err, string txn_json)
+        static void ParseVerifyPaymentResponseDelegateMethod(int xcommand_handle, int err, string txn_json)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
@@ -195,6 +208,7 @@ namespace Hyperledger.Indy.PaymentsApi
 
             taskCompletionSource.SetResult(txn_json);
         }
+        static ParseVerifyPaymentResponseDelegate ParseVerifyPaymentResponseDelegate = ParseVerifyPaymentResponseDelegateMethod;
 
         /// <summary>
         /// Create the payment address for this payment method.

--- a/wrappers/dotnet/indy-sdk-dotnet/PoolApi/Pool.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/PoolApi/Pool.cs
@@ -20,7 +20,7 @@ namespace Hyperledger.Indy.PoolApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(OpenPoolLedgerCompletedDelegate))]
 #endif
-        private static void OpenPoolLedgerCallback(int command_handle, int err, IntPtr pool_handle)
+        private static void OpenPoolLedgerCallbackMethod(int command_handle, int err, IntPtr pool_handle)
         {
             var taskCompletionSource = PendingCommands.Remove<Pool>(command_handle);
 
@@ -29,6 +29,7 @@ namespace Hyperledger.Indy.PoolApi
 
             taskCompletionSource.SetResult(new Pool(pool_handle));
         }
+        private static OpenPoolLedgerCompletedDelegate OpenPoolLedgerCallback = OpenPoolLedgerCallbackMethod;
 
         /// <summary>
         /// Callback to use when list pools command has completed.
@@ -36,7 +37,7 @@ namespace Hyperledger.Indy.PoolApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(ListPoolsCompletedDelegate))]
 #endif
-        private static void ListPoolsCallback(int command_handle, int err, string pools)
+        private static void ListPoolsCallbackMethod(int command_handle, int err, string pools)
         {
             var taskCompletionSource = PendingCommands.Remove<string>(command_handle);
 
@@ -45,6 +46,7 @@ namespace Hyperledger.Indy.PoolApi
 
             taskCompletionSource.SetResult(pools);
         }
+        private static ListPoolsCompletedDelegate ListPoolsCallback = ListPoolsCallbackMethod;
 
         /// <summary>
         /// Creates a new local pool configuration with the specified name that can be used later to open a connection to 

--- a/wrappers/dotnet/indy-sdk-dotnet/Utils/CallbackHelper.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/Utils/CallbackHelper.cs
@@ -21,7 +21,7 @@ namespace Hyperledger.Indy.Utils
 #if __IOS__
         [MonoPInvokeCallback(typeof(IndyMethodCompletedDelegate))]
 #endif
-        public static void TaskCompletingNoValueCallback(int xcommand_handle, int err)
+        public static void TaskCompletingNoValueCallbackMethod(int xcommand_handle, int err)
         {
             var taskCompletionSource = PendingCommands.Remove<bool>(xcommand_handle);
 
@@ -30,6 +30,7 @@ namespace Hyperledger.Indy.Utils
 
             taskCompletionSource.SetResult(true);
         }
+        public static IndyMethodCompletedDelegate TaskCompletingNoValueCallback = TaskCompletingNoValueCallbackMethod;
 
         /// <summary>
         /// Gets the callback to use for functions that don't return a value and are not associated with a task.
@@ -37,10 +38,11 @@ namespace Hyperledger.Indy.Utils
 #if __IOS__
         [MonoPInvokeCallback(typeof(IndyMethodCompletedDelegate))]
 #endif
-        public static void NoValueCallback(int xcommand_handle, int err)
+        public static void NoValueCallbackMethod(int xcommand_handle, int err)
         {
             CheckCallback(err);
         }
+        public static IndyMethodCompletedDelegate NoValueCallback = NoValueCallbackMethod;
 
         /// <summary>
         /// Checks the result from a Sovrin function call.

--- a/wrappers/dotnet/indy-sdk-dotnet/WalletApi/NativeMethods.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/WalletApi/NativeMethods.cs
@@ -110,13 +110,6 @@ namespace Hyperledger.Indy.WalletApi
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_import_wallet(int command_handle, string config, string credentials, string import_config, IndyMethodCompletedDelegate cb);
 
-
-        /// <summary>
-        /// Delegate to be used on completion of calls to indy_open_wallet.
-        /// </summary>
-        /// <param name="xcommand_handle">The handle for the command that initiated the callback.</param>
-        /// <param name="err">The outcome of execution of the command.</param>
-        /// <param name="wallet_handle">The handle for the opened wallet.</param>
         internal delegate void OpenWalletCompletedDelegate(int xcommand_handle, int err, IntPtr wallet_handle);
 
         /// <summary>
@@ -139,5 +132,11 @@ namespace Hyperledger.Indy.WalletApi
         /// <returns>0 if the command was initiated successfully.  Any non-zero result indicates an error.</returns>
         [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern int indy_delete_wallet(int command_handle, string config, string credentials, IndyMethodCompletedDelegate cb);
+
+        [DllImport(Consts.NATIVE_LIB_NAME, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern int indy_generate_wallet_key(int command_handle, string config, GenerateWalletKeyCompletedDelegate cb);
+
+        internal delegate void GenerateWalletKeyCompletedDelegate(int xcommand_handle, int err, string key);
+
     }
 }

--- a/wrappers/dotnet/indy-sdk-dotnet/WalletApi/Wallet.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet/WalletApi/Wallet.cs
@@ -26,7 +26,7 @@ namespace Hyperledger.Indy.WalletApi
 #if __IOS__
         [MonoPInvokeCallback(typeof(OpenWalletCompletedDelegate))]
 #endif
-        private static void OpenWalletCallback(int xcommand_handle, int err, IntPtr wallet_handle)
+        private static void OpenWalletCallbackMethod(int xcommand_handle, int err, IntPtr wallet_handle)
         {
             var taskCompletionSource = PendingCommands.Remove<Wallet>(xcommand_handle);
 
@@ -35,53 +35,22 @@ namespace Hyperledger.Indy.WalletApi
 
             taskCompletionSource.SetResult(new Wallet(wallet_handle));
         }
+        private static OpenWalletCompletedDelegate OpenWalletCallback = OpenWalletCallbackMethod;
 
-        ///// <summary>
-        ///// Registers a custom wallet type implementation.
-        ///// </summary>
-        ///// <remarks>
-        ///// <para>This method allows custom wallet implementations to be registered at runtime so that alternatives
-        ///// to the default wallet type can be used.  Implementing a custom wallet is achieved by
-        ///// deriving from the <see cref="WalletType"/> class - see the <see cref="WalletType"/> and 
-        ///// <see cref="ICustomWallet"/> classes for further detail.
-        ///// </para>
-        ///// <para>Each custom wallet type is registered with a name which can subsequently be used when 
-        ///// creating a new wallet using the <see cref="CreateWalletAsync(string, string, string, string, string)"/> method.
-        ///// </para>
-        ///// </remarks>
-        ///// <param name="typeName">The name of the custom wallet type.</param>
-        ///// <param name="walletType">An instance of a class derived from <see cref="WalletType "/> containing the logic for 
-        ///// the custom wallet type.</param>
-        ///// <returns>An asynchronous <see cref="Task"/> with no return value that completes when
-        ///// the registration is complete.</returns>
-        //public static Task RegisterWalletTypeAsync(string typeName, WalletType walletType)
-        //{
-        //    ParamGuard.NotNullOrWhiteSpace(typeName, "typeName");
-        //    ParamGuard.NotNull(walletType, "walletType");
+#if __IOS__
+        [MonoPInvokeCallback(typeof(GenerateWalletKeyCompletedDelegate))]
+#endif
+        private static void GenerateWalletKeyCallbackMethod(int xcommand_handle, int err, string key)
+        {
+            var taskCompletionSource = PendingCommands.Remove<string>(xcommand_handle);
 
-        //    var taskCompletionSource = new TaskCompletionSource<bool>();
-        //    var commandHandle = PendingCommands.Add(taskCompletionSource);
+            if (!CallbackHelper.CheckCallback(taskCompletionSource, err))
+                return;
 
-        //    _registeredWalletTypes.Add(walletType);
+            taskCompletionSource.SetResult(key);
+        }
+        private static GenerateWalletKeyCompletedDelegate GenerateWalletKeyCallback = GenerateWalletKeyCallbackMethod;
 
-        //    var result = NativeMethods.indy_register_wallet_type(
-        //        commandHandle,
-        //        typeName,
-        //        walletType.CreateCallback,
-        //        walletType.OpenCallback,
-        //        walletType.SetCallback,
-        //        walletType.GetCallback,
-        //        walletType.GetNotExpiredCallback,
-        //        walletType.ListCallback,
-        //        walletType.CloseCallback,
-        //        walletType.DeleteCallback,
-        //        walletType.FreeCallback,
-        //        CallbackHelper.TaskCompletingNoValueCallback);
-
-        //    CallbackHelper.CheckResult(result);
-
-        //    return taskCompletionSource.Task;
-        //}
 
         /// <summary>
         /// Create a new secure wallet.
@@ -330,6 +299,35 @@ namespace Hyperledger.Indy.WalletApi
                 config,
                 credentials,
                 CallbackHelper.TaskCompletingNoValueCallback
+                );
+
+            CallbackHelper.CheckResult(result);
+
+            return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Generate wallet master key.
+        /// Returned key is compatible with "RAW" key derivation method.
+        /// It allows to avoid expensive key derivation for use cases when wallet keys can be stored in a secure enclave.
+        /// </summary>
+        /// <returns>The generated wallet key.</returns>
+        /// <param name="config">
+        /// config: (optional) key configuration json.
+        /// {
+        ///   "seed": optional&lt;string> Seed that allows deterministic key creation (if not set random one will be used).
+        /// }</param>
+        public static Task<string> GenerateWalletKeyAsync(string config)
+        {
+            ParamGuard.NotNullOrWhiteSpace(config, "config");
+
+            var taskCompletionSource = new TaskCompletionSource<string>();
+            var commandHandle = PendingCommands.Add(taskCompletionSource);
+
+            var result = NativeMethods.indy_generate_wallet_key(
+                commandHandle,
+                config,
+                GenerateWalletKeyCallback
                 );
 
             CallbackHelper.CheckResult(result);

--- a/wrappers/dotnet/indy-sdk-dotnet/indy-sdk-dotnet.csproj
+++ b/wrappers/dotnet/indy-sdk-dotnet/indy-sdk-dotnet.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Hyperledger.Indy.Sdk</AssemblyName>
     <RootNamespace>Hyperledger.Indy</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.6.2</Version>
+    <Version>1.6.4</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Authors>Symon Rottem, Tomislav Markovski</Authors>
     <Company>Hyperledger Indy</Company>
@@ -19,8 +19,8 @@ Please note that to function the C-Callable Hyperledger Indy SDK and its depende
     <PackageTags>hyperledger indy sdk</PackageTags>
     <PackageLicenseUrl>https://github.com/hyperledger/indy-sdk/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl></PackageIconUrl>
-    <AssemblyVersion>1.6.2</AssemblyVersion>
-    <FileVersion>1.6.2</FileVersion>
+    <AssemblyVersion>1.6.4</AssemblyVersion>
+    <FileVersion>1.6.4</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
This PR updates the API to prevent a rarely occurring, but valid bug in cases when garbage collector prematurely collects method pointers resulting in an exception that the native method pointer was collected.
Various missing wrappers have been updated, mainly around credential search.

Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>