### PR TITLE
Vcx Object Release Errors

### DIFF
--- a/vcx/libvcx/src/api/connection.rs
+++ b/vcx/libvcx/src/api/connection.rs
@@ -458,10 +458,10 @@ pub extern fn vcx_connection_release(connection_handle: u32) -> u32 {
 
     let source_id = get_source_id(connection_handle).unwrap_or_default();
     match release(connection_handle) {
-        Ok(c) => {
+        Ok(_) => {
             trace!("vcx_connection_release(connection_handle: {}, rc: {}), source_id: {:?}",
-                       connection_handle, error_string(0), source_id);
-            c
+                       connection_handle, error_string(error::SUCCESS.code_num), source_id);
+            error::SUCCESS.code_num
         },
         Err(e) => {
             warn!("vcx_connection_release(connection_handle: {}), rc: {}), source_id: {:?}",

--- a/vcx/libvcx/src/api/credential_def.rs
+++ b/vcx/libvcx/src/api/credential_def.rs
@@ -57,13 +57,18 @@ pub extern fn vcx_credentialdef_create(command_handle: u32,
     check_useful_c_str!(tag, error::INVALID_OPTION.code_num);
     check_useful_c_str!(revocation_details, error::INVALID_OPTION.code_num);
 
+    debug!("Parameters to vcx_credentialdef_create are valid");
+
     let issuer_did: String = if !issuer_did.is_null() {
         check_useful_c_str!(issuer_did, error::INVALID_OPTION.code_num);
         issuer_did.to_owned()
     } else {
         match settings::get_config_value(settings::CONFIG_INSTITUTION_DID) {
             Ok(x) => x,
-            Err(x) => return x
+            Err(x) => { 
+                error!("Invalid {} set", settings::CONFIG_INSTITUTION_DID);
+                return x
+            },
         }
     };
     
@@ -311,12 +316,18 @@ pub extern fn vcx_credentialdef_release(credentialdef_handle: u32) -> u32 {
 
     let source_id = credential_def::get_source_id(credentialdef_handle).unwrap_or_default();
     match credential_def::release(credentialdef_handle) {
-        Ok(_) => trace!("vcx_credentialdef_release(credentialdef_handle: {}, rc: {}), source_id: {}",
-                      credentialdef_handle, error_string(0), source_id),
-        Err(x) => warn!("vcx_credentialdef_release(credentialdef_handle: {}, rc: {}), source_id: {}",
-                        credentialdef_handle, x.to_string(), source_id),
-    };
-    error::SUCCESS.code_num
+        Ok(_) => {
+            trace!("vcx_credentialdef_release(credentialdef_handle: {}, rc: {}), source_id: {}",
+                      credentialdef_handle, error_string(0), source_id);
+            error::SUCCESS.code_num
+        },
+
+        Err(x) => {
+            warn!("vcx_credentialdef_release(credentialdef_handle: {}, rc: {}), source_id: {}",
+                        credentialdef_handle, x.to_string(), source_id);
+            x.to_error_code()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -398,6 +409,27 @@ mod tests {
         assert!(handle > 0);
 
     }
+
+    #[test]
+    fn test_vcx_credentialdef_release() {
+        init!("true");
+
+        let cb = return_types_u32::Return_U32_U32::new().unwrap();
+        assert_eq!(vcx_credentialdef_create(cb.command_handle,
+                                            CString::new("Test Source ID Release Test").unwrap().into_raw(),
+                                            CString::new("Test Credential Def Release").unwrap().into_raw(),
+                                            CString::new(SCHEMA_ID).unwrap().into_raw(),
+                                            ptr::null(),
+                                            CString::new("tag").unwrap().into_raw(),
+                                            CString::new("{}").unwrap().into_raw(),
+                                            0,
+                                            Some(cb.get_callback())), error::SUCCESS.code_num);
+
+        let handle = cb.receive(Some(Duration::from_secs(10))).unwrap();
+        let unknown_handle = handle+1;
+        assert_eq!(vcx_credentialdef_release(unknown_handle), error::INVALID_CREDENTIAL_DEF_HANDLE.code_num);
+    }
+        
 
     #[test]
     fn test_vcx_creddef_get_id(){

--- a/vcx/libvcx/src/api/credential_def.rs
+++ b/vcx/libvcx/src/api/credential_def.rs
@@ -57,18 +57,13 @@ pub extern fn vcx_credentialdef_create(command_handle: u32,
     check_useful_c_str!(tag, error::INVALID_OPTION.code_num);
     check_useful_c_str!(revocation_details, error::INVALID_OPTION.code_num);
 
-    debug!("Parameters to vcx_credentialdef_create are valid");
-
     let issuer_did: String = if !issuer_did.is_null() {
         check_useful_c_str!(issuer_did, error::INVALID_OPTION.code_num);
         issuer_did.to_owned()
     } else {
         match settings::get_config_value(settings::CONFIG_INSTITUTION_DID) {
             Ok(x) => x,
-            Err(x) => { 
-                error!("Invalid {} set", settings::CONFIG_INSTITUTION_DID);
-                return x
-            },
+            Err(x) => return x,
         }
     };
     

--- a/vcx/libvcx/src/api/issuer_credential.rs
+++ b/vcx/libvcx/src/api/issuer_credential.rs
@@ -430,12 +430,17 @@ pub extern fn vcx_issuer_credential_release(credential_handle: u32) -> u32 {
     info!("vcx_issuer_credential_release >>>");
     let source_id = issuer_credential::get_source_id(credential_handle).unwrap_or_default();
     match issuer_credential::release(credential_handle) {
-        Ok(_) => trace!("(vcx_issuer_credential_release credential_handle: {}, rc: {}), source_id: {}",
-                       credential_handle, error_string(0), source_id),
-        Err(e) => warn!("(vcx_issuer_credential_release credential_handle: {}, rc: {}), source_id: {}",
-                       credential_handle, error_string(e.to_error_code()), source_id),
-    };
-    error::SUCCESS.code_num
+        Ok(_) => {
+            trace!("(vcx_issuer_credential_release credential_handle: {}, rc: {}), source_id: {}",
+                       credential_handle, error_string(0), source_id);
+            error::SUCCESS.code_num
+        },
+        Err(e) => {
+            warn!("(vcx_issuer_credential_release credential_handle: {}, rc: {}), source_id: {}",
+                       credential_handle, error_string(e.to_error_code()), source_id);
+            e.to_error_code()
+        },
+    }
 }
 
 /// Retrieve the txn associated with paying for the issuer_credential
@@ -596,6 +601,18 @@ mod tests {
         cb.receive(Some(Duration::from_secs(10))).is_err();
     }
 
+    fn create_default_issuer_credential() -> u32 {
+        let cb = return_types_u32::Return_U32_U32::new().unwrap();
+        assert_eq!(vcx_issuer_create_credential(cb.command_handle,
+            CString::new(DEFAULT_CREDENTIAL_NAME).unwrap().into_raw(),
+            ::credential_def::tests::create_cred_def_fake(),
+            ptr::null(),
+            CString::new(DEFAULT_ATTR).unwrap().into_raw(),
+            CString::new(DEFAULT_CREDENTIAL_NAME).unwrap().into_raw(),
+            CString::new("1").unwrap().into_raw(),
+            Some(cb.get_callback())), error::SUCCESS.code_num);
+       cb.receive(Some(Duration::from_secs(10))).unwrap()
+    }
     #[test]
     fn test_vcx_issuer_credential_serialize_deserialize() {
         init!("true");
@@ -744,5 +761,13 @@ mod tests {
                                               Some(cb.get_callback())),
                    error::SUCCESS.code_num);
         cb.receive(Some(Duration::from_secs(10))).unwrap();
+    }
+
+    #[test]
+    fn test_vcx_issuer_credential_release() {
+        init!("true");
+        let handle = create_default_issuer_credential();
+        let unknown_handle = handle + 1;
+        assert_eq!(vcx_issuer_credential_release(unknown_handle), error::INVALID_ISSUER_CREDENTIAL_HANDLE.code_num);
     }
 }

--- a/vcx/libvcx/src/api/schema.rs
+++ b/vcx/libvcx/src/api/schema.rs
@@ -184,12 +184,17 @@ pub extern fn vcx_schema_release(schema_handle: u32) -> u32 {
 
     let source_id = schema::get_source_id(schema_handle).unwrap_or_default();
     match schema::release(schema_handle) {
-        Ok(x) => trace!("vcx_schema_release(schema_handle: {}, rc: {}), source_id: {}",
-                       schema_handle, error_string(0), source_id),
-        Err(e) => warn!("vcx_schema_release(schema_handle: {}, rc: {}), source_id: {}",
-                       schema_handle, error_string(e.to_error_code()), source_id),
-    };
-    error::SUCCESS.code_num
+        Ok(_) => {
+            trace!("vcx_schema_release(schema_handle: {}, rc: {}), source_id: {}",
+                       schema_handle, error_string(0), source_id);
+            error::SUCCESS.code_num
+        },
+        Err(e) => {
+            warn!("vcx_schema_release(schema_handle: {}, rc: {}), source_id: {}",
+                       schema_handle, error_string(e.to_error_code()), source_id);
+            e.to_error_code()
+        }
+    }
 }
 
 /// Retrieves schema's id
@@ -521,6 +526,7 @@ mod tests {
         init!("true");
         let did = settings::get_config_value(settings::CONFIG_INSTITUTION_DID).unwrap();
         let handle = schema::create_new_schema("testid", did, "name".to_string(),"1.0".to_string(),"[\"name\":\"male\"]".to_string()).unwrap();
-        
+        let unknown_handle = handle + 1;
+        assert_eq!(vcx_schema_release(unknown_handle), error::INVALID_SCHEMA_HANDLE.code_num);
     }
 }

--- a/vcx/libvcx/src/api/schema.rs
+++ b/vcx/libvcx/src/api/schema.rs
@@ -515,4 +515,12 @@ mod tests {
         assert_eq!(j["version"], "1.0");
         assert_eq!(schema.get_source_id(), source_id);
     }
+
+    #[test]
+    fn test_vcx_schema_release() {
+        init!("true");
+        let did = settings::get_config_value(settings::CONFIG_INSTITUTION_DID).unwrap();
+        let handle = schema::create_new_schema("testid", did, "name".to_string(),"1.0".to_string(),"[\"name\":\"male\"]".to_string()).unwrap();
+        
+    }
 }


### PR DESCRIPTION
Vcx Objects, when released, previously always returned error_code::SUCCESS.code_num, even when handle was not valid.

This PR corrects this issue, as well as aligns the Connection Release result with other Vcx Objects (release returns the unit value).