### PR TITLE
changes A2AMessageV1::UpdateConnectionMethod to UpdateComMethod

### DIFF
--- a/vcx/dummy-cloud-agent/src/actors/agent.rs
+++ b/vcx/dummy-cloud-agent/src/actors/agent.rs
@@ -262,6 +262,7 @@ impl Agent {
             A2AMessageV1::UpdateConfigs(msg) => self.handle_update_configs_v1(msg),
             A2AMessageV1::GetConfigs(msg) => self.handle_get_configs_v1(msg),
             A2AMessageV1::RemoveConfigs(msg) => self.handle_remove_configs_v1(msg),
+            A2AMessageV1::UpdateComMethod(msg) => self.handle_update_com_method_v1(msg),
             _ => err_act!(self, err_msg("Unsupported message"))
         }
             .and_then(move |msgs, slf, _|
@@ -545,6 +546,12 @@ impl Agent {
                     .into_actor(slf)
             })
             .into_box()
+    }
+
+    fn handle_update_com_method_v1(&mut self, _msg: UpdateComMethod) -> ResponseActFuture<Self, Vec<A2AMessage>, Error> {
+        trace!("UpdateComMethod: {:?}", _msg);
+        let messages = vec![A2AMessage::Version1(A2AMessageV1::ComMethodUpdated(ComMethodUpdated {id: "123".to_string()}))];
+        ok_act!(self,  messages)
     }
 
     fn handle_update_configs_v1(&mut self, msg: UpdateConfigs) -> ResponseActFuture<Self, Vec<A2AMessage>, Error> {

--- a/vcx/dummy-cloud-agent/src/domain/a2a.rs
+++ b/vcx/dummy-cloud-agent/src/domain/a2a.rs
@@ -55,6 +55,8 @@ pub enum A2AMessageV1 {
     Configs(Configs),
     RemoveConfigs(RemoveConfigs),
     ConfigsRemoved(ConfigsRemoved),
+    UpdateComMethod(UpdateComMethod),
+    ComMethodUpdated(ComMethodUpdated),
 }
 
 #[derive(Debug)]
@@ -93,6 +95,8 @@ pub enum A2AMessageV2 {
     Configs(Configs),
     RemoveConfigs(RemoveConfigs),
     ConfigsRemoved(ConfigsRemoved),
+    UpdateComMethod(UpdateComMethod),
+    ComMethodUpdated(ComMethodUpdated),
 
     ConnectionRequest(ConnectionRequest),
     ConnectionRequestResponse(ConnectionRequestResponse),
@@ -470,6 +474,25 @@ pub struct RemoveConfigs {
 pub struct ConfigsRemoved {}
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct ComMethod {
+    id: String,
+    #[serde(rename = "type")]
+    e_type: i32,
+    value: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UpdateComMethod {
+    #[serde(rename = "comMethod")]
+    com_method: ComMethod,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ComMethodUpdated {
+    pub id: String
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ConnectionRequest {
     #[serde(rename = "sendMsg")]
     pub send_msg: bool,
@@ -591,6 +614,8 @@ pub enum A2AMessageKinds {
     ConnectionRequestAnswerResponse,
     SendRemoteMessage,
     SendRemoteMessageResponse,
+    UpdateComMethod,
+    ComMethodUpdated,
 }
 
 impl A2AMessageKinds {
@@ -630,6 +655,8 @@ impl A2AMessageKinds {
             A2AMessageKinds::Configs => MessageFamilies::Configs,
             A2AMessageKinds::RemoveConfigs => MessageFamilies::Configs,
             A2AMessageKinds::ConfigsRemoved => MessageFamilies::Configs,
+            A2AMessageKinds::UpdateComMethod => MessageFamilies::Configs,
+            A2AMessageKinds::ComMethodUpdated => MessageFamilies::Configs,
             A2AMessageKinds::SendRemoteMessage => MessageFamilies::Routing,
             A2AMessageKinds::SendRemoteMessageResponse => MessageFamilies::Routing,
         }
@@ -671,6 +698,8 @@ impl A2AMessageKinds {
             A2AMessageKinds::Configs => "CONFIGS".to_string(),
             A2AMessageKinds::RemoveConfigs => "REMOVE_CONFIGS".to_string(),
             A2AMessageKinds::ConfigsRemoved => "CONFIGS_REMOVED".to_string(),
+            A2AMessageKinds::UpdateComMethod => "UPDATE_COM_METHOD".to_string(),
+            A2AMessageKinds::ComMethodUpdated => "COM_METHOD_UPDATED".to_string(),
             A2AMessageKinds::SendRemoteMessage => "SEND_REMOTE_MSG".to_string(),
             A2AMessageKinds::SendRemoteMessageResponse => "REMOTE_MSG_SENT".to_string(),
         }
@@ -813,6 +842,16 @@ impl<'de> Deserialize<'de> for A2AMessageV1 {
                     .map(|msg| A2AMessageV1::ConfigsRemoved(msg))
                     .map_err(de::Error::custom)
             }
+            "UPDATE_COM_METHOD" => {
+                UpdateComMethod::deserialize(value)
+                    .map(|msg| A2AMessageV1::UpdateComMethod(msg))
+                    .map_err(de::Error::custom)
+            }
+            "COM_METHOD_UPDATED" => {
+                ComMethodUpdated::deserialize(value)
+                    .map(|msg| A2AMessageV1::ComMethodUpdated(msg))
+                    .map_err(de::Error::custom)
+            }
             "CREATE_MSG" => {
                 CreateMessage::deserialize(value)
                     .map(|msg| A2AMessageV1::CreateMessage(msg))
@@ -917,6 +956,16 @@ impl<'de> Deserialize<'de> for A2AMessageV2 {
             "MSG_STATUS_UPDATED" => {
                 MessageStatusUpdated::deserialize(value)
                     .map(|msg| A2AMessageV2::MessageStatusUpdated(msg))
+                    .map_err(de::Error::custom)
+            }
+            "UPDATE_COM_METHOD" => {
+                UpdateComMethod::deserialize(value)
+                    .map(|msg| A2AMessageV2::UpdateComMethod(msg))
+                    .map_err(de::Error::custom)
+            }
+            "COM_METHOD_UPDATED" => {
+                ComMethodUpdated::deserialize(value)
+                    .map(|msg| A2AMessageV2::ComMethodUpdated(msg))
                     .map_err(de::Error::custom)
             }
             "GET_MSGS" => {
@@ -1072,6 +1121,8 @@ impl Serialize for A2AMessageV1 {
             A2AMessageV1::MessageStatusUpdatedByConnections(msg) => set_a2a_message_type_v1(msg, A2AMessageKinds::MessageStatusUpdatedByConnections),
             A2AMessageV1::UpdateConfigs(msg) => set_a2a_message_type_v1(msg, A2AMessageKinds::UpdateConfigs),
             A2AMessageV1::ConfigsUpdated(msg) => set_a2a_message_type_v1(msg, A2AMessageKinds::ConfigsUpdated),
+            A2AMessageV1::UpdateComMethod(msg) => set_a2a_message_type_v1(msg, A2AMessageKinds::UpdateComMethod),
+            A2AMessageV1::ComMethodUpdated(msg) => set_a2a_message_type_v1(msg, A2AMessageKinds::ComMethodUpdated),
             A2AMessageV1::GetConfigs(msg) => set_a2a_message_type_v1(msg, A2AMessageKinds::GetConfigs),
             A2AMessageV1::Configs(msg) => set_a2a_message_type_v1(msg, A2AMessageKinds::Configs),
             A2AMessageV1::RemoveConfigs(msg) => set_a2a_message_type_v1(msg, A2AMessageKinds::RemoveConfigs),
@@ -1112,6 +1163,8 @@ impl Serialize for A2AMessageV2 {
             A2AMessageV2::MessageStatusUpdatedByConnections(msg) => set_a2a_message_type_v2(msg, A2AMessageKinds::MessageStatusUpdatedByConnections),
             A2AMessageV2::UpdateConfigs(msg) => set_a2a_message_type_v2(msg, A2AMessageKinds::UpdateConfigs),
             A2AMessageV2::ConfigsUpdated(msg) => set_a2a_message_type_v2(msg, A2AMessageKinds::ConfigsUpdated),
+            A2AMessageV2::UpdateComMethod(msg) => set_a2a_message_type_v2(msg, A2AMessageKinds::UpdateComMethod),
+            A2AMessageV2::ComMethodUpdated(msg) => set_a2a_message_type_v2(msg, A2AMessageKinds::ComMethodUpdated),
             A2AMessageV2::GetConfigs(msg) => set_a2a_message_type_v2(msg, A2AMessageKinds::GetConfigs),
             A2AMessageV2::Configs(msg) => set_a2a_message_type_v2(msg, A2AMessageKinds::Configs),
             A2AMessageV2::RemoveConfigs(msg) => set_a2a_message_type_v2(msg, A2AMessageKinds::RemoveConfigs),

--- a/vcx/libvcx/src/messages/agent_utils.rs
+++ b/vcx/libvcx/src/messages/agent_utils.rs
@@ -82,17 +82,24 @@ pub struct CreateAgentResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct UpdateConnectionMethod {
+pub struct UpdateComMethodResponse {
+    #[serde(rename = "@type")]
+    msg_type: MessageTypes,
+    id: String
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct UpdateComMethod {
     #[serde(rename = "@type")]
     msg_type: MessageTypes,
     #[serde(rename = "comMethod")]
     com_method: ComMethod,
 }
 
-impl UpdateConnectionMethod {
-    fn build(com_method: ComMethod) -> UpdateConnectionMethod {
-        UpdateConnectionMethod {
-            msg_type: MessageTypes::build(A2AMessageKinds::CreateAgent),
+impl UpdateComMethod {
+    fn build(com_method: ComMethod) -> UpdateComMethod {
+        UpdateComMethod {
+            msg_type: MessageTypes::build(A2AMessageKinds::UpdateComMethod),
             com_method,
         }
     }
@@ -354,7 +361,7 @@ fn update_agent_info_v1(to_did: &str, com_method: ComMethod) -> VcxResult<()> {
     }
 
     let message = A2AMessage::Version1(
-        A2AMessageV1::UpdateConnectionMethod(UpdateConnectionMethod::build(com_method))
+        A2AMessageV1::UpdateComMethod(UpdateComMethod::build(com_method))
     );
     send_message_to_agency(&message, to_did)?;
     Ok(())
@@ -362,7 +369,7 @@ fn update_agent_info_v1(to_did: &str, com_method: ComMethod) -> VcxResult<()> {
 
 fn update_agent_info_v2(to_did: &str, com_method: ComMethod) -> VcxResult<()> {
     let message = A2AMessage::Version2(
-        A2AMessageV2::UpdateConnectionMethod(UpdateConnectionMethod::build(com_method))
+        A2AMessageV2::UpdateComMethod(UpdateComMethod::build(com_method))
     );
     send_message_to_agency(&message, to_did)?;
     Ok(())
@@ -427,5 +434,15 @@ mod tests {
         settings::set_config_value(settings::CONFIG_ENABLE_TEST_MODE, "true");
 
         update_agent_info("123", "value").unwrap();
+    }
+
+    #[cfg(feature = "agency")]
+    #[cfg(feature = "pool_tests")]
+    #[test]
+    fn test_update_agent_info_real() {
+        init!("agency");
+        ::utils::devsetup::tests::set_consumer();
+        assert!(update_agent_info("7b7f97f2","FCM:Value").is_ok());
+        teardown!("agency");
     }
 }

--- a/vcx/libvcx/src/messages/agent_utils.rs
+++ b/vcx/libvcx/src/messages/agent_utils.rs
@@ -82,7 +82,7 @@ pub struct CreateAgentResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct UpdateComMethodResponse {
+pub struct ComMethodUpdated {
     #[serde(rename = "@type")]
     msg_type: MessageTypes,
     id: String

--- a/vcx/libvcx/src/messages/mod.rs
+++ b/vcx/libvcx/src/messages/mod.rs
@@ -25,7 +25,7 @@ use self::get_message::{GetMessagesBuilder, GetMessages, GetMessagesResponse, Me
 use self::send_message::SendMessageBuilder;
 use self::update_message::{UpdateMessageStatusByConnections, UpdateMessageStatusByConnectionsResponse};
 use self::proofs::proof_request::ProofRequestMessage;
-use self::agent_utils::{Connect, ConnectResponse, SignUp, SignUpResponse, CreateAgent, CreateAgentResponse, UpdateConnectionMethod};
+use self::agent_utils::{Connect, ConnectResponse, SignUp, SignUpResponse, CreateAgent, CreateAgentResponse, UpdateComMethod, UpdateComMethodResponse};
 use self::message_type::*;
 use error::prelude::*;
 
@@ -68,7 +68,8 @@ pub enum A2AMessageV1 {
     /// Configs
     UpdateConfigs(UpdateConfigs),
     UpdateConfigsResponse(UpdateConfigsResponse),
-    UpdateConnectionMethod(UpdateConnectionMethod),
+    UpdateComMethod(UpdateComMethod),
+    UpdateComMethodResponse(UpdateComMethodResponse),
 }
 
 impl<'de> Deserialize<'de> for A2AMessageV1 {
@@ -113,8 +114,13 @@ impl<'de> Deserialize<'de> for A2AMessageV1 {
                     .map_err(de::Error::custom)
             }
             "UPDATE_COM_METHOD" => {
-                UpdateConnectionMethod::deserialize(value)
-                    .map(|msg| A2AMessageV1::UpdateConnectionMethod(msg))
+                UpdateComMethod::deserialize(value)
+                    .map(|msg| A2AMessageV1::UpdateComMethod(msg))
+                    .map_err(de::Error::custom)
+            }
+            "COM_METHOD_UPDATED" => {
+                UpdateComMethodResponse::deserialize(value)
+                    .map(|msg| A2AMessageV1::UpdateComMethodResponse(msg))
                     .map_err(de::Error::custom)
             }
             "CREATE_KEY" => {
@@ -241,7 +247,8 @@ pub enum A2AMessageV2 {
     /// config
     UpdateConfigs(UpdateConfigs),
     UpdateConfigsResponse(UpdateConfigsResponse),
-    UpdateConnectionMethod(UpdateConnectionMethod),
+    UpdateComMethod(UpdateComMethod),
+    UpdateComMethodResponse(UpdateComMethodResponse),
 }
 
 impl<'de> Deserialize<'de> for A2AMessageV2 {
@@ -286,8 +293,13 @@ impl<'de> Deserialize<'de> for A2AMessageV2 {
                     .map_err(de::Error::custom)
             }
             "UPDATE_COM_METHOD" => {
-                UpdateConnectionMethod::deserialize(value)
-                    .map(|msg| A2AMessageV2::UpdateConnectionMethod(msg))
+                UpdateComMethod::deserialize(value)
+                    .map(|msg| A2AMessageV2::UpdateComMethod(msg))
+                    .map_err(de::Error::custom)
+            }
+            "COM_METHOD_UPDATED" => {
+                UpdateComMethodResponse::deserialize(value)
+                    .map(|msg| A2AMessageV2::UpdateComMethodResponse(msg))
                     .map_err(de::Error::custom)
             }
             "CREATE_KEY" => {
@@ -628,7 +640,7 @@ pub enum A2AMessageKinds {
     UpdateConnectionStatus,
     UpdateConfigs,
     ConfigsUpdated,
-    UpdateConMethod,
+    UpdateComMethod,
     ConnectionRequest,
     ConnectionRequestAnswer,
     SendRemoteMessage,
@@ -661,7 +673,7 @@ impl A2AMessageKinds {
             A2AMessageKinds::MessageStatusUpdatedByConnections => MessageFamilies::Pairwise,
             A2AMessageKinds::UpdateConfigs => MessageFamilies::Configs,
             A2AMessageKinds::ConfigsUpdated => MessageFamilies::Configs,
-            A2AMessageKinds::UpdateConMethod => MessageFamilies::Configs,
+            A2AMessageKinds::UpdateComMethod => MessageFamilies::Configs,
             A2AMessageKinds::SendRemoteMessage => MessageFamilies::Routing,
             A2AMessageKinds::SendRemoteMessageResponse => MessageFamilies::Routing,
         }
@@ -692,7 +704,7 @@ impl A2AMessageKinds {
             A2AMessageKinds::ConnectionRequestAnswer => "CONN_REQUEST_ANSWER".to_string(),
             A2AMessageKinds::UpdateConfigs => "UPDATE_CONFIGS".to_string(),
             A2AMessageKinds::ConfigsUpdated => "CONFIGS_UPDATED".to_string(),
-            A2AMessageKinds::UpdateConMethod => "UPDATE_CONNECTION_METHOD".to_string(),
+            A2AMessageKinds::UpdateComMethod => "UPDATE_COM_METHOD".to_string(),
             A2AMessageKinds::SendRemoteMessage => "SEND_REMOTE_MSG".to_string(),
             A2AMessageKinds::SendRemoteMessageResponse => "REMOTE_MSG_SENT".to_string(),
         }

--- a/vcx/libvcx/src/messages/mod.rs
+++ b/vcx/libvcx/src/messages/mod.rs
@@ -25,7 +25,7 @@ use self::get_message::{GetMessagesBuilder, GetMessages, GetMessagesResponse, Me
 use self::send_message::SendMessageBuilder;
 use self::update_message::{UpdateMessageStatusByConnections, UpdateMessageStatusByConnectionsResponse};
 use self::proofs::proof_request::ProofRequestMessage;
-use self::agent_utils::{Connect, ConnectResponse, SignUp, SignUpResponse, CreateAgent, CreateAgentResponse, UpdateComMethod, UpdateComMethodResponse};
+use self::agent_utils::{Connect, ConnectResponse, SignUp, SignUpResponse, CreateAgent, CreateAgentResponse, UpdateComMethod, ComMethodUpdated};
 use self::message_type::*;
 use error::prelude::*;
 
@@ -69,7 +69,7 @@ pub enum A2AMessageV1 {
     UpdateConfigs(UpdateConfigs),
     UpdateConfigsResponse(UpdateConfigsResponse),
     UpdateComMethod(UpdateComMethod),
-    UpdateComMethodResponse(UpdateComMethodResponse),
+    ComMethodUpdated(ComMethodUpdated),
 }
 
 impl<'de> Deserialize<'de> for A2AMessageV1 {
@@ -119,8 +119,8 @@ impl<'de> Deserialize<'de> for A2AMessageV1 {
                     .map_err(de::Error::custom)
             }
             "COM_METHOD_UPDATED" => {
-                UpdateComMethodResponse::deserialize(value)
-                    .map(|msg| A2AMessageV1::UpdateComMethodResponse(msg))
+                ComMethodUpdated::deserialize(value)
+                    .map(|msg| A2AMessageV1::ComMethodUpdated(msg))
                     .map_err(de::Error::custom)
             }
             "CREATE_KEY" => {
@@ -248,7 +248,7 @@ pub enum A2AMessageV2 {
     UpdateConfigs(UpdateConfigs),
     UpdateConfigsResponse(UpdateConfigsResponse),
     UpdateComMethod(UpdateComMethod),
-    UpdateComMethodResponse(UpdateComMethodResponse),
+    ComMethodUpdated(ComMethodUpdated),
 }
 
 impl<'de> Deserialize<'de> for A2AMessageV2 {
@@ -290,16 +290,6 @@ impl<'de> Deserialize<'de> for A2AMessageV2 {
             "AGENT_CREATED" => {
                 CreateAgentResponse::deserialize(value)
                     .map(|msg| A2AMessageV2::CreateAgentResponse(msg))
-                    .map_err(de::Error::custom)
-            }
-            "UPDATE_COM_METHOD" => {
-                UpdateComMethod::deserialize(value)
-                    .map(|msg| A2AMessageV2::UpdateComMethod(msg))
-                    .map_err(de::Error::custom)
-            }
-            "COM_METHOD_UPDATED" => {
-                UpdateComMethodResponse::deserialize(value)
-                    .map(|msg| A2AMessageV2::UpdateComMethodResponse(msg))
                     .map_err(de::Error::custom)
             }
             "CREATE_KEY" => {
@@ -390,6 +380,16 @@ impl<'de> Deserialize<'de> for A2AMessageV2 {
             "CONFIGS_UPDATED" => {
                 UpdateConfigsResponse::deserialize(value)
                     .map(|msg| A2AMessageV2::UpdateConfigsResponse(msg))
+                    .map_err(de::Error::custom)
+            }
+            "UPDATE_COM_METHOD" => {
+                UpdateComMethod::deserialize(value)
+                    .map(|msg| A2AMessageV2::UpdateComMethod(msg))
+                    .map_err(de::Error::custom)
+            }
+            "COM_METHOD_UPDATED" => {
+                ComMethodUpdated::deserialize(value)
+                    .map(|msg| A2AMessageV2::ComMethodUpdated(msg))
                     .map_err(de::Error::custom)
             }
             _ => Err(de::Error::custom("Unexpected @type field structure."))
@@ -641,6 +641,7 @@ pub enum A2AMessageKinds {
     UpdateConfigs,
     ConfigsUpdated,
     UpdateComMethod,
+    ComMethodUpdated,
     ConnectionRequest,
     ConnectionRequestAnswer,
     SendRemoteMessage,
@@ -674,6 +675,7 @@ impl A2AMessageKinds {
             A2AMessageKinds::UpdateConfigs => MessageFamilies::Configs,
             A2AMessageKinds::ConfigsUpdated => MessageFamilies::Configs,
             A2AMessageKinds::UpdateComMethod => MessageFamilies::Configs,
+            A2AMessageKinds::ComMethodUpdated => MessageFamilies::Configs,
             A2AMessageKinds::SendRemoteMessage => MessageFamilies::Routing,
             A2AMessageKinds::SendRemoteMessageResponse => MessageFamilies::Routing,
         }
@@ -705,6 +707,7 @@ impl A2AMessageKinds {
             A2AMessageKinds::UpdateConfigs => "UPDATE_CONFIGS".to_string(),
             A2AMessageKinds::ConfigsUpdated => "CONFIGS_UPDATED".to_string(),
             A2AMessageKinds::UpdateComMethod => "UPDATE_COM_METHOD".to_string(),
+            A2AMessageKinds::ComMethodUpdated => "COM_METHOD_UPDATED".to_string(),
             A2AMessageKinds::SendRemoteMessage => "SEND_REMOTE_MSG".to_string(),
             A2AMessageKinds::SendRemoteMessageResponse => "REMOTE_MSG_SENT".to_string(),
         }


### PR DESCRIPTION
Signed-off-by: Ryan Marsh <ryan.marsh44@gmail.com>
Connect.me would fail when trying to update the communication method `UPDATE_COM_METHOD` because the message type was `CREATE_AGENT`. 
All references to UpdateConnectionMethod is changed to UpdateComMethod.