### PR TITLE
Refactor Inmem storage shared library and Update unit tests to run against dynamic library

### DIFF
--- a/libindy/Cargo.lock
+++ b/libindy/Cargo.lock
@@ -1,5 +1,13 @@
 [[package]]
 name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -291,6 +299,11 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -432,6 +445,7 @@ dependencies = [
  "named_type 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "named_type_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "os_type 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -442,6 +456,7 @@ dependencies = [
  "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sharedlib 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -590,6 +605,14 @@ dependencies = [
 
 [[package]]
 name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -732,6 +755,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_type"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +851,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -841,6 +884,11 @@ dependencies = [
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
@@ -982,6 +1030,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharedlib"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "simplelog"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,9 +1154,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread-scoped"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "thread_local"
@@ -1155,6 +1231,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "utf8-ranges"
@@ -1241,6 +1322,7 @@ dependencies = [
 ]
 
 [metadata]
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum amcl 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a555cfaa0e641430ad130ad6cac857cf494a7a02964720fe5a73e5e7a548b39"
 "checksum android_log-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8052e2d8aabbb8d556d6abbcce2a22b9590996c5f849b9c7ce4544a2e3b984e"
@@ -1277,6 +1359,7 @@ dependencies = [
 "checksum env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0e6e40ebb0e66918a37b38c7acab4e10d299e0463fe2af5d29b9cc86710cfd2a"
 "checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e92ecf0a508c8e074c0e6fa8fe0fa38414848ad4dfc4db6f74c5e9753330b248"
 "checksum etcommon-hexutil 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f004de816005d210e0af76640ade09b78aa0b6e7065ddb627782374ccd299f8a"
 "checksum etcommon-rlp 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4d8ea61b03717f963c7a49403499135e05e1c23269882b8ab4d1e98668317254"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
@@ -1309,6 +1392,7 @@ dependencies = [
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum log-panics 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae0136257df209261daa18d6c16394757c63e032e27aafd8b07788b051082bef"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
 "checksum named_type 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b019f6b44ee806be42058acc23c38aa173a14dc396390562d98a9965e564cf20"
@@ -1325,6 +1409,7 @@ dependencies = [
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-sys 0.9.31 (registry+https://github.com/rust-lang/crates.io-index)" = "a4d6a27d108b29befe1822d40e2e22f85518dac59acbf7f30fdc532f48fd0a77"
+"checksum os_type 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b86e98f6ba3e51ab565f507fee357e90544ddd8548e587786d25e4e906648461"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0fce5d8b5cc33983fc74f78ad552b5522ab41442c4ca91606e4236eb4b5ceefc"
 "checksum pest_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3294f437119209b084c797604295f40227cffa35c57220b1e99a6ff3bf8ee4"
@@ -1337,8 +1422,10 @@ dependencies = [
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
 "checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
@@ -1355,6 +1442,7 @@ dependencies = [
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
 "checksum sha3 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b64dcef59ed4290b9fb562b53df07f564690d6539e8ecdd4728cf392477530bc"
+"checksum sharedlib 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1ab7ad123216d2b04448d3b31edd7e5314b500012b2b01812245725536df2c"
 "checksum simplelog 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9cc12b39fdf4c9a07f88bffac2d628f0118ed5ac077a4b0feece61fadf1429e5"
 "checksum sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb5cb2f14f9a51352ad65e59257a0a9459d5a36a3615f3d53a974c82fdaaa00a"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
@@ -1368,7 +1456,9 @@ dependencies = [
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
@@ -1378,6 +1468,7 @@ dependencies = [
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"

--- a/libindy/Cargo.toml
+++ b/libindy/Cargo.toml
@@ -75,6 +75,9 @@ named_type = "0.1.3"
 named_type_derive = "0.1.3"
 byteorder = "1.0.0"
 log-panics = "2.0.0"
+sharedlib = "7.0.0"
+os_type="1.0.0"
+
 [dependencies.uuid]
 version = "0.5.0"
 default-features = false

--- a/libindy/src/lib.rs
+++ b/libindy/src/lib.rs
@@ -35,6 +35,9 @@ extern crate rusqlite;
 #[macro_use]
 extern crate derivative;
 
+extern crate sharedlib;
+extern crate os_type;
+
 // Note that to use macroses from util inside of other modules it must me loaded first!
 #[macro_use]
 mod utils;

--- a/libindy/tests/anoncreds.rs
+++ b/libindy/tests/anoncreds.rs
@@ -76,6 +76,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let invalid_wallet_handle = wallet_handle + 100;
             let res = anoncreds::issuer_create_credential_definition(invalid_wallet_handle,
@@ -103,6 +104,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let invalid_wallet_handle = wallet_handle + 100;
             let res = anoncreds::issuer_create_credential_offer(invalid_wallet_handle,
@@ -126,6 +128,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let invalid_wallet_handle = wallet_handle + 100;
             let res = anoncreds::prover_create_master_secret(invalid_wallet_handle, COMMON_MASTER_SECRET);
@@ -148,6 +151,7 @@ mod high_cases {
             let (credential_def, credential_offer, _, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let invalid_wallet_handle = wallet_handle + 100;
             let res = anoncreds::prover_create_credential_req(invalid_wallet_handle,
@@ -165,6 +169,7 @@ mod high_cases {
             let (issuer1_gvt_credential_def, issuer1_gvt_credential_offer, _, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let mut issuer_create_credential_offer: serde_json::Value = serde_json::from_str(&issuer1_gvt_credential_offer).unwrap();
             issuer_create_credential_offer["key_correctness_proof"]["c"] = serde_json::Value::String("11111111".to_string());
@@ -195,6 +200,7 @@ mod high_cases {
             let (_, credential_offer, credential_req, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::issuer_create_credential(wallet_handle,
                                                           &credential_offer,
@@ -212,6 +218,7 @@ mod high_cases {
             let (_, credential_offer, credential_req, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let invalid_wallet_handle = wallet_handle + 100;
             let res = anoncreds::issuer_create_credential(invalid_wallet_handle,
@@ -239,6 +246,8 @@ mod high_cases {
             let (credential_def_json, credential_offer, _, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
+
             let prover_wallet_handle = wallet::create_and_open_default_wallet().unwrap();
 
             anoncreds::prover_create_master_secret(prover_wallet_handle, COMMON_MASTER_SECRET).unwrap();
@@ -278,6 +287,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let credentials = anoncreds::prover_get_credentials(wallet_handle, r#"{}"#).unwrap();
             println!("!!!!\n{}", credentials);
@@ -297,6 +307,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let filter_json = json!({"issuer_did": ISSUER_DID}).to_string();
             let credentials = anoncreds::prover_get_credentials(wallet_handle, &filter_json).unwrap();
@@ -314,6 +325,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let filter = json!({"schema_id": anoncreds::gvt_schema_id()}).to_string();
 
@@ -332,6 +344,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let credentials = anoncreds::prover_get_credentials(wallet_handle, &format!(r#"{{"schema_name":"{}"}}"#, GVT_SCHEMA_NAME)).unwrap();
             let credentials: Vec<CredentialInfo> = serde_json::from_str(&credentials).unwrap();
@@ -348,6 +361,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let credentials = anoncreds::prover_get_credentials(wallet_handle, &format!(r#"{{"schema_version":"{}"}}"#, SCHEMA_VERSION)).unwrap();
             let credentials: Vec<CredentialInfo> = serde_json::from_str(&credentials).unwrap();
@@ -365,6 +379,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let credentials = anoncreds::prover_get_credentials(wallet_handle, &format!(r#"{{"schema_issuer_did":"{}"}}"#, ISSUER_DID)).unwrap();
             let credentials: Vec<CredentialInfo> = serde_json::from_str(&credentials).unwrap();
@@ -382,6 +397,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let filter = json!({"cred_def_id": anoncreds::issuer_1_gvt_cred_def_id()}).to_string();
 
@@ -399,6 +415,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let credentials = anoncreds::prover_get_credentials(wallet_handle, r#"{"cred_def_id":"other_cred_def_id"}"#).unwrap();
             let credentials: Vec<CredentialInfo> = serde_json::from_str(&credentials).unwrap();
@@ -413,6 +430,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let invalid_wallet_handle = wallet_handle + 100;
             let res = anoncreds::prover_get_credentials(invalid_wallet_handle, r#"{}"#);
@@ -430,6 +448,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let credential = anoncreds::prover_get_credential(wallet_handle, CREDENTIAL1_ID).unwrap();
             let credential: CredentialInfo = serde_json::from_str(&credential).unwrap();
@@ -443,6 +462,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::prover_get_credential(wallet_handle, "other_cred_id");
             assert_eq!(ErrorCode::WalletItemNotFound, res.unwrap_err());
@@ -459,6 +479,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let (search_handle, count) = anoncreds::prover_search_credentials(wallet_handle, "{}").unwrap();
             assert_eq!(count, 3);
@@ -480,6 +501,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let filter_json = json!({"issuer_did": ISSUER_DID}).to_string();
             let (search_handle, count) = anoncreds::prover_search_credentials(wallet_handle, &filter_json).unwrap();
@@ -501,6 +523,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let filter_json = json!({"schema_id": anoncreds::gvt_schema_id()}).to_string();
             let (search_handle, count) = anoncreds::prover_search_credentials(wallet_handle, &filter_json).unwrap();
@@ -522,6 +545,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let filter_json = json!({
                 "schema_id": anoncreds::gvt_schema_id(),
@@ -546,6 +570,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let filter_json = json!({
                 "schema_id": json!({
@@ -573,6 +598,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let filter_json = json!({
                 "$or": vec![
@@ -601,6 +627,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let filter_json = json!({"other_field": "other_value"}).to_string();
 
@@ -628,6 +655,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -651,6 +679,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -681,6 +710,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -710,6 +740,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -742,6 +773,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -773,6 +805,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -803,6 +836,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -833,6 +867,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -863,6 +898,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -893,6 +929,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -923,6 +960,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -953,6 +991,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -983,6 +1022,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1013,6 +1053,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1043,6 +1084,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1073,6 +1115,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1104,6 +1147,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1135,6 +1179,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1166,6 +1211,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = r#"{
                    "nonce":"123432421212",
@@ -1210,6 +1256,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1241,6 +1288,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1275,6 +1323,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1305,6 +1354,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1335,6 +1385,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1365,6 +1416,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1395,6 +1447,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1430,6 +1483,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1464,6 +1518,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1494,6 +1549,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1528,6 +1584,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1561,6 +1618,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1596,6 +1654,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1627,6 +1686,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1658,6 +1718,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1690,6 +1751,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -1718,6 +1780,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -1745,6 +1808,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -1775,6 +1839,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1802,6 +1867,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1830,6 +1896,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1858,6 +1925,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1886,6 +1954,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1914,6 +1983,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1942,6 +2012,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1970,6 +2041,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -1998,6 +2070,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2029,6 +2102,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2061,6 +2135,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2097,6 +2172,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2129,6 +2205,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2165,6 +2242,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2197,6 +2275,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2233,6 +2312,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2268,6 +2348,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2300,6 +2381,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2333,6 +2415,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -2379,6 +2462,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -2408,6 +2492,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -2437,6 +2522,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -2466,6 +2552,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let invalid_wallet_handle = wallet_handle + 100;
             let res = anoncreds::prover_get_credentials_for_proof_req(invalid_wallet_handle, &anoncreds::proof_request_attr());
@@ -2483,6 +2570,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -2515,6 +2603,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -2551,6 +2640,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -2590,6 +2680,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                        "nonce":"123432421212",
@@ -2628,6 +2719,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                        "nonce":"123432421212",
@@ -2668,6 +2760,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                        "nonce":"123432421212",
@@ -2706,6 +2799,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                        "nonce":"123432421212",
@@ -2744,6 +2838,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2783,6 +2878,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2822,6 +2918,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                    "nonce":"123432421212",
@@ -2884,6 +2981,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                        "nonce":"123432421212",
@@ -2929,6 +3027,7 @@ mod high_cases {
                 anoncreds::init_common_wallet();
 
                 let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
                 let proof_req = json!({
                        "nonce":"123432421212",
@@ -2983,6 +3082,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let requested_credentials_json = json!({
                  "self_attested_attributes": json!({}),
@@ -3010,6 +3110,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -3048,6 +3149,7 @@ mod high_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let requested_credentials_json = json!({
                  "self_attested_attributes": json!({}),
@@ -3158,6 +3260,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let schema = r#"{"name":"name","version":"1.0", "attr_names":["name"]}"#;
 
@@ -3177,6 +3280,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::issuer_create_credential_definition(wallet_handle,
                                                                      INVALID_IDENTIFIER,
@@ -3194,6 +3298,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let mut schema = anoncreds::gvt_schema();
             schema.attr_names = HashSet::new();
@@ -3228,6 +3333,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::issuer_create_credential_definition(wallet_handle,
                                                                      ISSUER_DID,
@@ -3245,6 +3351,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::issuer_create_credential_definition(wallet_handle,
                                                                      ISSUER_DID,
@@ -3262,6 +3369,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::issuer_create_credential_definition(wallet_handle,
                                                                      ISSUER_DID,
@@ -3296,6 +3404,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::issuer_create_credential_offer(wallet_handle, "unknown_cred_def_id");
             assert_eq!(res.unwrap_err(), ErrorCode::WalletItemNotFound);
@@ -3312,6 +3421,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::prover_create_master_secret(wallet_handle, COMMON_MASTER_SECRET);
             assert_eq!(res.unwrap_err(), ErrorCode::AnoncredsMasterSecretDuplicateNameError);
@@ -3328,6 +3438,7 @@ mod medium_cases {
             let (credential_def, _, _, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::prover_create_credential_req(wallet_handle,
                                                               DID_MY1,
@@ -3344,6 +3455,7 @@ mod medium_cases {
             let (_, credential_offer, _, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let credential_def = r#"{
                             "schema_seq_no":1,
@@ -3368,6 +3480,7 @@ mod medium_cases {
             let (credential_def, credential_offer, _, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::prover_create_credential_req(wallet_handle,
                                                               DID_MY1,
@@ -3388,6 +3501,7 @@ mod medium_cases {
             let (_, credential_offer, _, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let credential_req = r#"{
                                         "blinded_ms":{"ur":null},
@@ -3410,6 +3524,7 @@ mod medium_cases {
             let (_, credential_offer, credential_request, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let credential_values_json = r#"{
                                            "sex":"male",
@@ -3438,6 +3553,7 @@ mod medium_cases {
             let (credential_def_json, credential_offer, _, _) = anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let (_, cred_req_metadata) = anoncreds::prover_create_credential_req(wallet_handle,
                                                                                  DID_MY1,
@@ -3471,6 +3587,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let res = anoncreds::prover_get_credentials(wallet_handle, r#""issuer_did": 12345"#);
             assert_eq!(res.unwrap_err(), ErrorCode::WalletQueryError);
@@ -3487,6 +3604,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -3506,6 +3624,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -3528,6 +3647,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let proof_req = json!({
                "nonce":"123432421212",
@@ -3554,6 +3674,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let requested_credentials_json = json!({
                  "self_attested_attributes": json!({}),
@@ -3580,6 +3701,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let requested_credentials_json = json!({
                  "self_attested_attributes": json!({}),
@@ -3606,6 +3728,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let requested_credentials_json = json!({
                  "self_attested_attributes": json!({}),
@@ -3632,6 +3755,7 @@ mod medium_cases {
             anoncreds::init_common_wallet();
 
             let wallet_handle = wallet::open_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let _w_h_wrapper = wallet::WalletHandleWrapper { handle: wallet_handle };
 
             let requested_credentials_json = json!({
                  "self_attested_attributes": json!({}),
@@ -3812,6 +3936,7 @@ mod demos {
 
         wallet::create_wallet(&issuer_wallet_config, WALLET_CREDENTIALS).unwrap();
         let issuer_wallet_handle = wallet::open_wallet(&issuer_wallet_config, WALLET_CREDENTIALS).unwrap();
+        let _w_h_wrapper1 = wallet::WalletHandleWrapper { handle: issuer_wallet_handle };
 
         //3. Creates and opens Prover wallet
         let prover_wallet_config = json!({
@@ -3821,6 +3946,7 @@ mod demos {
 
         wallet::create_wallet(&prover_wallet_config, WALLET_CREDENTIALS).unwrap();
         let prover_wallet_handle = wallet::open_wallet(&prover_wallet_config, WALLET_CREDENTIALS).unwrap();
+        let _w_h_wrapper2 = wallet::WalletHandleWrapper { handle: prover_wallet_handle };
 
         //4. Issuer creates Schema and Credential Definition
         let (schema_id, schema_json, cred_def_id, cred_def_json) = anoncreds::multi_steps_issuer_preparation(issuer_wallet_handle,

--- a/libindy/tests/utils/anoncreds.rs
+++ b/libindy/tests/utils/anoncreds.rs
@@ -747,6 +747,9 @@ pub fn init_common_wallet() -> (&'static str, &'static str, &'static str, &'stat
         COMMON_WALLET_INIT.call_once(|| {
             test::cleanup_storage();
 
+            // delete wallet if exists, just to be sure!  (don't bother to validate)
+            let _res = wallet::delete_wallet(ANONCREDS_WALLET_CONFIG, WALLET_CREDENTIALS);
+
             pool::set_protocol_version(PROTOCOL_VERSION).unwrap();
 
             //1. Create and Open wallet

--- a/libindy/tests/utils/mod.rs
+++ b/libindy/tests/utils/mod.rs
@@ -42,12 +42,18 @@ pub mod inmem_wallet;
 #[path = "../../src/domain/mod.rs"]
 pub mod domain;
 
+use self::constants::{WALLET_CONFIG, WALLET_CREDENTIALS};
+
 pub fn setup() {
+    // delete wallet if exists, just to be sure!  (don't bother to validate)
+    let _res = wallet::delete_wallet(WALLET_CONFIG, WALLET_CREDENTIALS);
     test::cleanup_storage();
     logger::set_default_logger();
 }
 
 pub fn tear_down() {
+    // delete wallet if exists, just to be sure!  (don't bother to validate)
+    let _res = wallet::delete_wallet(WALLET_CONFIG, WALLET_CREDENTIALS);
     test::cleanup_storage();
 }
 

--- a/libindy/tests/utils/wallet.rs
+++ b/libindy/tests/utils/wallet.rs
@@ -1,10 +1,18 @@
+extern crate sharedlib;
+extern crate base64;
+
+use self::sharedlib::{Lib, Func, Symbol};
+
 use indy::api::ErrorCode;
 use indy::api::wallet::*;
 
 use utils::{callback, sequence, environment, ctypes};
 use utils::inmem_wallet::InmemWallet;
+use utils::domain::wallet::{Config, Credentials};
 
 use std::collections::HashSet;
+use std::collections::HashMap;
+use std::env;
 use std::ffi::CString;
 use std::sync::Mutex;
 use std::ptr::null;
@@ -13,6 +21,8 @@ use utils::constants::{TYPE, INMEM_TYPE, WALLET_CREDENTIALS};
 use std::path::{Path, PathBuf};
 
 use serde_json;
+use serde_json::Value;
+
 
 pub fn register_wallet_storage(xtype: &str, force_create: bool) -> Result<(), ErrorCode> {
     lazy_static! {
@@ -68,6 +78,8 @@ pub fn register_wallet_storage(xtype: &str, force_create: bool) -> Result<(), Er
 pub fn create_wallet(config: &str, credentials: &str) -> Result<(), ErrorCode> {
     let (receiver, command_handle, cb) = callback::_closure_to_cb_ec();
 
+    let (config, credentials) = override_wallet_config_creds(config, credentials, true);
+
     let config = CString::new(config).unwrap();
     let credentials = CString::new(credentials).unwrap();
 
@@ -82,6 +94,8 @@ pub fn create_wallet(config: &str, credentials: &str) -> Result<(), ErrorCode> {
 
 pub fn open_wallet(config: &str, credentials: &str) -> Result<i32, ErrorCode> {
     let (receiver, command_handle, cb) = callback::_closure_to_cb_ec_i32();
+
+    let (config, credentials) = override_wallet_config_creds(config, credentials, false);
 
     let config = CString::new(config).unwrap();
     let credentials = CString::new(credentials).unwrap();
@@ -129,6 +143,8 @@ pub fn create_and_open_plugged_wallet() -> Result<i32, ErrorCode> {
 pub fn delete_wallet(config: &str, credentials: &str) -> Result<(), ErrorCode> {
     let (receiver, command_handle, cb) = callback::_closure_to_cb_ec();
 
+    let (config, credentials) = override_wallet_config_creds(config, credentials, false);
+
     let config = CString::new(config).unwrap();
     let credentials = CString::new(credentials).unwrap();
 
@@ -143,6 +159,20 @@ pub fn close_wallet(wallet_handle: i32) -> Result<(), ErrorCode> {
     let err = indy_close_wallet(command_handle, wallet_handle, cb);
 
     super::results::result_to_empty(err, receiver)
+}
+
+/* 
+ * Wrapper to ensure a wallet is closed when it goes out of scope
+ * (i.e. if the unit test didn't shut down cleanly)
+ */
+pub struct WalletHandleWrapper {
+    pub handle: i32,
+}
+impl ::std::ops::Drop for WalletHandleWrapper {
+    fn drop(&mut self) {
+        // close wallet; ignore result in case we are closing it twice
+        let _res = close_wallet(self.handle);
+    }
 }
 
 pub fn export_wallet(wallet_handle: i32, export_config_json: &str) -> Result<(), ErrorCode> {
@@ -194,4 +224,243 @@ pub fn generate_wallet_key(config: Option<&str>) -> Result<String, ErrorCode> {
                                  cb);
 
     super::results::result_to_string(err, receiver)
+}
+
+/*
+ * Update wallet config based on supplied configuration,
+ *     *only if* "storage_type" is not already provided.
+ */
+pub fn override_wallet_config_creds(config: &str, credentials: &str, load_dynalib: bool) -> (String, String) {
+    // if storge_type is explicit then bail
+    let check_config: Config = serde_json::from_str(config).unwrap();
+    if let Some(_) = check_config.storage_type {
+        return (config.to_owned(), credentials.to_owned());
+    }
+
+    // if no config is provided at all then bail
+    let storage_config = wallet_storage_overrides();
+    if !any_overrides(&storage_config) {
+        return (config.to_owned(), credentials.to_owned());
+    }
+
+    // load dynamic library if requested
+    if load_dynalib {
+        load_storage_library_config(&storage_config).unwrap();
+    }
+
+    // update config and credentials
+    let config = override_wallet_configuration(config, &storage_config);
+    let credentials = override_wallet_credentials(credentials, &storage_config);
+
+    return (config, credentials);
+}
+
+/*
+ * Dynamically loads the specified library and registers storage
+ */
+pub fn load_storage_library(stg_type: &str, library_path: &str, fn_pfx: &str) -> Result<(), ErrorCode> {
+    println!("Loading {} {} {}", stg_type, library_path, fn_pfx);
+    lazy_static! {
+            static ref STG_REGISERED_WALLETS: Mutex<HashMap<String, Lib>> = Default::default();
+        }
+
+    let mut wallets = STG_REGISERED_WALLETS.lock().unwrap();
+
+    if wallets.contains_key(stg_type) {
+        // as registering of plugged wallet with
+        return Ok(());
+    }
+
+    let (receiver, command_handle, cb) = callback::_closure_to_cb_ec();
+
+    let xxtype = CString::new(stg_type).unwrap();
+
+    let err;
+    let lib;
+    let lib_path = Path::new(library_path);
+    unsafe {
+        println!("Loading {:?}", lib_path);
+        lib = match Lib::new(lib_path) {
+            Ok(rlib) => {
+                println!("Loaded lib");
+                rlib
+            },
+            Err(err) => {
+                println!("Load error {:?}", err);
+                panic!("Load error {:?}", err)
+            }
+        };
+
+        println!("Get fn pointers ...");
+        let fn_create_handler: Func<WalletCreate> = lib.find_func(&format!("{}create", fn_pfx)).unwrap();
+        let fn_open_handler: Func<WalletOpen> = lib.find_func(&format!("{}open", fn_pfx)).unwrap();
+        let fn_close_handler: Func<WalletClose> = lib.find_func(&format!("{}close", fn_pfx)).unwrap();
+        let fn_delete_handler: Func<WalletDelete> = lib.find_func(&format!("{}delete", fn_pfx)).unwrap();
+        let fn_add_record_handler: Func<WalletAddRecord> = lib.find_func(&format!("{}add_record", fn_pfx)).unwrap();
+        let fn_update_record_value_handler: Func<WalletUpdateRecordValue> = lib.find_func(&format!("{}update_record_value", fn_pfx)).unwrap();
+        let fn_update_record_tags_handler: Func<WalletUpdateRecordTags> = lib.find_func(&format!("{}update_record_tags", fn_pfx)).unwrap();
+        let fn_add_record_tags_handler: Func<WalletAddRecordTags> = lib.find_func(&format!("{}add_record_tags", fn_pfx)).unwrap();
+        let fn_delete_record_tags_handler: Func<WalletDeleteRecordTags> = lib.find_func(&format!("{}delete_record_tags", fn_pfx)).unwrap();
+        let fn_delete_record_handler: Func<WalletDeleteRecord> = lib.find_func(&format!("{}delete_record", fn_pfx)).unwrap();
+        let fn_get_record_handler: Func<WalletGetRecord> = lib.find_func(&format!("{}get_record", fn_pfx)).unwrap();
+        let fn_get_record_id_handler: Func<WalletGetRecordId> = lib.find_func(&format!("{}get_record_id", fn_pfx)).unwrap();
+        let fn_get_record_type_handler: Func<WalletGetRecordType> = lib.find_func(&format!("{}get_record_type", fn_pfx)).unwrap();
+        let fn_get_record_value_handler: Func<WalletGetRecordValue> = lib.find_func(&format!("{}get_record_value", fn_pfx)).unwrap();
+        let fn_get_record_tags_handler: Func<WalletGetRecordTags> = lib.find_func(&format!("{}get_record_tags", fn_pfx)).unwrap();
+        let fn_free_record_handler: Func<WalletFreeRecord> = lib.find_func(&format!("{}free_record", fn_pfx)).unwrap();
+        let fn_get_storage_metadata_handler: Func<WalletGetStorageMetadata> = lib.find_func(&format!("{}get_storage_metadata", fn_pfx)).unwrap();
+        let fn_set_storage_metadata_handler: Func<WalletSetStorageMetadata> = lib.find_func(&format!("{}set_storage_metadata", fn_pfx)).unwrap();
+        let fn_free_storage_metadata_handler: Func<WalletFreeStorageMetadata> = lib.find_func(&format!("{}free_storage_metadata", fn_pfx)).unwrap();
+        let fn_search_records_handler: Func<WalletSearchRecords> = lib.find_func(&format!("{}search_records", fn_pfx)).unwrap();
+        let fn_search_all_records_handler: Func<WalletSearchAllRecords> = lib.find_func(&format!("{}search_all_records", fn_pfx)).unwrap();
+        let fn_get_search_total_count_handler: Func<WalletGetSearchTotalCount> = lib.find_func(&format!("{}get_search_total_count", fn_pfx)).unwrap();
+        let fn_fetch_search_next_record_handler: Func<WalletFetchSearchNextRecord> = lib.find_func(&format!("{}fetch_search_next_record", fn_pfx)).unwrap();
+        let fn_free_search_handler: Func<WalletFreeSearch> = lib.find_func(&format!("{}free_search", fn_pfx)).unwrap();
+
+        println!("Register wallet ...");
+        err = indy_register_wallet_storage(
+            command_handle,
+            xxtype.as_ptr(),
+            Some(fn_create_handler.get()),
+            Some(fn_open_handler.get()),
+            Some(fn_close_handler.get()),
+            Some(fn_delete_handler.get()),
+            Some(fn_add_record_handler.get()),
+            Some(fn_update_record_value_handler.get()),
+            Some(fn_update_record_tags_handler.get()),
+            Some(fn_add_record_tags_handler.get()),
+            Some(fn_delete_record_tags_handler.get()),
+            Some(fn_delete_record_handler.get()),
+            Some(fn_get_record_handler.get()),
+            Some(fn_get_record_id_handler.get()),
+            Some(fn_get_record_type_handler.get()),
+            Some(fn_get_record_value_handler.get()),
+            Some(fn_get_record_tags_handler.get()),
+            Some(fn_free_record_handler.get()),
+            Some(fn_get_storage_metadata_handler.get()),
+            Some(fn_set_storage_metadata_handler.get()),
+            Some(fn_free_storage_metadata_handler.get()),
+            Some(fn_search_records_handler.get()),
+            Some(fn_search_all_records_handler.get()),
+            Some(fn_get_search_total_count_handler.get()),
+            Some(fn_fetch_search_next_record_handler.get()),
+            Some(fn_free_search_handler.get()),
+            cb
+        );
+    }
+
+    println!("Finish up ...");
+    wallets.insert(stg_type.to_string(), lib);
+
+    super::results::result_to_empty(err, receiver)
+}
+
+/*
+ * Dynamically loads the specified library and registers storage, based on provided config
+ */
+pub fn load_storage_library_config(storage_config: &HashMap<String, Option<String>>) -> Result<(), ErrorCode> {
+    match storage_config.get("STG_LIB") {
+        Some(slibrary) => match slibrary {
+            Some(library) => {
+                let stg_type: String = match storage_config.get("STG_TYPE") {
+                    Some(styp) => match styp {
+                        Some(typ) => typ.clone(),
+                        None => "".to_string()
+                    },
+                    None => "".to_string()
+                };
+                let fn_pfx: String = match storage_config.get("STG_FN_PREFIX") {
+                    Some(spfx) => match spfx {
+                        Some(pfx) => pfx.clone(),
+                        None => "".to_string()
+                    },
+                    None => "".to_string()
+                };
+                load_storage_library(&stg_type[..], &library[..], &fn_pfx[..])
+            },
+            None => Ok(())
+        },
+        None => Ok(())
+    }
+}
+
+/*
+ * Update the given configuration string based on supplied overrides
+ */
+pub fn override_wallet_configuration(config: &str, overrides: &HashMap<String, Option<String>>) -> String {
+    let mut config: Config = serde_json::from_str(config).unwrap();
+
+    match overrides.get("STG_TYPE") {
+        Some(stype) => match stype {
+            Some(wtype) => {
+                config.storage_type = Some(wtype.clone());
+            },
+            None => ()
+        },
+        None => ()
+    }
+    match overrides.get("STG_CONFIG") {
+        Some(sconfig) => match sconfig {
+            Some(wconfig) => {
+                let v: Value = serde_json::from_str(&wconfig[..]).unwrap();
+                config.storage_config = Some(v.clone());
+            },
+            None => ()
+        },
+        None => ()
+    }
+
+    serde_json::to_string(&config).unwrap()
+}
+
+/*
+ * Update the given credentials string based on supplied overrides
+ */
+pub fn override_wallet_credentials(creds: &str, overrides: &HashMap<String, Option<String>>) -> String {
+    let mut creds: Credentials = serde_json::from_str(creds).unwrap();
+
+    match overrides.get("STG_CREDS") {
+        Some(screds) => match screds {
+            Some(wcreds) => {
+                let v: Value = serde_json::from_str(&wcreds[..]).unwrap();
+                creds.storage_credentials = Some(v.clone());
+            },
+            None => ()
+        },
+        None => ()
+    }
+
+    serde_json::to_string(&creds).unwrap()
+}
+
+/*
+ * Returns wallet storage configuation dynamically configured via environment variables:
+ * STG_CONFIG - json configuration string to pass to the wallet on creation and open
+ * STG_CREDS - json credentials string to pass to the wallet on creation and open
+ * STG_TYPE - storage type to create
+ * STG_LIB - c-callable library to load (contains a plug-in storage)
+ *             - if specified will dynamically load and register a wallet storage
+ * STG_FN_PREFIX - prefix for all plug-in functions (allows standard function naming)
+ */
+pub fn wallet_storage_overrides() -> HashMap<String, Option<String>> {
+    let mut storage_config = HashMap::new();
+    let env_vars = vec!["STG_CONFIG", "STG_CREDS", "STG_TYPE", "STG_LIB", "STG_FN_PREFIX"];
+
+    for env_var in env_vars.iter() {
+        match env::var(env_var) {
+            Ok(var) => storage_config.insert(env_var.to_string(), Some(var.to_string())),
+            Err(_) => storage_config.insert(env_var.to_string(), None)
+        };
+    }
+
+    storage_config
+}
+
+pub fn any_overrides(storage_config: &HashMap<String, Option<String>>) -> bool {
+    for (_key, val) in storage_config {
+        if let Some(_) = val {
+            return true;
+        }
+    }
+    return false;
 }

--- a/libindy/tests/wallet.rs
+++ b/libindy/tests/wallet.rs
@@ -22,6 +22,7 @@ extern crate rmp_serde;
 extern crate rust_base58;
 extern crate time;
 extern crate serde;
+extern crate os_type;
 
 // Workaround to share some utils code based on indy sdk types between tests and indy sdk
 use indy::api as api;
@@ -737,9 +738,145 @@ mod medium_cases {
     }
 }
 
+mod dynamic_storage_cases {
+    extern crate libc;
+
+    use super::*;
+    use std::env;
+    use std::collections::HashMap;
+    use utils::domain::wallet::{Config, Credentials};
+    use serde_json::Value;
+
+    mod configure_wallet_storage {
+        use super::*;
+
+        fn save_config_overrides() -> HashMap<String, Option<String>> {
+            // save (and clear) existing vars
+            let hs_keep = utils::wallet::wallet_storage_overrides();
+            for (key, _val) in hs_keep.iter() {
+                env::remove_var(key);
+            }
+            hs_keep
+        }
+
+        fn restore_config_overrides(hs_keep: HashMap<String, Option<String>>) {
+            // restore original vars
+            for (key, val) in hs_keep.iter() {
+                match val {
+                    Some(hval) => env::set_var(key, hval),
+                    None => ()
+                }
+            }
+        }
+
+        fn some_test_overrides() -> HashMap<String, Option<String>> {
+            let mut storage_config = HashMap::new();
+            let env_vars = vec!["STG_CONFIG", "STG_CREDS", "STG_TYPE", "STG_LIB", "STG_FN_PREFIX"];
+            storage_config.insert(env_vars[0].to_string(), Some(r#"{"conf1":"key1", "conf2":"key2"}"#.to_string()));
+            storage_config.insert(env_vars[1].to_string(), Some(r#"{"account":"key1", "password":"key2"}"#.to_string()));
+            storage_config.insert(env_vars[2].to_string(), Some("type1".to_string()));
+            storage_config.insert(env_vars[3].to_string(), Some("./a/library.so".to_string()));
+            storage_config.insert(env_vars[4].to_string(), Some("my_fn_".to_string()));
+            storage_config
+        }
+
+        fn inmem_lib_test_overrides() -> HashMap<String, Option<String>> {
+            // Note - on OS/X we specify the fully qualified path to the shared lib
+            //      - on UNIX systems we have to include the directories in LD_LIBRARY_PATH, e.g.:
+            //      export LD_LIBRARY_PATH=../samples/storage/storage-inmem/target/debug/:./target/debug/
+            let os = os_type::current_platform();
+            let osfile = match os.os_type {
+                os_type::OSType::OSX => "../samples/storage/storage-inmem/target/debug/libindystrginmem.dylib",
+                _ => "libindystrginmem.so"
+            };
+
+            let mut storage_config = HashMap::new();
+            let env_vars = vec!["STG_CONFIG", "STG_CREDS", "STG_TYPE", "STG_LIB", "STG_FN_PREFIX"];
+            storage_config.insert(env_vars[0].to_string(), None);
+            storage_config.insert(env_vars[1].to_string(), None);
+            storage_config.insert(env_vars[2].to_string(), Some("inmem_custom".to_string()));
+            storage_config.insert(env_vars[3].to_string(), Some(osfile.to_string()));
+            storage_config.insert(env_vars[4].to_string(), Some("inmemwallet_fn_".to_string()));
+            storage_config
+        }
+
+        #[test]
+        fn configure_wallet_works_for_case() {
+            let hs_keep = save_config_overrides();
+
+            // test we correctly pick up the values
+            env::set_var("STG_TYPE", "inmem_mylocaltest");
+            let hs = utils::wallet::wallet_storage_overrides();
+            env::remove_var("STG_TYPE");
+
+            restore_config_overrides(hs_keep);
+
+            // finally assert our test
+            assert_eq!(hs.get("STG_TYPE").unwrap(), &Some("inmem_mylocaltest".to_string()));
+        }
+
+        #[test]
+        fn override_wallet_configuration_works() {
+            let hs_vars = some_test_overrides();
+            let new_config = utils::wallet::override_wallet_configuration(&UNKNOWN_WALLET_CONFIG, &hs_vars);
+
+            let old_config: Config = serde_json::from_str(UNKNOWN_WALLET_CONFIG).unwrap();
+            let new_config: Config = serde_json::from_str(&new_config).unwrap();
+            let wconf = hs_vars.get("STG_CONFIG").as_ref().unwrap().as_ref().unwrap();
+            let v: Value = serde_json::from_str(&wconf[..]).unwrap();
+
+            assert_eq!(old_config.id, new_config.id);
+            assert_eq!(new_config.storage_config, Some(v));
+        }
+
+        #[test]
+        fn override_wallet_credentials_works() {
+            let hs_vars = some_test_overrides();
+            let new_creds = utils::wallet::override_wallet_credentials(&WALLET_CREDENTIALS_RAW, &hs_vars);
+
+            let old_creds: Credentials = serde_json::from_str(WALLET_CREDENTIALS_RAW).unwrap();
+            let new_creds: Credentials = serde_json::from_str(&new_creds).unwrap();
+            let wcreds = hs_vars.get("STG_CREDS").as_ref().unwrap().as_ref().unwrap();
+            let v: Value = serde_json::from_str(&wcreds[..]).unwrap();
+
+            assert_eq!(old_creds.key, new_creds.key);
+            assert_eq!(new_creds.storage_credentials, Some(v));
+        }
+
+        #[test]
+        fn dynaload_wallet_storage_plugin_works() {
+            utils::setup();
+
+            // load dynamic lib and set config/creds based on overrides
+            let hs_vars = inmem_lib_test_overrides();
+            println!("Testing: {:?}", hs_vars);
+            let new_config = utils::wallet::override_wallet_configuration(&UNKNOWN_WALLET_CONFIG, &hs_vars);
+            let new_creds = utils::wallet::override_wallet_credentials(&WALLET_CREDENTIALS_RAW, &hs_vars);
+            println!("Loading library ...");
+            let res = utils::wallet::load_storage_library_config(&hs_vars);
+            println!(" ... returns {:?}", res);
+
+            // confirm dynamic lib loaded ok
+            assert_eq!(res, Ok(()));
+
+            // verify wallet COCD
+            println!("Create ...");
+            wallet::create_wallet(&new_config, &new_creds).unwrap();
+            println!("Open ...");
+            let wallet_handle = wallet::open_wallet(&new_config, &new_creds).unwrap();
+            println!("Close ...");
+            wallet::close_wallet(wallet_handle).unwrap();
+            println!("Delete ...");
+            wallet::delete_wallet(&new_config, &new_creds).unwrap();
+            println!("Done!");
+
+            utils::tear_down();
+        }
+    }
+}
+
 fn _custom_path() -> String {
     let mut path = environment::tmp_path();
     path.push("custom_wallet_path");
     path.to_str().unwrap().to_owned()
 }
-

--- a/samples/storage/storage-inmem/Cargo.lock
+++ b/samples/storage/storage-inmem/Cargo.lock
@@ -1,13 +1,5 @@
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -184,11 +176,6 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -299,7 +286,6 @@ dependencies = [
  "named_type 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "named_type_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "os_type 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -310,7 +296,6 @@ dependencies = [
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sharedlib 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -360,15 +345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lazy_static"
@@ -442,14 +418,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "memchr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -584,14 +552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_type"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "owning_ref"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,18 +625,6 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -698,11 +646,6 @@ dependencies = [
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
@@ -839,17 +782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharedlib"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "sodiumoxide"
 version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,23 +887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,11 +931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "utf8-ranges"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "utf8-ranges"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1044,22 +954,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1108,7 +1008,6 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum amcl 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a555cfaa0e641430ad130ad6cac857cf494a7a02964720fe5a73e5e7a548b39"
 "checksum android_log-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8052e2d8aabbb8d556d6abbcce2a22b9590996c5f849b9c7ce4544a2e3b984e"
@@ -1134,7 +1033,6 @@ dependencies = [
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
-"checksum error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e92ecf0a508c8e074c0e6fa8fe0fa38414848ad4dfc4db6f74c5e9753330b248"
 "checksum etcommon-hexutil 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f004de816005d210e0af76640ade09b78aa0b6e7065ddb627782374ccd299f8a"
 "checksum etcommon-rlp 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4d8ea61b03717f963c7a49403499135e05e1c23269882b8ab4d1e98668317254"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -1152,7 +1050,6 @@ dependencies = [
 "checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
@@ -1163,7 +1060,6 @@ dependencies = [
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 "checksum log-panics 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae0136257df209261daa18d6c16394757c63e032e27aafd8b07788b051082bef"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
-"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d"
 "checksum metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
 "checksum named_type 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "24b5137ab6d9afa466d59b1f909170ea0f7180769fb62dd6ee165a54f3d6f48f"
@@ -1179,7 +1075,6 @@ dependencies = [
 "checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)" = "912f301a749394e1025d9dcddef6106ddee9252620e6d0a0e5f8d0681de9b129"
-"checksum os_type 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b86e98f6ba3e51ab565f507fee357e90544ddd8548e587786d25e4e906648461"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)" = "afa4d377067cc02eb5e0b491d3f7cfbe145ad4da778535bfb13c444413dd35b9"
@@ -1190,10 +1085,8 @@ dependencies = [
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
-"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
@@ -1209,7 +1102,6 @@ dependencies = [
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
 "checksum sha3 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b64dcef59ed4290b9fb562b53df07f564690d6539e8ecdd4728cf392477530bc"
-"checksum sharedlib 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1ab7ad123216d2b04448d3b31edd7e5314b500012b2b01812245725536df2c"
 "checksum sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb5cb2f14f9a51352ad65e59257a0a9459d5a36a3615f3d53a974c82fdaaa00a"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
@@ -1218,8 +1110,6 @@ dependencies = [
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum termcolor 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ff3bac0e465b59f194e7037ed404b0326e56ff234d767edc4c5cc9cd49e7a2c7"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
@@ -1227,14 +1117,11 @@ dependencies = [
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/samples/storage/storage-inmem/Cargo.lock
+++ b/samples/storage/storage-inmem/Cargo.lock
@@ -1,0 +1,1243 @@
+[[package]]
+name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "amcl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "android_log-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "android_logger"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "android_log-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "base64"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "block-buffer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "derivative"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "digest"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "digest"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "elastic-array-plus"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "env_logger"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "error-chain"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "etcommon-hexutil"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "etcommon-rlp"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic-array-plus 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-hexutil 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gcc"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "generic-array"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indy"
+version = "1.6.6"
+dependencies = [
+ "android_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-rlp 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indy-crypto 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "int_traits 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-panics 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "named_type 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "named_type_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "os_type 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sharedlib 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indy-crypto"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "amcl 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "int_traits 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "int_traits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itertools"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libsodium-sys"
+version = "0.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log-panics"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "metadeps"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "named_type"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "named_type_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "named_type 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl"
+version = "0.9.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "os_type"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "owning_ref"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rust-base58"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ryu"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "safemem"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha3"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha3"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sharedlib"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sodiumoxide"
+version = "0.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsodium-sys 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "storage-inmem"
+version = "1.6.0"
+dependencies = [
+ "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-rlp 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indy 1.6.6",
+ "indy-crypto 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "int_traits 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-panics 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "named_type 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "named_type_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "toml"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ucd-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uuid"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zmq"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq-sys 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zmq-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
+"checksum amcl 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a555cfaa0e641430ad130ad6cac857cf494a7a02964720fe5a73e5e7a548b39"
+"checksum android_log-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8052e2d8aabbb8d556d6abbcce2a22b9590996c5f849b9c7ce4544a2e3b984e"
+"checksum android_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86983875e7c3a202e31471cc6d60fcc18f30e194f1729cfff3bfb43d646ffced"
+"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814"
+"checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
+"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
+"checksum cc 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "70f2a88c2e69ceee91c209d8ef25b81fc1a65f42c7f14dfd59d1fed189e514d1"
+"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
+"checksum derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67b3d6d0e84e53a5bdc263cc59340541877bb541706a191d762bfac6a481bdde"
+"checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
+"checksum digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5b29c278aa8fd30796bd977169e8004b4aa88cdcd2f32a6eb22bc2d5d38df94a"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum elastic-array-plus 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6432870c5bd8b1b788e12e1095c337afab982a56aad4f48fda45471ff0abcc24"
+"checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+"checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
+"checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+"checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e92ecf0a508c8e074c0e6fa8fe0fa38414848ad4dfc4db6f74c5e9753330b248"
+"checksum etcommon-hexutil 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f004de816005d210e0af76640ade09b78aa0b6e7065ddb627782374ccd299f8a"
+"checksum etcommon-rlp 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4d8ea61b03717f963c7a49403499135e05e1c23269882b8ab4d1e98668317254"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
+"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
+"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
+"checksum indy-crypto 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "47ba86607167deddfe02f2fee2f7ce834fc158a9ffbc4d49622dde20c7a83470"
+"checksum int_traits 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b33c9a5c599d67d051c4dc25eb1b6b4ef715d1763c20c85c688717a1734f204e"
+"checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
+"checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
+"checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum libsodium-sys 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fcbd1beeed8d44caa8a669ebaa697c313976e242c03cc9fb23d88bf1656f5542"
+"checksum libsqlite3-sys 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d3711dfd91a1081d2458ad2d06ea30a8755256e74038be2ad927d94e1c955ca8"
+"checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
+"checksum log-panics 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae0136257df209261daa18d6c16394757c63e032e27aafd8b07788b051082bef"
+"checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d"
+"checksum metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
+"checksum named_type 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "24b5137ab6d9afa466d59b1f909170ea0f7180769fb62dd6ee165a54f3d6f48f"
+"checksum named_type_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "695241cbf43baec4302b2032132c95427a46b54fb468f9933773fb241b601c53"
+"checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+"checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
+"checksum num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3eceac7784c5dc97c2d6edf30259b4e153e6e2b42b3c85e9a6e9f45d06caef6e"
+"checksum num-complex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68de83578789e0fbda3fa923035be83cf8bfd3b30ccfdecd5aa89bf8601f408e"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
+"checksum num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e96f040177bb3da242b5b1ecf3f54b5d5af3efbbfb18608977a5d2767b22f10"
+"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
+"checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
+"checksum openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)" = "912f301a749394e1025d9dcddef6106ddee9252620e6d0a0e5f8d0681de9b129"
+"checksum os_type 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b86e98f6ba3e51ab565f507fee357e90544ddd8548e587786d25e4e906648461"
+"checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
+"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+"checksum proc-macro2 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)" = "afa4d377067cc02eb5e0b491d3f7cfbe145ad4da778535bfb13c444413dd35b9"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
+"checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
+"checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
+"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+"checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
+"checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
+"checksum rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9409d78a5a9646685688266e1833df8f08b71ffcae1b5db6c1bfb5970d8a80f"
+"checksum rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b313b91fcdc6719ad41fa2dad2b7e810b03833fae4bf911950e15529a5f04439"
+"checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
+"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
+"checksum serde 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)" = "c6e67977d7523ce4d9284ed58918af99392de8edb6192c44afefcf634654ab7f"
+"checksum serde_derive 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)" = "5569c52faae3e21b9abae2cc5cfbb56ed008bfcac480ad62bc241b828f0b0aee"
+"checksum serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "59790990c5115d16027f00913e2e66de23a51f70422e549d2ad68c8c5f268f1c"
+"checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
+"checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+"checksum sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
+"checksum sha3 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b64dcef59ed4290b9fb562b53df07f564690d6539e8ecdd4728cf392477530bc"
+"checksum sharedlib 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1ab7ad123216d2b04448d3b31edd7e5314b500012b2b01812245725536df2c"
+"checksum sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb5cb2f14f9a51352ad65e59257a0a9459d5a36a3615f3d53a974c82fdaaa00a"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "85fb2f7f9b7a4c8df2c913a852de570efdb40f0d2edd39c8245ad573f5c7fbcc"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum termcolor 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ff3bac0e465b59f194e7037ed404b0326e56ff234d767edc4c5cc9cd49e7a2c7"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
+"checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
+"checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
+"checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum zmq 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e6e33f05ebc9a1cb360e5db1f8ed6e5512ece86aed271654b0f171d04c24c23"
+"checksum zmq-sys 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3cc251d25f3c6ffc54dfa3e8d808598825f8ccfee3a008dfc7866ffe325dcb3"

--- a/samples/storage/storage-inmem/Cargo.toml
+++ b/samples/storage/storage-inmem/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "storage-inmem"
+version = "1.6.0"
+authors = [
+  "Sergej Pupykin <sergej.pupykin@dsr-company.com>",
+  "Vyacheslav Gudkov <vyacheslav.gudkov@dsr-company.com>",
+  "Artem Ivanov <artem.ivanov@dsr-company.com>",
+  "Evgeniy Razinkov <evgeniy.razinkov@dsr-company.com.ru>",
+  "Kirill Neznamov <kirill.neznamov@dsr-company.com>",
+  "Sergey Minaev <sergey.minaev@dsr-company.com>",
+  "Ian Costanzo <ian@anon-solutions.ca>"
+]
+
+description = "This is the official SDK for Hyperledger Indy (https://www.hyperledger.org/projects), which provides a distributed-ledger-based foundation for self-sovereign identity (https://sovrin.org). The major artifact of the SDK is a c-callable library."
+license = "MIT/Apache-2.0"
+build = "build.rs"
+
+[lib]
+name = "indystrginmem"
+path = "src/lib.rs"
+crate-type = ["staticlib","rlib","cdylib"]
+
+[features]
+default = ["base58_rust_base58", "base64_rust_base64", "pair_amcl"]
+base58_rust_base58 = ["rust-base58"]
+base64_rust_base64 = ["base64"]
+pair_amcl = ["indy-crypto"]
+
+# Causes the build to fail on all warnings
+fatal_warnings = []
+
+[dependencies]
+indy = { path = "../../../libindy"}
+indy-crypto = { version = "=0.4.3", optional = true }
+int_traits = { version = "0.1.1", optional = true }
+digest = "0.6.2"
+env_logger = "0.5.10"
+errno = "0.2.3"
+etcommon-rlp = "0.2.3"
+generic-array = "0.8.3"
+hex = "0.2.0"
+libc = "0.2.21"
+log = "0.4.1"
+openssl = { version = "=0.9.24", optional = true }
+owning_ref = "0.3.3"
+rand = "0.3"
+rust-base58 = {version = "0.0.4", optional = true}
+base64 = {version = "0.6.0", optional = true}
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+sha2 = "0.6.0"
+sha3 = "0.6.0"
+rmp-serde = "0.13.6"
+time = "0.1.36"
+lazy_static = "1.0"
+named_type = "0.1.3"
+named_type_derive = "0.1.3"
+byteorder = "1.0.0"
+log-panics = "2.0.0"
+
+[dependencies.uuid]
+version = "0.5.0"
+default-features = false
+features = ["v4"]
+

--- a/samples/storage/storage-inmem/build.rs
+++ b/samples/storage/storage-inmem/build.rs
@@ -1,0 +1,65 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+    println!("target={}", target);
+
+    let sodium_static = env::var("CARGO_FEATURE_SODIUM_STATIC").ok();
+    println!("sodium_static={:?}", sodium_static);
+
+    if sodium_static.is_some() {
+        println!("cargo:rustc-link-lib=static=sodium");
+    }
+
+    if target.find("-windows-").is_some() {
+        // do not build c-code on windows, use binaries
+        let output_dir = env::var("OUT_DIR").unwrap();
+        let prebuilt_dir = env::var("INDY_PREBUILT_DEPS_DIR").unwrap();
+
+        let dst = Path::new(&output_dir[..]).join("..\\..\\..");
+        let prebuilt_lib = Path::new(&prebuilt_dir[..]).join("lib");
+
+        println!("cargo:rustc-link-search=native={}", prebuilt_dir);
+        println!("cargo:rustc-flags=-L {}\\lib", prebuilt_dir);
+        println!("cargo:include={}\\include", prebuilt_dir);
+
+        let files = vec!["libeay32md.dll", "libsodium.dll", "libzmq.dll", "ssleay32md.dll"];
+        for f in files.iter() {
+            if let Ok(_) = fs::copy(&prebuilt_lib.join(f), &dst.join(f)) {
+                println!("copy {} -> {}", &prebuilt_lib.join(f).display(), &dst.join(f).display());
+            }
+        }
+    } else if target.find("linux-android").is_some() {
+        //statically link files
+        let openssl = match env::var("OPENSSL_LIB_DIR") {
+            Ok(val) => val,
+            Err(..) => match env::var("OPENSSL_DIR") {
+                Ok(dir) => Path::new(&dir[..]).join("/lib").to_string_lossy().into_owned(),
+                Err(..) => panic!("Missing required environment variables OPENSSL_DIR or OPENSSL_LIB_DIR")
+            }
+        };
+
+        let sodium = match env::var("SODIUM_LIB_DIR") {
+            Ok(val) => val,
+            Err(..) => panic!("Missing required environment variable SODIUM_LIB_DIR")
+        };
+
+        let zmq = match env::var("LIBZMQ_LIB_DIR") {
+            Ok(val) => val,
+            Err(..) => match env::var("LIBZMQ_PREFIX") {
+                Ok(dir) => Path::new(&dir[..]).join("/lib").to_string_lossy().into_owned(),
+                Err(..) => panic!("Missing required environment variables LIBZMQ_PREFIX or LIBZMQ_LIB_DIR")
+            }
+        };
+
+        println!("cargo:rustc-link-search=native={}", openssl);
+        println!("cargo:rustc-link-lib=static=crypto");
+        println!("cargo:rustc-link-lib=static=ssl");
+        println!("cargo:rustc-link-search=native={}", sodium);
+        println!("cargo:rustc-link-lib=static=sodium");
+        println!("cargo:rustc-link-search=native={}", zmq);
+        println!("cargo:rustc-link-lib=static=zmq");
+    }
+}

--- a/samples/storage/storage-inmem/src/lib.rs
+++ b/samples/storage/storage-inmem/src/lib.rs
@@ -1,0 +1,47 @@
+#![cfg_attr(feature = "fatal_warnings", deny(warnings))]
+
+extern crate base64;
+
+//#[macro_use]
+//extern crate log;
+
+//extern crate serde;
+
+//#[macro_use]
+//extern crate serde_derive;
+
+//#[macro_use]
+extern crate serde_json;
+
+//extern crate rmp_serde;
+
+#[macro_use]
+extern crate lazy_static;
+
+//extern crate named_type;
+
+//#[macro_use]
+//extern crate named_type_derive;
+
+extern crate indy;
+extern crate indy_crypto;
+extern crate libc;
+extern crate rand;
+
+// Note that to use macroses from util inside of other modules it must me loaded first!
+#[macro_use]
+pub mod utils;
+
+//pub mod api;
+//mod errors;
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn dummy() {
+        assert!(true, "Dummy check!");
+    }
+}
+

--- a/samples/storage/storage-inmem/src/utils/byte_array.rs
+++ b/samples/storage/storage-inmem/src/utils/byte_array.rs
@@ -1,0 +1,30 @@
+macro_rules! check_useful_c_byte_array {
+    ($ptr:ident, $len:expr, $err1:expr, $err2:expr) => {
+        if $ptr.is_null() {
+            return $err1
+        }
+
+        if $len <= 0 {
+            return $err2
+        }
+
+        let $ptr = unsafe { $crate::std::slice::from_raw_parts($ptr, $len as usize) };
+        let $ptr = $ptr.to_vec();
+    }
+}
+
+//Returnable pointer is valid only before first vector modification
+pub fn vec_to_pointer(v: &Vec<u8>) -> (*const u8, u32) {
+    let len = v.len() as u32;
+    (v.as_ptr() as *const u8, len)
+}
+
+// TODO: FIXME: I don't like how we convert slices to array.
+// TODO: FIXME: Size checking and keys validation.
+pub fn _clone_into_array<A, T>(slice: &[T]) -> A
+    where A: Sized + Default + AsMut<[T]>, T: Clone
+{
+    let mut a = Default::default();
+    <A as AsMut<[T]>>::as_mut(&mut a).clone_from_slice(slice);
+    a
+}

--- a/samples/storage/storage-inmem/src/utils/cstring.rs
+++ b/samples/storage/storage-inmem/src/utils/cstring.rs
@@ -1,0 +1,60 @@
+extern crate libc;
+
+use self::libc::c_char;
+
+use std::ffi::CStr;
+use std::str::Utf8Error;
+use std::ffi::CString;
+
+pub struct CStringUtils {}
+
+impl CStringUtils {
+    pub fn c_str_to_string(cstr: *const c_char) -> Result<Option<String>, Utf8Error> {
+        if cstr.is_null() {
+            return Ok(None);
+        }
+
+        unsafe {
+            match CStr::from_ptr(cstr).to_str() {
+                Ok(str) => Ok(Some(str.to_string())),
+                Err(err) => Err(err)
+            }
+        }
+    }
+
+    pub fn string_to_cstring(s: String) -> CString {
+        CString::new(s).unwrap()
+    }
+}
+
+macro_rules! check_useful_c_str {
+    ($x:ident, $e:expr) => {
+        let $x = match CStringUtils::c_str_to_string($x) {
+            Ok(Some(val)) => val,
+            _ => return $e,
+        };
+
+        if $x.is_empty() {
+            return $e
+        }
+    }
+}
+/*
+macro_rules! check_useful_c_str_empty_accepted {
+    ($x:ident, $e:expr) => {
+        let $x = match CStringUtils::c_str_to_string($x) {
+            Ok(Some(val)) => val,
+            _ => return $e,
+        };
+    }
+}
+
+macro_rules! check_useful_opt_c_str {
+    ($x:ident, $e:expr) => {
+        let $x = match CStringUtils::c_str_to_string($x) {
+            Ok(opt_val) => opt_val,
+            Err(_) => return $e
+        };
+    }
+}
+*/

--- a/samples/storage/storage-inmem/src/utils/inmem_wallet.rs
+++ b/samples/storage/storage-inmem/src/utils/inmem_wallet.rs
@@ -1,0 +1,749 @@
+extern crate libc;
+extern crate time;
+extern crate indy;
+extern crate indy_crypto;
+extern crate serde_json;
+
+use indy::api::ErrorCode;
+use utils::cstring::CStringUtils;
+use utils::sequence::SequenceUtils;
+
+use self::libc::c_char;
+
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::sync::Mutex;
+
+
+#[derive(Debug)]
+struct InmemWalletContext {
+    id: String
+}
+
+#[derive(Debug, Clone)]
+struct InmemWalletRecord {
+    type_: CString,
+    id: CString,
+    value: Vec<u8>,
+    tags: CString
+}
+
+#[derive(Debug, Clone)]
+struct InmemWalletEntity {
+    metadata: CString,
+    records: HashMap<String, InmemWalletRecord>
+}
+
+lazy_static! {
+    static ref INMEM_WALLETS: Mutex<HashMap<String, InmemWalletEntity>> = Default::default();
+}
+
+lazy_static! {
+    static ref INMEM_OPEN_WALLETS: Mutex<HashMap<i32, InmemWalletContext>> = Default::default();
+}
+
+lazy_static! {
+    static ref ACTIVE_METADATAS: Mutex<HashMap<i32, CString>> = Default::default();
+}
+
+lazy_static! {
+    static ref ACTIVE_RECORDS: Mutex<HashMap<i32, InmemWalletRecord>> = Default::default();
+}
+
+lazy_static! {
+    static ref ACTIVE_SEARCHES: Mutex<HashMap<i32, Vec<InmemWalletRecord>,>> = Default::default();
+}
+
+pub struct InmemWallet {}
+
+impl InmemWallet {
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_create(id: *const c_char,
+                             _: *const c_char,
+                             _: *const c_char,
+                             metadata: *const c_char) -> ErrorCode {
+        check_useful_c_str!(id, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(metadata, ErrorCode::CommonInvalidStructure);
+
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+        if wallets.contains_key(&id) {
+            // Invalid state as "already exists" case must be checked on service layer
+            return ErrorCode::CommonInvalidState;
+        }
+        wallets.insert(id.clone(), InmemWalletEntity { metadata: CString::new(metadata).unwrap(), records: HashMap::new() });
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_open(id: *const c_char,
+                           _: *const c_char,
+                           _: *const c_char,
+                           handle: *mut i32) -> ErrorCode {
+        check_useful_c_str!(id, ErrorCode::CommonInvalidStructure);
+
+        let wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let mut handles = INMEM_OPEN_WALLETS.lock().unwrap();
+        let xhandle = SequenceUtils::get_next_id();
+        handles.insert(xhandle, InmemWalletContext {
+            id,
+        });
+
+        unsafe { *handle = xhandle };
+        ErrorCode::Success
+    }
+
+    fn build_record_id(type_: &str, id: &str) -> String {
+        format!("{}-{}", type_, id)
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_add_record(xhandle: i32,
+                                 type_: *const c_char,
+                                 id: *const c_char,
+                                 value: *const u8,
+                                 value_len: usize,
+                                 tags_json: *const c_char) -> ErrorCode {
+        check_useful_c_str!(type_, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(id, ErrorCode::CommonInvalidStructure);
+        check_useful_c_byte_array!(value, value_len, ErrorCode::CommonInvalidStructure, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(tags_json, ErrorCode::CommonInvalidStructure);
+
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get_mut(&wallet_context.id).unwrap();
+
+        wallet.records.insert(InmemWallet::build_record_id(&type_, &id), InmemWalletRecord {
+            type_: CString::new(type_).unwrap(),
+            id: CString::new(id).unwrap(),
+            value,
+            tags: CString::new(tags_json).unwrap(),
+        });
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_update_record_value(xhandle: i32,
+                                          type_: *const c_char,
+                                          id: *const c_char,
+                                          joined_value: *const u8,
+                                          joined_value_len: usize) -> ErrorCode {
+        check_useful_c_str!(type_, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(id, ErrorCode::CommonInvalidStructure);
+        check_useful_c_byte_array!(joined_value, joined_value_len, ErrorCode::CommonInvalidStructure, ErrorCode::CommonInvalidStructure);
+
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get_mut(&wallet_context.id).unwrap();
+
+        match wallet.records.get_mut(&InmemWallet::build_record_id(&type_, &id)) {
+            Some(ref mut record) => record.value = joined_value,
+            None => return ErrorCode::WalletItemNotFound
+        }
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_get_record(xhandle: i32,
+                                 type_: *const c_char,
+                                 id: *const c_char,
+                                 options_json: *const c_char,
+                                 handle: *mut i32) -> ErrorCode {
+        check_useful_c_str!(type_, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(id, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(options_json, ErrorCode::CommonInvalidStructure);
+
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get(&wallet_context.id).unwrap();
+
+        let key = InmemWallet::build_record_id(&type_, &id);
+
+        if !wallet.records.contains_key(&key) {
+            return ErrorCode::WalletItemNotFound;
+        }
+
+        let record = wallet.records.get(&key).unwrap();
+
+        let record_handle = SequenceUtils::get_next_id();
+
+        let mut handles = ACTIVE_RECORDS.lock().unwrap();
+        handles.insert(record_handle, record.clone());
+
+        unsafe { *handle = record_handle };
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_get_record_id(xhandle: i32,
+                                    record_handle: i32,
+                                    id_ptr: *mut *const c_char) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let handles = ACTIVE_RECORDS.lock().unwrap();
+
+        if !handles.contains_key(&record_handle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let record = handles.get(&record_handle).unwrap();
+
+        unsafe { *id_ptr = record.id.as_ptr(); }
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_get_record_type(xhandle: i32,
+                                      record_handle: i32,
+                                      type_ptr: *mut *const c_char) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let handles = ACTIVE_RECORDS.lock().unwrap();
+
+        if !handles.contains_key(&record_handle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let record = handles.get(&record_handle).unwrap();
+
+        unsafe { *type_ptr = record.type_.as_ptr(); }
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_get_record_value(xhandle: i32,
+                                       record_handle: i32,
+                                       value_ptr: *mut *const u8,
+                                       value_len: *mut usize) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let handles = ACTIVE_RECORDS.lock().unwrap();
+
+        if !handles.contains_key(&record_handle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let record = handles.get(&record_handle).unwrap();
+
+        unsafe { *value_ptr = record.value.as_ptr() as *const u8; }
+        unsafe { *value_len = record.value.len() as usize; }
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_get_record_tags(xhandle: i32,
+                                      record_handle: i32,
+                                      tags_json_ptr: *mut *const c_char) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let handles = ACTIVE_RECORDS.lock().unwrap();
+
+        if !handles.contains_key(&record_handle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let record = handles.get(&record_handle).unwrap();
+
+        unsafe { *tags_json_ptr = record.tags.as_ptr(); }
+
+        ErrorCode::Success
+    }
+
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_free_record(xhandle: i32, record_handle: i32) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let mut handles = ACTIVE_RECORDS.lock().unwrap();
+
+        if !handles.contains_key(&record_handle) {
+            return ErrorCode::CommonInvalidState;
+        }
+        handles.remove(&record_handle);
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_add_record_tags(xhandle: i32,
+                                      type_: *const c_char,
+                                      id: *const c_char,
+                                      tags_json: *const c_char) -> ErrorCode {
+        check_useful_c_str!(type_, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(id, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(tags_json, ErrorCode::CommonInvalidStructure);
+
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get_mut(&wallet_context.id).unwrap();
+
+        match wallet.records.get_mut(&InmemWallet::build_record_id(&type_, &id)) {
+            Some(ref mut record) => {
+                let curr_tags_json =record.tags.to_str().unwrap().to_string() ;
+
+                let new_tags_result = serde_json::from_str::<HashMap<String, String>>(&tags_json);
+                let curr_tags_result = serde_json::from_str::<HashMap<String, String>>(&curr_tags_json);
+
+                let (new_tags, mut curr_tags) = match (new_tags_result, curr_tags_result) {
+                    (Ok(new), Ok(cur)) => (new, cur),
+                    _ => return ErrorCode::CommonInvalidStructure
+                };
+
+                curr_tags.extend(new_tags);
+
+                let new_tags_json = serde_json::to_string(&curr_tags).unwrap();
+
+                record.tags = CString::new(new_tags_json).unwrap();
+            }
+            None => return ErrorCode::WalletItemNotFound
+        }
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_update_record_tags(xhandle: i32,
+                                         type_: *const c_char,
+                                         id: *const c_char,
+                                         tags_json: *const c_char) -> ErrorCode {
+        check_useful_c_str!(type_, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(id, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(tags_json, ErrorCode::CommonInvalidStructure);
+
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get_mut(&wallet_context.id).unwrap();
+
+        match wallet.records.get_mut(&InmemWallet::build_record_id(&type_, &id)) {
+            Some(ref mut record) => record.tags = CString::new(tags_json).unwrap(),
+            None => return ErrorCode::WalletItemNotFound
+        }
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_delete_record_tags(xhandle: i32,
+                                         type_: *const c_char,
+                                         id: *const c_char,
+                                         tag_names: *const c_char) -> ErrorCode {
+        check_useful_c_str!(type_, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(id, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(tag_names, ErrorCode::CommonInvalidStructure);
+
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get_mut(&wallet_context.id).unwrap();
+
+        match wallet.records.get_mut(&InmemWallet::build_record_id(&type_, &id)) {
+            Some(ref mut record) => {
+                let curr_tags_json = record.tags.to_str().unwrap().to_string() ;
+
+                let mut curr_tags_res = serde_json::from_str::<HashMap<String, String>>(&curr_tags_json);
+                let tags_names_to_delete = serde_json::from_str::<Vec<String>>(&tag_names);
+
+                let (mut curr_tags, tags_delete) = match (curr_tags_res, tags_names_to_delete) {
+                    (Ok(cur), Ok(to_delete)) => (cur, to_delete),
+                    _ => return ErrorCode::CommonInvalidStructure
+                };
+
+                for tag_name in tags_delete {
+                    curr_tags.remove(&tag_name);
+                }
+
+                let new_tags_json = serde_json::to_string(&curr_tags).unwrap();
+
+                record.tags = CString::new(new_tags_json).unwrap()
+            }
+            None => return ErrorCode::WalletItemNotFound
+        }
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_delete_record(xhandle: i32,
+                                    type_: *const c_char,
+                                    id: *const c_char) -> ErrorCode {
+        check_useful_c_str!(type_, ErrorCode::CommonInvalidStructure);
+        check_useful_c_str!(id, ErrorCode::CommonInvalidStructure);
+
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get_mut(&wallet_context.id).unwrap();
+
+        let key = InmemWallet::build_record_id(&type_, &id);
+
+        if !wallet.records.contains_key(&key) {
+            return ErrorCode::WalletItemNotFound;
+        }
+
+        wallet.records.remove(&key);
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_get_storage_metadata(xhandle: i32, metadata_ptr: *mut *const c_char, metadata_handle: *mut i32) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get(&wallet_context.id).unwrap();
+
+        let metadata = wallet.metadata.clone();
+        let metadata_pointer = metadata.as_ptr();
+
+        let handle = SequenceUtils::get_next_id();
+
+        let mut metadatas = ACTIVE_METADATAS.lock().unwrap();
+        metadatas.insert(handle, metadata);
+
+        unsafe { *metadata_ptr = metadata_pointer; }
+        unsafe { *metadata_handle = handle };
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_set_storage_metadata(xhandle: i32, metadata: *const c_char) -> ErrorCode {
+        check_useful_c_str!(metadata, ErrorCode::CommonInvalidStructure);
+
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get_mut(&wallet_context.id).unwrap();
+
+        wallet.metadata = CString::new(metadata).unwrap();
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_free_storage_metadata(xhandle: i32, metadata_handler: i32) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let mut handles = ACTIVE_METADATAS.lock().unwrap();
+
+        if !handles.contains_key(&metadata_handler) {
+            return ErrorCode::CommonInvalidState;
+        }
+        handles.remove(&metadata_handler);
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_search_records(xhandle: i32, type_: *const c_char, _query_json: *const c_char, _options_json: *const c_char, handle: *mut i32) -> ErrorCode {
+        check_useful_c_str!(type_, ErrorCode::CommonInvalidStructure);
+
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get(&wallet_context.id).unwrap();
+
+        let search_records = wallet.records
+            .iter()
+            .filter(|&(key, _)| key.starts_with(&type_))
+            .map(|(_, value)| value.clone())
+            .collect::<Vec<InmemWalletRecord>>();
+
+        let search_handle = SequenceUtils::get_next_id();
+
+        let mut searches = ACTIVE_SEARCHES.lock().unwrap();
+
+        searches.insert(search_handle, search_records);
+
+        unsafe { *handle = search_handle };
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_search_all_records(xhandle: i32, handle: *mut i32) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet_context = handles.get(&xhandle).unwrap();
+
+        let wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&wallet_context.id) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let wallet = wallets.get(&wallet_context.id).unwrap();
+
+        let search_records = wallet.records
+            .values()
+            .cloned()
+            .collect::<Vec<InmemWalletRecord>>();
+
+        let search_handle = SequenceUtils::get_next_id();
+
+        let mut searches = ACTIVE_SEARCHES.lock().unwrap();
+
+        searches.insert(search_handle, search_records);
+
+        unsafe { *handle = search_handle };
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_get_search_total_count(xhandle: i32, search_handle: i32, count: *mut usize) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let searches = ACTIVE_SEARCHES.lock().unwrap();
+
+        match searches.get(&search_handle) {
+            Some(records) => {
+                unsafe { *count = records.len() };
+            }
+            None => return ErrorCode::CommonInvalidState
+        }
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_fetch_search_next_record(xhandle: i32, search_handle: i32, record_handle: *mut i32) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let mut searches = ACTIVE_SEARCHES.lock().unwrap();
+
+        match searches.get_mut(&search_handle) {
+            Some(records) => {
+                match records.pop() {
+                    Some(record) => {
+                        let handle = SequenceUtils::get_next_id();
+
+                        let mut handles = ACTIVE_RECORDS.lock().unwrap();
+                        handles.insert(handle, record.clone());
+
+                        unsafe { *record_handle = handle };
+                    }
+                    None => return ErrorCode::WalletItemNotFound
+                }
+            }
+            None => return ErrorCode::CommonInvalidState
+        }
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_free_search(xhandle: i32, search_handle: i32) -> ErrorCode {
+        let handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        let mut handles = ACTIVE_SEARCHES.lock().unwrap();
+
+        if !handles.contains_key(&search_handle) {
+            return ErrorCode::CommonInvalidState;
+        }
+        handles.remove(&search_handle);
+
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_close(xhandle: i32) -> ErrorCode {
+        let mut handles = INMEM_OPEN_WALLETS.lock().unwrap();
+
+        if !handles.contains_key(&xhandle) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        handles.remove(&xhandle);
+        ErrorCode::Success
+    }
+
+#[no_mangle]
+    pub extern "C" fn inmemwallet_fn_delete(name: *const c_char,
+                             _: *const c_char,
+                             _: *const c_char) -> ErrorCode {
+        check_useful_c_str!(name, ErrorCode::CommonInvalidStructure);
+
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+
+        if !wallets.contains_key(&name) {
+            return ErrorCode::CommonInvalidState;
+        }
+
+        wallets.remove(&name);
+        ErrorCode::Success
+    }
+
+    pub fn cleanup() {
+        let mut wallets = INMEM_WALLETS.lock().unwrap();
+        wallets.clear();
+
+        let mut handles = INMEM_OPEN_WALLETS.lock().unwrap();
+        handles.clear();
+    }
+}

--- a/samples/storage/storage-inmem/src/utils/mod.rs
+++ b/samples/storage/storage-inmem/src/utils/mod.rs
@@ -1,0 +1,12 @@
+
+#[macro_use]
+pub mod cstring;
+
+#[macro_use]
+pub mod byte_array;
+
+//#[cfg(test)]
+#[allow(dead_code)]
+pub mod inmem_wallet;
+
+pub mod sequence;

--- a/samples/storage/storage-inmem/src/utils/sequence.rs
+++ b/samples/storage/storage-inmem/src/utils/sequence.rs
@@ -1,0 +1,14 @@
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+
+pub struct SequenceUtils {}
+
+lazy_static! {
+    static ref IDS_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT; //TODO use AtomicI32
+}
+
+impl SequenceUtils {
+    pub fn get_next_id() -> i32 {
+        (IDS_COUNTER.fetch_add(1, Ordering::SeqCst) + 1) as i32
+    }
+}
+

--- a/wrappers/python/indy/wallet.py
+++ b/wrappers/python/indy/wallet.py
@@ -6,6 +6,149 @@ from typing import Optional
 import logging
 
 
+def convert_to_pointer(fn):
+    return fn
+
+def get_fn_pointer(lib, fn_name: str):
+    return getattr(lib, fn_name)
+
+async def register_wallet_storage_library(storage_type: str, c_library: str, fn_pfx: str):
+    """
+    Register a wallet storage provider
+
+    :return: Error code
+    """
+
+    logger = logging.getLogger(__name__)
+    logger.debug("register_wallet_storage_library: >>> type: %r",
+                 storage_type)
+
+    stg_lib = CDLL(c_library)
+    await register_wallet_storage(storage_type,
+                                  get_fn_pointer(stg_lib, fn_pfx + "create"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "open"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "close"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "delete"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "add_record"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "update_record_value"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "update_record_tags"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "add_record_tags"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "delete_record_tags"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "delete_record"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "get_record"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "get_record_id"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "get_record_type"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "get_record_value"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "get_record_tags"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "free_record"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "get_storage_metadata"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "set_storage_metadata"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "free_storage_metadata"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "search_records"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "search_all_records"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "get_search_total_count"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "fetch_search_next_record"),
+                                  get_fn_pointer(stg_lib, fn_pfx + "free_search"))
+
+    logger.debug("register_wallet_storage_library: <<<")
+
+
+async def register_wallet_storage(storage_type: str,
+                                  fn_create,
+                                  fn_open,
+                                  fn_close,
+                                  fn_delete,
+                                  fn_add_record,
+                                  fn_update_record_value,
+                                  fn_update_record_tags,
+                                  fn_add_record_tags,
+                                  fn_delete_record_tags,
+                                  fn_delete_record,
+                                  fn_get_record,
+                                  fn_get_record_id,
+                                  fn_get_record_type,
+                                  fn_get_record_value,
+                                  fn_get_record_tags,
+                                  fn_free_record,
+                                  fn_get_storage_metadata,
+                                  fn_set_storage_metadata,
+                                  fn_free_storage_metadata,
+                                  fn_search_records,
+                                  fn_search_all_records,
+                                  fn_get_search_total_count,
+                                  fn_fetch_search_next_record,
+                                  fn_free_search) -> None:
+    """
+    Register a wallet storage provider
+
+    :return: Error code
+    """
+
+    logger = logging.getLogger(__name__)
+    logger.debug("register_wallet_storage: >>> type: %r",
+                 storage_type)
+
+    if not hasattr(register_wallet_storage, "cb"):
+        logger.debug("register_wallet_storage: Creating callback")
+        register_wallet_storage.cb = create_cb(CFUNCTYPE(None, c_int32, c_int32))
+
+    c_storage_type = c_char_p(storage_type.encode('utf-8'))
+    c_fn_create = convert_to_pointer(fn_create)
+    c_fn_open = convert_to_pointer(fn_open)
+    c_fn_close = convert_to_pointer(fn_close)
+    c_fn_delete = convert_to_pointer(fn_delete)
+    c_fn_add_record = convert_to_pointer(fn_add_record)
+    c_fn_update_record_value = convert_to_pointer(fn_update_record_value)
+    c_fn_update_record_tags = convert_to_pointer(fn_update_record_tags)
+    c_fn_add_record_tags = convert_to_pointer(fn_add_record_tags)
+    c_fn_delete_record_tags = convert_to_pointer(fn_delete_record_tags)
+    c_fn_delete_record = convert_to_pointer(fn_delete_record)
+    c_fn_get_record = convert_to_pointer(fn_get_record)
+    c_fn_get_record_id = convert_to_pointer(fn_get_record_id)
+    c_fn_get_record_type = convert_to_pointer(fn_get_record_type)
+    c_fn_get_record_value = convert_to_pointer(fn_get_record_value)
+    c_fn_get_record_tags = convert_to_pointer(fn_get_record_tags)
+    c_fn_free_record = convert_to_pointer(fn_free_record)
+    c_fn_get_storage_metadata = convert_to_pointer(fn_get_storage_metadata)
+    c_fn_set_storage_metadata = convert_to_pointer(fn_set_storage_metadata)
+    c_fn_free_storage_metadata = convert_to_pointer(fn_free_storage_metadata)
+    c_fn_search_records = convert_to_pointer(fn_search_records)
+    c_fn_search_all_records = convert_to_pointer(fn_search_all_records)
+    c_fn_get_search_total_count = convert_to_pointer(fn_get_search_total_count)
+    c_fn_fetch_search_next_record = convert_to_pointer(fn_fetch_search_next_record)
+    c_fn_free_search = convert_to_pointer(fn_free_search)
+
+    await do_call('indy_register_wallet_storage',
+                  c_storage_type,
+                  c_fn_create,
+                  c_fn_open,
+                  c_fn_close,
+                  c_fn_delete,
+                  c_fn_add_record,
+                  c_fn_update_record_value,
+                  c_fn_update_record_tags,
+                  c_fn_add_record_tags,
+                  c_fn_delete_record_tags,
+                  c_fn_delete_record,
+                  c_fn_get_record,
+                  c_fn_get_record_id,
+                  c_fn_get_record_type,
+                  c_fn_get_record_value,
+                  c_fn_get_record_tags,
+                  c_fn_free_record,
+                  c_fn_get_storage_metadata,
+                  c_fn_set_storage_metadata,
+                  c_fn_free_storage_metadata,
+                  c_fn_search_records,
+                  c_fn_search_all_records,
+                  c_fn_get_search_total_count,
+                  c_fn_fetch_search_next_record,
+                  c_fn_free_search,
+                  register_wallet_storage.cb)
+
+    logger.debug("register_wallet_storage: <<<")
+
+
 async def create_wallet(config: str,
                         credentials: str) -> None:
     """

--- a/wrappers/python/tests/wallet/test_register_wallet_storage.py
+++ b/wrappers/python/tests/wallet/test_register_wallet_storage.py
@@ -1,0 +1,116 @@
+import asyncio
+import json
+import logging
+import sys
+from os import environ
+from pathlib import Path
+from shutil import rmtree
+from tempfile import gettempdir
+
+from ctypes import *
+
+import pytest
+
+from indy import wallet
+from indy.error import IndyError, ErrorCode
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+# noinspection PyUnusedLocal
+@pytest.mark.asyncio
+async def test_register_custom_storage_works():
+    logger = logging.getLogger(__name__)
+
+    wallet_config = '{"id":"wallet1c", "storage_type":"custom_inmem"}'
+    wallet_credentials = '{"key":"key"}'
+
+    # load dynamic library
+    logger.debug("register_wallet: Load library with custom storage")
+    if sys.platform == 'darwin':
+        f_ext = 'dylib'
+    else:
+        f_ext = 'so'
+    inmemlib = CDLL("../../samples/storage/storage-inmem/target/debug/libindystrginmem." + f_ext)
+
+    await wallet.register_wallet_storage("custom_inmem",
+                                         inmemlib.inmemwallet_fn_create,
+                                         inmemlib.inmemwallet_fn_open,
+                                         inmemlib.inmemwallet_fn_close,
+                                         inmemlib.inmemwallet_fn_delete,
+                                         inmemlib.inmemwallet_fn_add_record,
+                                         inmemlib.inmemwallet_fn_update_record_value,
+                                         inmemlib.inmemwallet_fn_update_record_tags,
+                                         inmemlib.inmemwallet_fn_add_record_tags,
+                                         inmemlib.inmemwallet_fn_delete_record_tags,
+                                         inmemlib.inmemwallet_fn_delete_record,
+                                         inmemlib.inmemwallet_fn_get_record,
+                                         inmemlib.inmemwallet_fn_get_record_id,
+                                         inmemlib.inmemwallet_fn_get_record_type,
+                                         inmemlib.inmemwallet_fn_get_record_value,
+                                         inmemlib.inmemwallet_fn_get_record_tags,
+                                         inmemlib.inmemwallet_fn_free_record,
+                                         inmemlib.inmemwallet_fn_get_storage_metadata,
+                                         inmemlib.inmemwallet_fn_set_storage_metadata,
+                                         inmemlib.inmemwallet_fn_free_storage_metadata,
+                                         inmemlib.inmemwallet_fn_search_records,
+                                         inmemlib.inmemwallet_fn_search_all_records,
+                                         inmemlib.inmemwallet_fn_get_search_total_count,
+                                         inmemlib.inmemwallet_fn_fetch_search_next_record,
+                                         inmemlib.inmemwallet_fn_free_search)
+
+    # create/open/close/delete wallet
+    logger.debug("register_wallet: Creating wallet")
+    await wallet.create_wallet(wallet_config, wallet_credentials)
+
+    logger.debug("register_wallet: Opening wallet")
+    wallet_handle = await wallet.open_wallet(wallet_config, wallet_credentials)
+    assert type(wallet_handle) is int
+
+    logger.debug("register_wallet: Closing wallet")
+    await wallet.close_wallet(wallet_handle)
+
+    logger.debug("register_wallet: Deleting wallet")
+    await wallet.delete_wallet(wallet_config, wallet_credentials)
+
+    logger.debug("register_wallet: Done!")
+
+    pass
+
+
+@pytest.mark.asyncio
+async def test_register_custom_storage_library_works():
+    logger = logging.getLogger(__name__)
+
+    wallet_config = '{"id":"wallet1c", "storage_type":"custom_inmem2"}'
+    wallet_credentials = '{"key":"key"}'
+
+    # register custom wallet storage
+    logger.debug("register_wallet: Register custom wallet storage")
+    if sys.platform == 'darwin':
+        f_ext = 'dylib'
+    else:
+        f_ext = 'so'
+    await wallet.register_wallet_storage_library("custom_inmem2",
+                                "../../samples/storage/storage-inmem/target/debug/libindystrginmem." + f_ext,
+                                "inmemwallet_fn_")
+
+    # create/open/close/delete wallet
+    logger.debug("register_wallet: Creating wallet")
+    await wallet.create_wallet(wallet_config, wallet_credentials)
+
+    logger.debug("register_wallet: Opening wallet")
+    wallet_handle = await wallet.open_wallet(wallet_config, wallet_credentials)
+    assert type(wallet_handle) is int
+
+    logger.debug("register_wallet: Closing wallet")
+    await wallet.close_wallet(wallet_handle)
+
+    logger.debug("register_wallet: Deleting wallet")
+    await wallet.delete_wallet(wallet_config, wallet_credentials)
+
+    logger.debug("register_wallet: Done!")
+
+    pass
+
+


### PR DESCRIPTION
Added a new shared library containing inmem wallet storage plug-in (to demonstrate and test dynamic storage loading).

Added python wrapper functions to load wallet storage from shared library.

Updated unit tests to optionally use dynamic storage rather than default via environment parameters:

STG_CONFIG - json configuration string to pass to the wallet on creation and open
STG_CREDS - json credentials string to pass to the wallet on creation and open
STG_TYPE - storage type to create
STG_LIB - c-callable library to load (contains a plug-in storage)
        (if specified will dynamically load and register a wallet storage)
STG_FN_PREFIX - prefix for all plug-in functions (allows standard function naming)

For example to run tests against the inmem wallet:

STG_TYPE=inmem_custom STG_LIB=../samples/storage/storage-inmem/target/debug/libindystrginmem.dylib STG_FN_PREFIX=inmemwallet_fn_ cargo test issuer_create_and_store_credential_def_works