### PR TITLE
Corrected `get_response_metadata_works_for_get_txn_request` libindy test

### DIFF
--- a/libindy/tests/ledger.rs
+++ b/libindy/tests/ledger.rs
@@ -1561,6 +1561,8 @@ mod high_cases {
 
             let seq_no = response_metadata["seqNo"].as_u64().unwrap() as i32;
 
+            thread::sleep(std::time::Duration::from_secs(2));
+
             let get_txn_request = ledger::build_get_txn_request(None, seq_no, None).unwrap();
             let get_txn_response = ledger::submit_request(pool_handle, &get_txn_request).unwrap();
 


### PR DESCRIPTION
Signed-off-by: artem.ivanov <artem.ivanov@dsr-company.com>