### PR TITLE
Fix bad comparison IS-825

### DIFF
--- a/libindy/src/services/pool/catchup.rs
+++ b/libindy/src/services/pool/catchup.rs
@@ -22,9 +22,7 @@ pub enum CatchupProgress {
 }
 
 pub fn build_catchup_req(merkle: &MerkleTree, target_mt_size: usize) -> IndyResult<Option<(String, String)>> {
-    let txns_cnt = target_mt_size - merkle.count();
-
-    if txns_cnt <= 0 {
+    if merkle.count() >= target_mt_size  {
         warn!("No transactions to catch up!");
         return Ok(None);
     }


### PR DESCRIPTION
**Issue:**
[IS-825](https://jira.hyperledger.org/browse/IS-825)
**Summary:**
Static analysis bug, `txns_cnt` were previously a `usize` and could not be negative, thus the comparison for less than 0 did not make sense.
An alternative solution would probably be to cast to `ìsize`, but this solution seems better and more understandable.

Signed-off-by: rasviitanen <rasviitanen@gmail.com>