### PR TITLE
Update rust version to 1.29

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -1222,7 +1222,7 @@ def downloadPackagingUtils() {
 }
 
 def setupRust() {
-    sh "rustup default 1.27.0"
+    sh "rustup default 1.29.0"
 }
 
 def androidPublishing() {

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -656,7 +656,7 @@ def closePool(env_name, network_name, poolInst) {
 }
 
 def setupRust() {
-    sh "rustup default 1.27.0"
+    sh "rustup default 1.29.0"
 }
 
 def setupRustIOS() {

--- a/libindy/ci/amazon.dockerfile
+++ b/libindy/ci/amazon.dockerfile
@@ -39,7 +39,7 @@ RUN wget https://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-mav
 RUN sed -i s/\$releasever/6/g /etc/yum.repos.d/epel-apache-maven.repo
 RUN yum install -y apache-maven
 
-ENV RUST_ARCHIVE=rust-1.27.0-x86_64-unknown-linux-gnu.tar.gz
+ENV RUST_ARCHIVE=rust-1.29.0-x86_64-unknown-linux-gnu.tar.gz
 ENV RUST_DOWNLOAD_URL=https://static.rust-lang.org/dist/$RUST_ARCHIVE
 
 RUN mkdir -p /rust

--- a/libindy/ci/ubuntu.dockerfile
+++ b/libindy/ci/ubuntu.dockerfile
@@ -55,7 +55,7 @@ RUN apt-get install -y zip
 RUN useradd -ms /bin/bash -u $uid indy
 USER indy
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.27.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.29.0
 ENV PATH /home/indy/.cargo/bin:$PATH
 
 WORKDIR /home/indy

--- a/vcx/ci/libindy.dockerfile
+++ b/vcx/ci/libindy.dockerfile
@@ -41,7 +41,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get install -y nodejs
 
 # Install Rust
-ARG RUST_VER="1.27.0"
+ARG RUST_VER="1.29.0"
 ENV RUST_ARCHIVE=rust-${RUST_VER}-x86_64-unknown-linux-gnu.tar.gz
 ENV RUST_DOWNLOAD_URL=https://static.rust-lang.org/dist/$RUST_ARCHIVE
 

--- a/vcx/ci/libvcx.dockerfile
+++ b/vcx/ci/libvcx.dockerfile
@@ -4,7 +4,7 @@ ARG uid=1000
 RUN useradd -ms /bin/bash -u $uid vcx
 USER vcx
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.27.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.29.0
 ENV PATH /home/vcx/.cargo/bin:$PATH
 WORKDIR /home/vcx
 ENV PATH /home/vcx:$PATH

--- a/vcx/ci/ubuntu.dockerfile
+++ b/vcx/ci/ubuntu.dockerfile
@@ -60,7 +60,7 @@ ARG uid=1000
 RUN useradd -ms /bin/bash -u $uid vcx
 USER vcx
 
-ARG RUST_VER="1.27.0"
+ARG RUST_VER="1.29.0"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
 ENV PATH /home/vcx/.cargo/bin:$PATH
 

--- a/vcx/libvcx/build_scripts/ios/mac/mac.01.libindy.setup.sh
+++ b/vcx/libvcx/build_scripts/ios/mac/mac.01.libindy.setup.sh
@@ -44,7 +44,7 @@ fi
 
 if [[ $RUSTUP_VERSION =~ ^'rustup ' ]]; then
     rustup update
-    rustup default 1.27.0
+    rustup default 1.29.0
     rustup component add rls-preview rust-analysis rust-src
     echo "Using rustc version $(rustc --version)"
     rustup target remove aarch64-linux-android armv7-linux-androideabi arm-linux-androideabi i686-linux-android x86_64-linux-android

--- a/vcx/wrappers/java/ci/android.dockerfile
+++ b/vcx/wrappers/java/ci/android.dockerfile
@@ -21,5 +21,5 @@ RUN yes | .//home/android/android-sdk-linux/tools/bin/sdkmanager "ndk-bundle"
 RUN echo "android ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers 
 
 USER android
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.27.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.29.0
 ENV PATH /home/android/.cargo/bin:$PATH


### PR DESCRIPTION
This is for to allow for clippy support in #1320  