### PR TITLE
WIP use different names and ids for wallets and storage

### DIFF
--- a/libindy/src/services/wallet/export_import.rs
+++ b/libindy/src/services/wallet/export_import.rs
@@ -368,14 +368,6 @@ mod tests {
         test::cleanup_storage()
     }
 
-    fn _wallet1_id() -> &'static str {
-        "w1"
-    }
-
-    fn _wallet2_id() -> &'static str {
-        "w2"
-    }
-
     fn _wallet(id: &str) -> Wallet {
         let storage_type = SQLiteStorageType::new();
         let master_key = _master_key();
@@ -404,11 +396,23 @@ mod tests {
     }
 
     fn _wallet1() -> Wallet {
-        _wallet(_wallet1_id())
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let i: i32 = rng.gen();
+        let s = i.to_string();
+        let mut w = "w".to_string();
+        w.push_str(&s);
+        _wallet(&w)
     }
 
     fn _wallet2() -> Wallet {
-        _wallet(_wallet2_id())
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let i: i32 = rng.gen();
+        let s = i.to_string();
+        let mut w = "v".to_string();
+        w.push_str(&s);
+        _wallet(&w)
     }
 
     fn _assert_is_empty(wallet: &Wallet) {

--- a/libindy/src/services/wallet/mod.rs
+++ b/libindy/src/services/wallet/mod.rs
@@ -882,9 +882,10 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
 
-        let res = wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY));
+        let res = wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY));
         assert_match!(Err(WalletError::AlreadyExists(_)), res);
     }
     /*
@@ -893,8 +894,8 @@ mod tests {
             _cleanup();
 
             let wallet_service = WalletService::new();
-            wallet_service.create_wallet(&_config(), &_credentials()).unwrap();
-            let res = wallet_service.create_wallet(&_config(), &_credentials_invalid_raw());
+            wallet_service.create_wallet(&config, &_credentials()).unwrap();
+            let res = wallet_service.create_wallet(&config, &_credentials_invalid_raw());
             assert_match!(Err(WalletError::CommonError(CommonError::InvalidStructure(_))), res);
         }
     */
@@ -903,9 +904,10 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        wallet_service.delete_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        wallet_service.delete_wallet(&config, &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
     }
 
     #[test]
@@ -913,9 +915,10 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &ARGON_INT_CREDENTIAL, (&INTERACTIVE_KDD, &INTERACTIVE_MASTER_KEY)).unwrap();
-        wallet_service.delete_wallet(&_config(), &ARGON_INT_CREDENTIAL).unwrap();
-        wallet_service.create_wallet(&_config(), &ARGON_INT_CREDENTIAL,(&INTERACTIVE_KDD, &INTERACTIVE_MASTER_KEY)).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &ARGON_INT_CREDENTIAL, (&INTERACTIVE_KDD, &INTERACTIVE_MASTER_KEY)).unwrap();
+        wallet_service.delete_wallet(&config, &ARGON_INT_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &ARGON_INT_CREDENTIAL,(&INTERACTIVE_KDD, &INTERACTIVE_MASTER_KEY)).unwrap();
     }
 
     #[test]
@@ -923,9 +926,10 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &ARGON_MOD_CREDENTIAL, (&MODERATE_KDD, &MODERATE_MASTER_KEY)).unwrap();
-        wallet_service.delete_wallet(&_config(), &ARGON_MOD_CREDENTIAL).unwrap();
-        wallet_service.create_wallet(&_config(), &ARGON_MOD_CREDENTIAL, (&MODERATE_KDD, &MODERATE_MASTER_KEY)).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &ARGON_MOD_CREDENTIAL, (&MODERATE_KDD, &MODERATE_MASTER_KEY)).unwrap();
+        wallet_service.delete_wallet(&config, &ARGON_MOD_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &ARGON_MOD_CREDENTIAL, (&MODERATE_KDD, &MODERATE_MASTER_KEY)).unwrap();
     }
 
     #[test]
@@ -936,9 +940,10 @@ mod tests {
 
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        wallet_service.delete_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        wallet_service.delete_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
     }
 
     #[test]
@@ -946,10 +951,11 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
-        let res = wallet_service.delete_wallet(&_config(), &RAW_CREDENTIAL);
+        let res = wallet_service.delete_wallet(&config, &RAW_CREDENTIAL);
 
         assert_match!(Err(WalletError::CommonError(CommonError::InvalidState(_))), res);
     }
@@ -959,9 +965,10 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
 
