### PR TITLE
CLI color-related bugfixes

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -111,6 +111,7 @@ name = "indy-cli"
 version = "1.6.5"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,7 @@ nullpay_plugin = []
 fatal_warnings = []
 
 [dependencies]
+atty = "0.2"
 ansi_term = "0.11"
 chrono = "0.4"
 unescape = "0.1"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "fatal_warnings", deny(warnings))]
 
+extern crate atty;
 extern crate ansi_term;
 extern crate unescape;
 #[macro_use]
@@ -36,6 +37,9 @@ use std::io::BufReader;
 use std::rc::Rc;
 
 fn main() {
+    #[cfg(target_os = "windows")]
+    ansi_term::enable_ansi_support().is_ok();
+
     let mut args = env::args();
     args.next(); // skip library
 
@@ -128,9 +132,6 @@ fn build_executor() -> CommandExecutor {
 }
 
 fn execute_stdin(command_executor: CommandExecutor) {
-    #[cfg(target_os = "windows")]
-    ansi_term::enable_ansi_support().is_ok();
-
     match Reader::new("indy-cli") {
         Ok(reader) => execute_interactive(command_executor, reader),
         Err(_) => execute_batch(&command_executor, None),

--- a/cli/src/utils/term.rs
+++ b/cli/src/utils/term.rs
@@ -1,24 +1,54 @@
+use atty;
+
 #[macro_export]
 macro_rules! println_err {
-    ($($arg:tt)*) => ( println!("{}", $crate::ansi_term::Color::Red.bold().paint(format!($($arg)*))) )
+    ($($arg:tt)*) => (
+        if $crate::utils::term::is_term() {
+            println!("{}", $crate::ansi_term::Color::Red.bold().paint(format!($($arg)*)))
+        } else {
+            println!($($arg)*)
+        }
+    )
 }
 
 #[macro_export]
 macro_rules! println_succ {
-    ($($arg:tt)*) => ( println!("{}", $crate::ansi_term::Color::Green.bold().paint(format!($($arg)*))) )
+    ($($arg:tt)*) => (
+        if $crate::utils::term::is_term() {
+            println!("{}", $crate::ansi_term::Color::Green.bold().paint(format!($($arg)*)))
+        } else {
+            println!($($arg)*)
+        }
+    )
 }
 #[macro_export]
 macro_rules! println_warn {
-    ($($arg:tt)*) => ( println!("{}", $crate::ansi_term::Color::Blue.bold().paint(format!($($arg)*))) )
+    ($($arg:tt)*) => (
+        if $crate::utils::term::is_term() {
+            println!("{}", $crate::ansi_term::Color::Blue.bold().paint(format!($($arg)*)))
+        } else {
+            println!($($arg)*)
+        }
+    )
 }
 
 #[macro_export]
 macro_rules! println_acc {
-    ($($arg:tt)*) => ( println!("{}", $crate::ansi_term::Style::new().bold().paint(format!($($arg)*))) )
+    ($($arg:tt)*) => (
+       if $crate::utils::term::is_term() {
+           println!("{}", $crate::ansi_term::Style::new().bold().paint(format!($($arg)*)))
+       } else {
+           println!($($arg)*)
+       }
+    )
 }
 
 // TODO: move to more relevant place
 #[macro_export]
 macro_rules! map_println_err {
     ($($arg:tt)*) => ( |err| println_err!("{}: {}", $($arg)*, err) )
+}
+
+pub fn is_term() -> bool {
+    atty::is(atty::Stream::Stdout)
 }


### PR DESCRIPTION
* Initialize ansi_term from the very beginning
* Check that stdout is terminal in printing macros and disable colors otherwise