### PR TITLE
Nodejs wrapper - indy_get_current_error

### DIFF
--- a/libindy/include/indy_mod.h
+++ b/libindy/include/indy_mod.h
@@ -189,7 +189,7 @@ extern "C" {
     /// Common*
     extern indy_error_t indy_set_runtime_config(const char * config);
 
-    extern void indy_get_current_error(const char * error_json_p);
+    extern void indy_get_current_error(const char * &error_json_p);
 
 #ifdef __cplusplus
 }

--- a/wrappers/nodejs/README.md
+++ b/wrappers/nodejs/README.md
@@ -89,8 +89,14 @@ var verkey = await indy.abbreviateVerkey(did, fullVerkey)
 
 All the functions may yield an IndyError. The errors are based on libindy error codes defined [here](https://github.com/hyperledger/indy-sdk/blob/master/libindy/include/indy_mod.h).
 
-* `err.indyCode` - the code number from libindy
-* `err.indyName` - the name string for the code
+* `err.indyCode`: Int - code number from libindy
+* `err.indyName`: String - name for the error code
+* `err.indyMessage`: String - human-readable error description
+* `err.indyBacktrace`: String? - if enabled, this is the libindy backtrace string
+
+Collecting of backtrace can be enabled by:
+1. Setting environment variable `RUST_BACKTRACE=1`
+2. Calling [setRuntimeConfig](#setruntimeconfig--config-)(`{collect_backtrace: true}`)
 
 ### anoncreds
 
@@ -2525,7 +2531,10 @@ Set libindy runtime configuration. Can be optionally called to change current pa
 * `config`: Json
 ```
 {
-  "crypto_thread_pool_size": <int> - size of thread pool for the most expensive crypto operations. (4 by default)
+  "crypto_thread_pool_size": Optional<int> - size of thread pool for the most expensive crypto operations. (4 by default)
+  "collect_backtrace": Optional<bool> - whether errors backtrace should be collected.
+    Capturing of backtrace can affect library performance.
+    NOTE: must be set before invocation of any other API functions.
 }
 ```
 

--- a/wrappers/nodejs/src/IndyError.js
+++ b/wrappers/nodejs/src/IndyError.js
@@ -1,4 +1,5 @@
 var util = require('util')
+var capi = require('./indyBinding')
 
 var errors = {
   100: 'CommonInvalidParam1',
@@ -58,6 +59,17 @@ function IndyError (err) {
     this.message = errors[err]
     this.indyCode = err
     this.indyName = errors[err]
+    try {
+      this.indyCurrentErrorJson = capi.getCurrentError()
+      var details = JSON.parse(this.indyCurrentErrorJson)
+      if (typeof details.message === 'string') {
+        this.indyMessage = details.message
+      }
+      if (typeof details.backtrace === 'string') {
+        this.indyBacktrace = details.backtrace
+      }
+    } catch (e) {
+    }
   } else {
     this.message = (err + '')
   }

--- a/wrappers/nodejs/src/index.js
+++ b/wrappers/nodejs/src/index.js
@@ -1,4 +1,4 @@
-var capi = require('bindings')('indynodejs')
+var capi = require('./indyBinding')
 var wrapIndyCallback = require('./wrapIndyCallback')
 var IndyError = require('./IndyError')
 

--- a/wrappers/nodejs/src/indy.cc
+++ b/wrappers/nodejs/src/indy.cc
@@ -2882,6 +2882,16 @@ NAN_METHOD(setRuntimeConfig) {
   info.GetReturnValue().Set(res);
 }
 
+
+NAN_METHOD(getCurrentError) {
+  INDY_ASSERT_NARGS(getCurrentError, 0)
+  const char* ptr = nullptr;
+  indy_get_current_error(ptr);
+  v8::Local<v8::Value> res = toJSString(ptr);
+  info.GetReturnValue().Set(res);
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // Logger
@@ -3104,6 +3114,7 @@ NAN_MODULE_INIT(InitAll) {
   Nan::Export(target, "deleteWallet", deleteWallet);
   Nan::Export(target, "generateWalletKey", generateWalletKey);
   Nan::Export(target, "setRuntimeConfig", setRuntimeConfig);
+  Nan::Export(target, "getCurrentError", getCurrentError);
   Nan::Export(target, "setDefaultLogger", setDefaultLogger);
   Nan::Export(target, "setLogger", setLogger);
 }

--- a/wrappers/nodejs/src/indyBinding.js
+++ b/wrappers/nodejs/src/indyBinding.js
@@ -1,0 +1,1 @@
+module.exports = require('bindings')('indynodejs')

--- a/wrappers/nodejs/test/index.js
+++ b/wrappers/nodejs/test/index.js
@@ -5,11 +5,21 @@ var did = 'VsKV7grR1BUE29mG2Fm2kX'
 var verkey = 'GjZWsBLgZCR18aL468JAT7w9CZRiBnpxUPPgyQxh4voa'
 var abbrVerkey = '~HYwqs2vrTc8Tn4uBV7NBTe'
 
+test.before('test getCurrentError before any errors', function (t) {
+  t.is(indy.capi.getCurrentError(), null)
+})
+
 test('wrapper essentials', async function (t) {
   t.is(await indy.abbreviateVerkey(did, verkey), abbrVerkey)
 
   var err = await t.throws(indy.abbreviateVerkey())
   t.is(err.message, 'CommonInvalidParam3')
+  t.is(err.indyCode, 102)
+  t.is(err.indyName, 'CommonInvalidParam3')
+  t.is(err.indyMessage, 'Error: Invalid parameter 3\n  caused by: Invalid pointer has been passed\n')
+  t.is(err.indyBacktrace, '')
+  t.is(typeof err.indyCurrentErrorJson, 'string')
+  t.is(err.indyCurrentErrorJson[0], '{')
 
   err = await t.throws(function () {
     indy.abbreviateVerkey(1, verkey)


### PR DESCRIPTION
For both async and sync errors, it calls `indy_get_current_error` and attaches the additional data to the IndyError object.