-        let res = wallet_service.delete_wallet(&_config(), &ARGON_INT_CREDENTIAL);
+        let res = wallet_service.delete_wallet(&config, &ARGON_INT_CREDENTIAL);
         assert_match!(Err(WalletError::AccessFailed(_)), res);
     }
 
@@ -970,8 +977,8 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-
-        let res = wallet_service.delete_wallet(&_config(), &RAW_CREDENTIAL);
+        let config = _config();
+        let res = wallet_service.delete_wallet(&config, &RAW_CREDENTIAL);
         assert_match!(Err(WalletError::NotFound(_)), res);
     }
 
@@ -980,8 +987,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         // cleanup
         wallet_service.close_wallet(handle).unwrap();
@@ -992,8 +1000,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &ARGON_INT_CREDENTIAL, (&INTERACTIVE_KDD, &INTERACTIVE_MASTER_KEY)).unwrap();
-        let handle = wallet_service.open_wallet(&_config(), &ARGON_INT_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &ARGON_INT_CREDENTIAL, (&INTERACTIVE_KDD, &INTERACTIVE_MASTER_KEY)).unwrap();
+        let handle = wallet_service.open_wallet(&config, &ARGON_INT_CREDENTIAL).unwrap();
 
         // cleanup
         wallet_service.close_wallet(handle).unwrap();
@@ -1004,8 +1013,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &ARGON_MOD_CREDENTIAL, (&MODERATE_KDD, &MODERATE_MASTER_KEY)).unwrap();
-        let handle = wallet_service.open_wallet(&_config(), &ARGON_MOD_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &ARGON_MOD_CREDENTIAL, (&MODERATE_KDD, &MODERATE_MASTER_KEY)).unwrap();
+        let handle = wallet_service.open_wallet(&config, &ARGON_MOD_CREDENTIAL).unwrap();
 
         // cleanup
         wallet_service.close_wallet(handle).unwrap();
@@ -1016,7 +1026,8 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        let res = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL);
+        let config = _config();
+        let res = wallet_service.open_wallet(&config, &RAW_CREDENTIAL);
         assert_match!(Err(WalletError::NotFound(_)), res);
     }
 
@@ -1025,9 +1036,10 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
-        let res = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL);
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
+        let res = wallet_service.open_wallet(&config, &RAW_CREDENTIAL);
         assert_match!(Err(WalletError::AlreadyOpened(_)), res);
     }
 
@@ -1038,8 +1050,9 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
     }
 
     #[test]
@@ -1047,9 +1060,10 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
 
-        let res = wallet_service.open_wallet(&_config(), &ARGON_INT_CREDENTIAL);
+        let res = wallet_service.open_wallet(&config, &ARGON_INT_CREDENTIAL);
         assert_match!(Err(WalletError::AccessFailed(_)), res);
     }
 
@@ -1058,11 +1072,12 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
         wallet_service.close_wallet(wallet_handle).unwrap();
 
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
         wallet_service.close_wallet(wallet_handle).unwrap();
     }
 
@@ -1073,11 +1088,12 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
         wallet_service.close_wallet(wallet_handle).unwrap();
 
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
         wallet_service.close_wallet(wallet_handle).unwrap();
     }
 
@@ -1086,8 +1102,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         let res = wallet_service.close_wallet(wallet_handle + 1);
         assert_match!(Err(WalletError::InvalidHandle(_)), res);
@@ -1100,8 +1117,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1114,8 +1132,9 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1126,8 +1145,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(false, false, false)).unwrap();
@@ -1145,8 +1165,9 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(false, false, false)).unwrap();
@@ -1161,8 +1182,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(false, true, false)).unwrap();
@@ -1179,8 +1201,9 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(false, true, false)).unwrap();
@@ -1195,8 +1218,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
         let mut tags = HashMap::new();
         tags.insert(String::from("1"), String::from("some"));
 
@@ -1215,8 +1239,9 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
         let tags = serde_json::from_str(r#"{"1":"some"}"#).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &tags).unwrap();
@@ -1232,12 +1257,13 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.close_wallet(wallet_handle).unwrap();
 
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(false, true, false)).unwrap();
         assert_eq!("value1", record.get_value().unwrap());
     }
@@ -1247,8 +1273,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         let res = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(false, true, false));
 
@@ -1261,9 +1288,9 @@ mod tests {
 
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
-
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         let res = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(false, true, false));
         assert_match!(Err(WalletError::ItemNotFound), res);
