### PR TITLE
Inline Documentation Fix

### DIFF
--- a/vcx/wrappers/node/src/api/issuer-credential.ts
+++ b/vcx/wrappers/node/src/api/issuer-credential.ts
@@ -63,7 +63,7 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData> {
    * Builds a generic Issuer Credential object
    * ```
    * issuerCredential = await IssuerCredential.create({sourceId: "12",
-   * credDefId: "credDefId", attr: {key: "value"}, credentialName: "name", price: 0})
+   * credDefId: "credDefId", attr: {key: "value"}, credentialName: "name", price: "0"})
    * ```
    * @returns {Promise<IssuerCredential>} An Issuer credential Object
    */


### PR DESCRIPTION
"price" should be shown as a string in the inline documentation because the function will only accept a string.