### PR TITLE
Use CRITICAL as default log level for python wrappers

### DIFF
--- a/vcx/wrappers/python3/vcx/logging.py
+++ b/vcx/wrappers/python3/vcx/logging.py
@@ -1,7 +1,7 @@
 from ctypes import *
 
 import logging
-from logging import ERROR, WARNING, INFO, DEBUG
+from logging import ERROR, WARNING, INFO, DEBUG, CRITICAL
 
 TRACE = 5
 
@@ -9,6 +9,7 @@ TRACE = 5
 def set_logger(cdll):
     logger = logging.getLogger(__name__)
     logging.addLevelName(TRACE, "TRACE")
+    logging.basicConfig(level=CRITICAL)
 
     logger.debug("set_logger: >>>")
 

--- a/wrappers/python/indy/libindy.py
+++ b/wrappers/python/indy/libindy.py
@@ -8,7 +8,7 @@ import asyncio
 import sys
 import itertools
 import logging
-from logging import ERROR, WARNING, INFO, DEBUG
+from logging import ERROR, WARNING, INFO, DEBUG, CRITICAL
 
 TRACE = 5
 
@@ -163,6 +163,7 @@ def _load_cdll() -> CDLL:
 def _set_logger():
     logger = logging.getLogger(__name__)
     logging.addLevelName(TRACE, "TRACE")
+    logging.basicConfig(level=CRITICAL)
 
     logger.debug("set_logger: >>>")
 


### PR DESCRIPTION
PR for IS-1168.
python `logging` use WARN as a default value for log functions. 
So, correspondent Libindy and Libvcx records appeared in a script output.

Signed-off-by: artem.ivanov <artem.ivanov@dsr-company.com>