@@ -1281,9 +1308,11 @@ mod tests {
         let value = "value";
         let new_value = "new_value";
 
+        let config = _config();
+
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, type_, name, &_fetch_options(false, true, false)).unwrap();
@@ -1306,8 +1335,9 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, type_, name, &_fetch_options(false, true, false)).unwrap();
@@ -1329,9 +1359,11 @@ mod tests {
         let name = "name";
         let value = "value";
 
+        let config = _config();
+
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, type_, name, &_fetch_options(false, true, false)).unwrap();
@@ -1353,8 +1385,9 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, type_, name, &_fetch_options(false, true, false)).unwrap();
@@ -1378,8 +1411,9 @@ mod tests {
         let tags = serde_json::from_str(r#"{"tag_name_1":"tag_value_1"}"#).unwrap();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &tags).unwrap();
 
@@ -1405,8 +1439,10 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &tags).unwrap();
 
@@ -1433,8 +1469,10 @@ mod tests {
         let tags = serde_json::from_str(r#"{"tag_name_1":"tag_value_1", "tag_name_2":"tag_value_2", "~tag_name_3":"tag_value_3"}"#).unwrap();
         let wallet_service = WalletService::new();
 
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &tags).unwrap();
 
@@ -1458,8 +1496,10 @@ mod tests {
 
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &tags).unwrap();
 
@@ -1485,9 +1525,9 @@ mod tests {
         let tags = serde_json::from_str(r#"{"tag_name_1":"tag_value_1", "tag_name_2":"new_tag_value_2", "~tag_name_3":"new_tag_value_3"}"#).unwrap();
 
         let wallet_service = WalletService::new();
-
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &tags).unwrap();
 
@@ -1514,8 +1554,10 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, type_, name, value, &tags).unwrap();
 
@@ -1534,8 +1576,11 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+
+        let config = _config();
+
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.add_record(wallet_handle, "type", "key2", "value2", &HashMap::new()).unwrap();
@@ -1557,8 +1602,9 @@ mod tests {
         let wallet_service = WalletService::new();
         _register_inmem_wallet(&wallet_service);
 
-        wallet_service.create_wallet(&_config_inmem(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config_inmem(), &RAW_CREDENTIAL).unwrap();
+        let config_inmem = _config_inmem();
+        wallet_service.create_wallet(&config_inmem, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config_inmem, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.add_record(wallet_handle, "type", "key2", "value2", &HashMap::new()).unwrap();
@@ -1581,8 +1627,11 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+
+        let config = _config();
+
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(true, true, true)).unwrap();
@@ -1591,18 +1640,18 @@ mod tests {
 
         wallet_service.close_wallet(wallet_handle).unwrap();
 
-        let wallet_handle = wallet_service.open_wallet(&_config(), &_rekey_credentials_moderate()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &_rekey_credentials_moderate()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(true, true, true)).unwrap();
         assert_eq!("type", record.get_type().unwrap());
         assert_eq!("value1", record.get_value().unwrap());
         wallet_service.close_wallet(wallet_handle).unwrap();
 
         // Access failed for old key
-        let res = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL);
+        let res = wallet_service.open_wallet(&config, &RAW_CREDENTIAL);
         assert_match!(Err(WalletError::AccessFailed(_)), res);
 
         // Works ok with new key when reopening
-        let wallet_handle = wallet_service.open_wallet(&_config(), &_credentials_for_new_key_moderate()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &_credentials_for_new_key_moderate()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(true, true, true)).unwrap();
         assert_eq!("type", record.get_type().unwrap());
         assert_eq!("value1", record.get_value().unwrap());
@@ -1613,8 +1662,10 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(true, true, true)).unwrap();
@@ -1623,18 +1674,18 @@ mod tests {
 
         wallet_service.close_wallet(wallet_handle).unwrap();
 
-        let wallet_handle = wallet_service.open_wallet(&_config(), &_rekey_credentials_interactive()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &_rekey_credentials_interactive()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(true, true, true)).unwrap();
         assert_eq!("type", record.get_type().unwrap());
         assert_eq!("value1", record.get_value().unwrap());
         wallet_service.close_wallet(wallet_handle).unwrap();
 
         // Access failed for old key
-        let res = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL);
+        let res = wallet_service.open_wallet(&config, &RAW_CREDENTIAL);
         assert_match!(Err(WalletError::AccessFailed(_)), res);
 
         // Works ok with new key when reopening
-        let wallet_handle = wallet_service.open_wallet(&_config(), &_credentials_for_new_key_interactive()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &_credentials_for_new_key_interactive()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(true, true, true)).unwrap();
         assert_eq!("type", record.get_type().unwrap());
         assert_eq!("value1", record.get_value().unwrap());
@@ -1644,9 +1695,11 @@ mod tests {
     fn wallet_service_key_rotation_for_rekey_raw_method() {
         _cleanup();
 
+        let config = _config();
+
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(true, true, true)).unwrap();
@@ -1655,18 +1708,18 @@ mod tests {
 
         wallet_service.close_wallet(wallet_handle).unwrap();
 
-        let wallet_handle = wallet_service.open_wallet(&_config(), &_rekey_credentials_raw()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &_rekey_credentials_raw()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(true, true, true)).unwrap();
         assert_eq!("type", record.get_type().unwrap());
         assert_eq!("value1", record.get_value().unwrap());
         wallet_service.close_wallet(wallet_handle).unwrap();
 
         // Access failed for old key
-        let res = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL);
+        let res = wallet_service.open_wallet(&config, &RAW_CREDENTIAL);
         assert_match!(Err(WalletError::AccessFailed(_)), res);
 
         // Works ok with new key when reopening
-        let wallet_handle = wallet_service.open_wallet(&_config(), &_credentials_for_new_key_raw()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &_credentials_for_new_key_raw()).unwrap();
         let record = wallet_service.get_record(wallet_handle, "type", "key1", &_fetch_options(true, true, true)).unwrap();
         assert_eq!("type", record.get_type().unwrap());
         assert_eq!("value1", record.get_value().unwrap());
@@ -1675,10 +1728,11 @@ mod tests {
     #[test]
     fn wallet_service_export_wallet_when_empty() {
         _cleanup();
+        let config = _config();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         let export_config = _export_config_raw();
         let (kdd, master_key) = _export_key_raw();
@@ -1690,10 +1744,11 @@ mod tests {
     #[test]
     fn wallet_service_export_wallet_1_item() {
         _cleanup();
+        let config = _config();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1707,10 +1762,11 @@ mod tests {
     #[test]
     fn wallet_service_export_wallet_1_item_interactive_method() {
         _cleanup();
+        let config = _config();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1724,10 +1780,11 @@ mod tests {
     #[test]
     fn wallet_service_export_wallet_1_item_raw_method() {
         _cleanup();
+        let config = _config();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1748,10 +1805,11 @@ mod tests {
         }
 
         assert!(_export_file_path().exists());
+        let config = _config();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         let (kdd, master_key) = _export_key_raw();
         let res = wallet_service.export_wallet(wallet_handle, &_export_config_raw(), 0, (&kdd, &master_key));
@@ -1762,9 +1820,10 @@ mod tests {
     fn wallet_service_export_wallet_returns_error_if_wrong_handle() {
         _cleanup();
 
+        let config = _config();
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         let (kdd, master_key) = _export_key_raw();
         let res = wallet_service.export_wallet(wallet_handle + 1, &_export_config_raw(), 0, (&kdd, &master_key));
@@ -1776,9 +1835,10 @@ mod tests {
     fn wallet_service_export_import_wallet_1_item() {
         _cleanup();
 
+        let config = _config();
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1788,10 +1848,10 @@ mod tests {
         assert!(_export_file_path().exists());
 
         wallet_service.close_wallet(wallet_handle).unwrap();
-        wallet_service.delete_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.delete_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
-        wallet_service.import_wallet(&_config(), &RAW_CREDENTIAL, &_export_config_raw()).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.import_wallet(&config, &RAW_CREDENTIAL, &_export_config_raw()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
     }
 
@@ -1799,9 +1859,10 @@ mod tests {
     fn wallet_service_export_import_wallet_1_item_for_interactive_method() {
         _cleanup();
 
+        let config = _config();
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1811,10 +1872,10 @@ mod tests {
         assert!(_export_file_path().exists());
 
         wallet_service.close_wallet(wallet_handle).unwrap();
-        wallet_service.delete_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.delete_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
-        wallet_service.import_wallet(&_config(), &RAW_CREDENTIAL, &_export_config_interactive()).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.import_wallet(&config, &RAW_CREDENTIAL, &_export_config_interactive()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
     }
 
@@ -1822,9 +1883,10 @@ mod tests {
     fn wallet_service_export_import_wallet_1_item_for_moderate_method() {
         _cleanup();
 
+        let config = _config();
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1834,10 +1896,10 @@ mod tests {
         assert!(_export_file_path().exists());
 
         wallet_service.close_wallet(wallet_handle).unwrap();
-        wallet_service.delete_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.delete_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
-        wallet_service.import_wallet(&_config(), &ARGON_MOD_CREDENTIAL, &_export_config_raw()).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &ARGON_MOD_CREDENTIAL).unwrap();
+        wallet_service.import_wallet(&config, &ARGON_MOD_CREDENTIAL, &_export_config_raw()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &ARGON_MOD_CREDENTIAL).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
     }
 
@@ -1846,8 +1908,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &ARGON_INT_CREDENTIAL, (&INTERACTIVE_KDD, &INTERACTIVE_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &ARGON_INT_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &ARGON_INT_CREDENTIAL, (&INTERACTIVE_KDD, &INTERACTIVE_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &ARGON_INT_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1857,10 +1920,10 @@ mod tests {
         assert!(_export_file_path().exists());
 
         wallet_service.close_wallet(wallet_handle).unwrap();
-        wallet_service.delete_wallet(&_config(), &ARGON_INT_CREDENTIAL).unwrap();
+        wallet_service.delete_wallet(&config, &ARGON_INT_CREDENTIAL).unwrap();
 
-        wallet_service.import_wallet(&_config(), &ARGON_MOD_CREDENTIAL, &_export_config_moderate()).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &ARGON_MOD_CREDENTIAL).unwrap();
+        wallet_service.import_wallet(&config, &ARGON_MOD_CREDENTIAL, &_export_config_moderate()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &ARGON_MOD_CREDENTIAL).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
     }
 
@@ -1869,8 +1932,9 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         wallet_service.add_record(wallet_handle, "type", "key1", "value1", &HashMap::new()).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
@@ -1880,10 +1944,10 @@ mod tests {
         assert!(_export_file_path().exists());
 
         wallet_service.close_wallet(wallet_handle).unwrap();
-        wallet_service.delete_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.delete_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
-        wallet_service.import_wallet(&_config(), &ARGON_INT_CREDENTIAL, &_export_config_interactive()).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &ARGON_INT_CREDENTIAL).unwrap();
+        wallet_service.import_wallet(&config, &ARGON_INT_CREDENTIAL, &_export_config_interactive()).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &ARGON_INT_CREDENTIAL).unwrap();
         wallet_service.get_record(wallet_handle, "type", "key1", "{}").unwrap();
     }
 
@@ -1892,18 +1956,19 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-        wallet_service.create_wallet(&_config(), &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
-        let wallet_handle = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        let config = _config();
+        wallet_service.create_wallet(&config, &RAW_CREDENTIAL, (&RAW_KDD, &RAW_MASTER_KEY)).unwrap();
+        let wallet_handle = wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
         let (kdd, master_key) = _export_key();
         wallet_service.export_wallet(wallet_handle, &_export_config_raw(), 0, (&kdd, &master_key)).unwrap();
         assert!(_export_file_path().exists());
 
         wallet_service.close_wallet(wallet_handle).unwrap();
-        wallet_service.delete_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.delete_wallet(&config, &RAW_CREDENTIAL).unwrap();
 
-        wallet_service.import_wallet(&_config(), &RAW_CREDENTIAL, &_export_config_raw()).unwrap();
-        wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL).unwrap();
+        wallet_service.import_wallet(&config, &RAW_CREDENTIAL, &_export_config_raw()).unwrap();
+        wallet_service.open_wallet(&config, &RAW_CREDENTIAL).unwrap();
     }
 
     #[test]
@@ -1911,11 +1976,11 @@ mod tests {
         _cleanup();
 
         let wallet_service = WalletService::new();
-
-        let res = wallet_service.import_wallet(&_config(), &RAW_CREDENTIAL, &_export_config_raw());
+        let config = _config();
+        let res = wallet_service.import_wallet(&config, &RAW_CREDENTIAL, &_export_config_raw());
         assert_match!(Err(WalletError::CommonError(CommonError::IOError(_))), res);
 
-        let res = wallet_service.open_wallet(&_config(), &RAW_CREDENTIAL);
+        let res = wallet_service.open_wallet(&config, &RAW_CREDENTIAL);
         assert_match!(Err(_), res);
     }
 
@@ -1928,32 +1993,56 @@ mod tests {
     }
 
     fn _config() -> Config {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let i: i32 = rng.gen();
+        let s = i.to_string();
+        let mut w = "w".to_string();
+        w.push_str(&s);
         Config {
-            id: "w1".to_string(),
+            id: w,
             storage_type: None,
             storage_config: None,
         }
     }
 
     fn _config_default() -> Config {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let i: i32 = rng.gen();
+        let s = i.to_string();
+        let mut w = "w".to_string();
+        w.push_str(&s);
         Config {
-            id: "w1".to_string(),
+            id: w,
             storage_type: Some("default".to_string()),
             storage_config: None,
         }
     }
 
     fn _config_inmem() -> Config {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let i: i32 = rng.gen();
+        let s = i.to_string();
+        let mut w = "w".to_string();
+        w.push_str(&s);
         Config {
-            id: "w1".to_string(),
+            id: w,
             storage_type: Some("inmem".to_string()),
             storage_config: None,
         }
     }
 
     fn _config_unknown() -> Config {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let i: i32 = rng.gen();
+        let s = i.to_string();
+        let mut w = "w".to_string();
+        w.push_str(&s);
         Config {
-            id: "w1".to_string(),
+            id: w,
             storage_type: Some("unknown".to_string()),
             storage_config: None,
         }

--- a/libindy/tests/wallet.rs
+++ b/libindy/tests/wallet.rs
@@ -62,6 +62,7 @@ mod high_cases {
         fn indy_create_wallet_works() {
             utils::setup();
 
+            const DEFAULT_WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_create_wallet_works","storage_type":"default"}"#;
             wallet::create_wallet(DEFAULT_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
 
             utils::tear_down();
@@ -72,7 +73,7 @@ mod high_cases {
             utils::setup();
 
             let config = json!({
-                "id": "wallet_1",
+                "id": "wallet_indy_create_wallet_works_for_custom_path",
                 "storage_type": "default",
                 "storage_config": {
                     "path": _custom_path(),
@@ -90,6 +91,7 @@ mod high_cases {
             InmemWallet::cleanup();
 
             wallet::register_wallet_storage(INMEM_TYPE, false).unwrap();
+            const INMEM_WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_create_wallet_works_for_plugged","storage_type":"inmem"}"#;
             wallet::create_wallet(INMEM_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
 
             InmemWallet::cleanup();
@@ -101,6 +103,7 @@ mod high_cases {
             utils::setup();
 
             let res = wallet::create_wallet(UNKNOWN_WALLET_CONFIG, WALLET_CREDENTIALS);
+            const UNKNOWN_WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_create_wallet_works_for_unknown_type","storage_type":"unknown"}"#;
             assert_eq!(res.unwrap_err(), ErrorCode::WalletUnknownTypeError);
 
             utils::tear_down();
@@ -110,6 +113,7 @@ mod high_cases {
         fn indy_create_wallet_works_for_empty_type() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_create_wallet_works_for_empty_type"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
 
             utils::tear_down();
@@ -123,6 +127,7 @@ mod high_cases {
         fn indy_delete_wallet_works() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_delete_wallet_works"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             wallet::delete_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
@@ -135,7 +140,7 @@ mod high_cases {
             utils::setup();
 
             let config = json!({
-                "id": "wallet_1",
+                "id": "wallet_indy_delete_wallet_works_for_custom_path",
                 "storage_type": "default",
                 "storage_config": {
                     "path": _custom_path(),
@@ -153,6 +158,7 @@ mod high_cases {
         fn indy_delete_wallet_works_for_closed() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_delete_wallet_works_for_closed"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             wallet::close_wallet(wallet_handle).unwrap();
@@ -166,6 +172,7 @@ mod high_cases {
         fn indy_delete_wallet_works_for_opened() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_delete_wallet_works_for_opened"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let res = wallet::delete_wallet(WALLET_CONFIG, WALLET_CREDENTIALS);
@@ -182,6 +189,7 @@ mod high_cases {
             InmemWallet::cleanup();
 
             wallet::register_wallet_storage(INMEM_TYPE, false).unwrap();
+            const INMEM_WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_delete_wallet_works_for_plugged","storage_type":"inmem"}"#;
             wallet::create_wallet(INMEM_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             wallet::delete_wallet(INMEM_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             wallet::create_wallet(INMEM_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
@@ -198,6 +206,7 @@ mod high_cases {
         fn indy_open_wallet_works() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_open_wallet_works"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
 
@@ -211,7 +220,7 @@ mod high_cases {
             utils::setup();
 
             let config = json!({
-                "id": "wallet_1",
+                "id": "wallet_indy_open_wallet_works_for_custom_path",
                 "storage_type": "default",
                 "storage_config": {
                     "path": _custom_path(),
@@ -232,6 +241,7 @@ mod high_cases {
             InmemWallet::cleanup();
 
             wallet::register_wallet_storage(INMEM_TYPE, false).unwrap();
+            const INMEM_WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_open_wallet_works_for_plugged","storage_type":"inmem"}"#;
             wallet::create_wallet(INMEM_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let wallet_handle = wallet::open_wallet(INMEM_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
 
@@ -244,37 +254,60 @@ mod high_cases {
 
     mod close_wallet {
         use super::*;
+        use std::panic;
 
         #[test]
         fn indy_close_wallet_works() {
             utils::setup();
+            const CONFIG: &'static str = r#"{"id":"wallet_indy_close_wallet_works"}"#;
 
-            wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            wallet::create_wallet(CONFIG, WALLET_CREDENTIALS).unwrap();
 
-            let wallet_handle = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let wallet_handle = wallet::open_wallet(CONFIG, WALLET_CREDENTIALS).unwrap();
             wallet::close_wallet(wallet_handle).unwrap();
 
-            let wallet_handle = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+            let wallet_handle = wallet::open_wallet(CONFIG, WALLET_CREDENTIALS).unwrap();
 
             utils::tear_down_with_wallet(wallet_handle);
         }
 
         #[test]
         fn indy_close_wallet_works_for_plugged() {
-            utils::setup();
-            InmemWallet::cleanup();
+            run_test(|| {
+                    utils::setup();
+                    InmemWallet::cleanup();
+                },
+                 || {
+                     wallet::register_wallet_storage(INMEM_TYPE, false).unwrap();
+                     const CONFIG: &'static str = r#"{"id":"wallet_indy_close_wallet_works_for_plugged"}"#;
+                     wallet::create_wallet(CONFIG, WALLET_CREDENTIALS).unwrap();
 
-            wallet::register_wallet_storage(INMEM_TYPE, false).unwrap();
-            wallet::create_wallet(INMEM_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
+                     let wallet_handle = wallet::open_wallet(CONFIG, WALLET_CREDENTIALS).unwrap();
+                     wallet::close_wallet(wallet_handle).unwrap();
 
-            let wallet_handle = wallet::open_wallet(INMEM_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
-            wallet::close_wallet(wallet_handle).unwrap();
+                     let wallet_handle = wallet::open_wallet(CONFIG, WALLET_CREDENTIALS).unwrap();
+                     wallet::close_wallet(wallet_handle).unwrap();
+                 },
+                 || {
+                     InmemWallet::cleanup();
+                     utils::tear_down();
+                 })
+        }
 
-            let wallet_handle = wallet::open_wallet(INMEM_WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
-            wallet::close_wallet(wallet_handle).unwrap();
+        fn run_test<S,T,D>(setup: S, test: T, teardown: D) -> ()
+            where S: FnOnce() -> () + panic::UnwindSafe,
+                  T: FnOnce() -> () + panic::UnwindSafe,
+                  D: FnOnce() -> () + panic::UnwindSafe
+        {
+            setup();
 
-            InmemWallet::cleanup();
-            utils::tear_down();
+            let result = panic::catch_unwind(|| {
+                test()
+            });
+
+            teardown();
+
+            assert!(result.is_ok())
         }
     }
 
@@ -309,6 +342,7 @@ mod high_cases {
             let path = wallet::export_wallet_path();
             let config_json = wallet::prepare_export_wallet_config(&path);
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_import_wallet_works"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
 
@@ -345,6 +379,7 @@ mod high_cases {
             let key = wallet::generate_wallet_key(None).unwrap();
 
             let credentials = json!({"key": key, "key_derivation_method": "RAW"}).to_string();
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_generate_wallet_key_works"}"#;
             wallet::create_wallet(WALLET_CONFIG, &credentials).unwrap();
 
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, &credentials).unwrap();
@@ -363,6 +398,7 @@ mod high_cases {
             assert_eq!(key.from_base58().unwrap(), vec![177, 92, 220, 199, 104, 203, 161, 4, 218, 78, 105, 13, 7, 50, 66, 107, 154, 155, 108, 133, 1, 30, 87, 149, 233, 76, 39, 156, 178, 46, 230, 124]);
 
             let credentials = json!({"key": key, "key_derivation_method": "RAW"}).to_string();
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_generate_wallet_key_works_for_seed"}"#;
             wallet::create_wallet(WALLET_CONFIG, &credentials).unwrap();
 
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, &credentials).unwrap();
@@ -423,6 +459,7 @@ mod medium_cases {
         fn indy_create_wallet_works_for_duplicate_name() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_create_wallet_works_for_duplicate_name"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let res = wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS);
             assert_eq!(res.unwrap_err(), ErrorCode::WalletAlreadyExistsError);
@@ -434,6 +471,7 @@ mod medium_cases {
         fn indy_create_wallet_works_for_missed_key() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_create_wallet_works_for_missed_key"}"#;
             let res = wallet::create_wallet(WALLET_CONFIG, r#"{}"#);
             assert_eq!(res.unwrap_err(), ErrorCode::CommonInvalidStructure);
 
@@ -455,6 +493,7 @@ mod medium_cases {
             test::cleanup_storage();
 
             let credentials = json!({"key": "key", "key_derivation_method": "RAW"}).to_string();
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_create_wallet_works_for_raw_key_invalid_length"}"#;
             let res = wallet::create_wallet(WALLET_CONFIG, &credentials);
             assert_eq!(res.unwrap_err(), ErrorCode::CommonInvalidStructure);
 
@@ -469,6 +508,7 @@ mod medium_cases {
         fn indy_delete_wallet_works_for_not_created() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_delete_wallet_works_for_not_created"}"#;
             let res = wallet::delete_wallet(WALLET_CONFIG, WALLET_CREDENTIALS);
             assert_eq!(res.unwrap_err(), ErrorCode::WalletNotFoundError);
 
@@ -491,6 +531,7 @@ mod medium_cases {
         fn indy_delete_wallet_works_for_wrong_credentials() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_delete_wallet_works_for_wrong_credentials"}"#;
             wallet::create_wallet(WALLET_CONFIG, r#"{"key":"key"}"#).unwrap();
             let res = wallet::delete_wallet(WALLET_CONFIG, r#"{"key":"other_key"}"#);
             assert_eq!(res.unwrap_err(), ErrorCode::WalletAccessFailed);
@@ -506,6 +547,7 @@ mod medium_cases {
         fn indy_open_wallet_works_for_not_created_wallet() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_open_wallet_works_for_not_created_wallet"}"#;
             let res = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS);
             assert_eq!(res.unwrap_err(), ErrorCode::WalletNotFoundError);
 
@@ -516,6 +558,7 @@ mod medium_cases {
         fn indy_open_wallet_works_for_twice() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_open_wallet_works_for_twice"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
 
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
@@ -550,6 +593,7 @@ mod medium_cases {
         fn indy_open_wallet_works_for_invalid_credentials() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_open_wallet_works_for_invalid_credentials"}"#;
             wallet::create_wallet(WALLET_CONFIG, r#"{"key":"key"}"#).unwrap();
             let res = wallet::open_wallet(WALLET_CONFIG, r#"{"key":"other_key"}"#);
             assert_eq!(ErrorCode::WalletAccessFailed, res.unwrap_err());
@@ -561,6 +605,7 @@ mod medium_cases {
         fn indy_open_wallet_works_for_changing_credentials() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_open_wallet_works_for_changing_credentials"}"#;
             wallet::create_wallet(WALLET_CONFIG, r#"{"key":"key"}"#).unwrap();
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, r#"{"key":"key", "rekey":"other_key"}"#).unwrap();
             wallet::close_wallet(wallet_handle).unwrap();
@@ -577,6 +622,7 @@ mod medium_cases {
 
             let config = r#"{"field":"value"}"#;
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_open_wallet_works_for_invalid_config"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let res = wallet::open_wallet(config, WALLET_CREDENTIALS);
             assert_eq!(res.unwrap_err(), ErrorCode::CommonInvalidStructure);
@@ -679,6 +725,7 @@ mod medium_cases {
         fn indy_import_wallet_returns_error_if_invalid_config() {
             utils::setup();
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_import_wallet_returns_error_if_invalid_config"}"#;
             let res = wallet::import_wallet(WALLET_CONFIG, WALLET_CREDENTIALS, "{}");
             assert_eq!(res.unwrap_err(), ErrorCode::CommonInvalidStructure);
 
@@ -692,6 +739,7 @@ mod medium_cases {
             let path = wallet::export_wallet_path();
             let config_json = wallet::prepare_export_wallet_config(&path);
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_import_wallet_works_for_other_key"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
 
@@ -720,6 +768,7 @@ mod medium_cases {
             let path = wallet::export_wallet_path();
             let config_json = wallet::prepare_export_wallet_config(&path);
 
+            const WALLET_CONFIG: &'static str = r#"{"id":"wallet_indy_import_wallet_works_for_duplicate_name"}"#;
             wallet::create_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
             let wallet_handle = wallet::open_wallet(WALLET_CONFIG, WALLET_CREDENTIALS).unwrap();
 


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

Currently tests can't run in parallel because all tests use the same wallet names and identifiers and because cleanup after one test wipes data of parallel tests too.

This PR gives unique name to all wallets and storage. Fixing cleanup will be done in another PR
This PR can be merged because all tests work as expected if run on one thread. `RUST_TEST_THREADS=1 cargo test`