### PR TITLE
ATOMIC_USIZE_INIT is deprecated

### DIFF
--- a/libindy/src/utils/sequence.rs
+++ b/libindy/src/utils/sequence.rs
@@ -1,7 +1,7 @@
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 lazy_static! {
-    static ref IDS_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT; //TODO use AtomicI32
+    static ref IDS_COUNTER: AtomicUsize = AtomicUsize::new(1);
 }
 
 pub fn get_next_id() -> i32 {

--- a/libindy/tests/utils/callback.rs
+++ b/libindy/tests/utils/callback.rs
@@ -6,13 +6,13 @@ use self::indy_sys::Error as ErrorCode;
 use self::libc::c_char;
 use std::ffi::CStr;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 use std::slice;
 use std::sync::mpsc::{channel, Receiver};
 
 lazy_static! {
-    static ref COMMAND_HANDLE_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
+    static ref COMMAND_HANDLE_COUNTER: AtomicUsize = AtomicUsize::new(1);
 }
 
 pub fn _closure_to_cb_ec() -> (Receiver<ErrorCode>, i32,

--- a/wrappers/rust/src/utils/sequence.rs
+++ b/wrappers/rust/src/utils/sequence.rs
@@ -1,9 +1,9 @@
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub struct SequenceUtils {}
 
 lazy_static! {
-    static ref IDS_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT; //TODO use AtomicI32
+    static ref IDS_COUNTER: AtomicUsize = AtomicUsize::new(1);
 }
 
 impl SequenceUtils {


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

ATOMIC_USIZE_INIT is deprecated in rustc 1.34.0