### PR TITLE
extern crate is unidiomatic in Rust 2018

### DIFF
--- a/libindy/src/api/anoncreds.rs
+++ b/libindy/src/api/anoncreds.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 extern crate serde_json;
 
 use api::{ErrorCode, IndyHandle, CommandHandle, WalletHandle, SearchHandle};
@@ -22,7 +21,7 @@ use domain::anoncreds::revocation_registry::RevocationRegistry;
 use domain::anoncreds::revocation_state::RevocationState;
 use utils::ctypes;
 
-use self::libc::c_char;
+use libc::c_char;
 use std::ptr;
 use std::collections::HashMap;
 

--- a/libindy/src/api/blob_storage.rs
+++ b/libindy/src/api/blob_storage.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 
 use api::{ErrorCode, IndyHandle, CommandHandle};
 use commands::{Command, CommandExecutor};
@@ -6,7 +5,7 @@ use commands::blob_storage::BlobStorageCommand;
 use errors::prelude::*;
 use utils::ctypes;
 
-use self::libc::c_char;
+use libc::c_char;
 
 #[no_mangle]
 pub extern fn indy_open_blob_storage_reader(command_handle: CommandHandle,

--- a/libindy/src/api/cache.rs
+++ b/libindy/src/api/cache.rs
@@ -1,12 +1,11 @@
-extern crate libc;
-
 use api::{ErrorCode, CommandHandle, WalletHandle, PoolHandle};
 use commands::{Command, CommandExecutor};
 use commands::cache::CacheCommand;
 use errors::prelude::*;
 use utils::ctypes;
 
-use self::libc::c_char;
+use
+libc::c_char;
 
 
 /// Gets credential definition json data for specified credential definition id.

--- a/libindy/src/api/crypto.rs
+++ b/libindy/src/api/crypto.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 
 use api::{ErrorCode, CommandHandle, WalletHandle};
 use commands::{Command, CommandExecutor};
@@ -8,7 +7,7 @@ use errors::prelude::*;
 use utils::ctypes;
 
 use serde_json;
-use self::libc::c_char;
+use libc::c_char;
 
 
 /// Creates keys pair and stores in the wallet.

--- a/libindy/src/api/did.rs
+++ b/libindy/src/api/did.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 
 use api::{ErrorCode, CommandHandle, WalletHandle, PoolHandle};
 use commands::{Command, CommandExecutor};
@@ -9,7 +8,7 @@ use errors::prelude::*;
 use utils::ctypes;
 
 use serde_json;
-use self::libc::c_char;
+use libc::c_char;
 
 use std::ptr;
 use domain::ledger::attrib::Endpoint;

--- a/libindy/src/api/ledger.rs
+++ b/libindy/src/api/ledger.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 use api::{ErrorCode, CommandHandle, WalletHandle, PoolHandle};
 use errors::prelude::*;
 use commands::{Command, CommandExecutor};
@@ -14,7 +12,7 @@ use domain::ledger::auth_rule::AuthRules;
 use utils::ctypes;
 
 use serde_json;
-use self::libc::c_char;
+use libc::c_char;
 
 /// Signs and submits request message to validator pool.
 ///

--- a/libindy/src/api/logger.rs
+++ b/libindy/src/api/logger.rs
@@ -1,8 +1,7 @@
-extern crate libc;
 extern crate time;
 extern crate log;
 
-use self::libc::{c_void, c_char};
+use libc::{c_void, c_char};
 
 use api::ErrorCode;
 use errors::prelude::*;

--- a/libindy/src/api/non_secrets.rs
+++ b/libindy/src/api/non_secrets.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 
 use api::{ErrorCode, CommandHandle, WalletHandle, SearchHandle};
 use commands::{Command, CommandExecutor};
@@ -8,7 +7,7 @@ use errors::prelude::*;
 use utils::ctypes;
 
 use serde_json;
-use self::libc::c_char;
+use libc::c_char;
 
 /// Create a new non-secret record in the wallet
 ///

--- a/libindy/src/api/pairwise.rs
+++ b/libindy/src/api/pairwise.rs
@@ -1,12 +1,10 @@
-extern crate libc;
-
 use api::{ErrorCode, CommandHandle, WalletHandle};
 use commands::{Command, CommandExecutor};
 use commands::pairwise::PairwiseCommand;
 use errors::prelude::*;
 use utils::ctypes;
 
-use self::libc::c_char;
+use libc::c_char;
 
 
 /// Check if pairwise is exists.

--- a/libindy/src/api/payments.rs
+++ b/libindy/src/api/payments.rs
@@ -1,6 +1,4 @@
-extern crate libc;
-
-use self::libc::c_char;
+use libc::c_char;
 use api::{ErrorCode, CommandHandle, WalletHandle};
 use commands::{Command, CommandExecutor};
 use commands::payments::PaymentsCommand;

--- a/libindy/src/api/pool.rs
+++ b/libindy/src/api/pool.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 
 use api::{ErrorCode, CommandHandle, PoolHandle};
 use commands::{Command, CommandExecutor};
@@ -8,7 +7,7 @@ use errors::prelude::*;
 use utils::ctypes;
 
 use serde_json;
-use self::libc::c_char;
+use libc::c_char;
 
 /// Creates a new local pool ledger configuration that can be used later to connect pool nodes.
 ///

--- a/libindy/src/api/wallet.rs
+++ b/libindy/src/api/wallet.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 
 use api::{ErrorCode, IndyHandle, CommandHandle, WalletHandle, SearchHandle, StorageHandle, INVALID_WALLET_HANDLE};
 use commands::{Command, CommandExecutor};
@@ -8,7 +7,7 @@ use errors::prelude::*;
 use utils::ctypes;
 
 use serde_json;
-use self::libc::c_char;
+use libc::c_char;
 
 
 /// Register custom wallet storage implementation.

--- a/libindy/src/services/payments.rs
+++ b/libindy/src/services/payments.rs
@@ -426,8 +426,6 @@ impl From<NulError> for IndyError {
 }
 
 mod cbs {
-    extern crate libc;
-
     use std::ffi::CStr;
     use std::sync::Mutex;
 
@@ -436,7 +434,7 @@ mod cbs {
 
     use super::*;
 
-    use self::libc::c_char;
+    use libc::c_char;
 
     pub fn create_address_cb(cmd_handle: i32, wallet_handle: WalletHandle) -> Option<extern fn(command_handle: i32,
                                                                                       err: ErrorCode,

--- a/libindy/src/services/pool/state_proof/mod.rs
+++ b/libindy/src/services/pool/state_proof/mod.rs
@@ -644,11 +644,8 @@ fn _if_rev_delta_multi_state_proof_expected(sp_key: &[u8]) -> bool {
 mod tests {
     use super::*;
 
-    use self::hex::FromHex;
-    use self::libc::c_char;
-
-    extern crate hex;
-    extern crate libc;
+    use hex::FromHex;
+    use libc::c_char;
 
     #[test]
     fn state_proof_nodes_parse_and_get_works() {

--- a/libindy/src/utils/crypto/ed25519_box/sodium.rs
+++ b/libindy/src/utils/crypto/ed25519_box/sodium.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 extern crate sodiumoxide;
 
 use errors::prelude::*;

--- a/libindy/src/utils/crypto/ed25519_sign/sodium.rs
+++ b/libindy/src/utils/crypto/ed25519_sign/sodium.rs
@@ -1,11 +1,8 @@
-extern crate sodiumoxide;
-extern crate libc;
-
 use errors::prelude::*;
 
-use self::libc::c_int;
-use self::sodiumoxide::crypto::sign;
-use self::sodiumoxide::crypto::box_;
+use libc::c_int;
+use sodiumoxide::crypto::sign;
+use sodiumoxide::crypto::box_;
 
 use utils::crypto::ed25519_box;
 use utils::crypto::randombytes::randombytes;

--- a/libindy/src/utils/crypto/pwhash_argon2i13/sodium.rs
+++ b/libindy/src/utils/crypto/pwhash_argon2i13/sodium.rs
@@ -1,11 +1,10 @@
 extern crate errno;
-extern crate libc;
 extern crate serde;
 extern crate sodiumoxide;
 
 use domain::wallet::KeyDerivationMethod;
 use errors::prelude::*;
-use self::libc::{c_int, c_ulonglong, size_t};
+use libc::{c_int, c_ulonglong, size_t};
 use self::sodiumoxide::crypto::pwhash;
 
 pub const SALTBYTES: usize = pwhash::SALTBYTES;

--- a/libindy/src/utils/crypto/randombytes/sodium.rs
+++ b/libindy/src/utils/crypto/randombytes/sodium.rs
@@ -1,9 +1,8 @@
-extern crate libc;
 extern crate sodiumoxide;
 extern crate zeroize;
 
 use errors::prelude::*;
-use self::libc::size_t;
+use libc::size_t;
 
 use self::zeroize::Zeroize;
 

--- a/libindy/src/utils/logger.rs
+++ b/libindy/src/utils/logger.rs
@@ -3,7 +3,6 @@ extern crate log_panics;
 extern crate log;
 #[cfg(target_os = "android")]
 extern crate android_logger;
-extern crate libc;
 
 use self::env_logger::Builder as EnvLoggerBuilder;
 use self::log::{LevelFilter, Level};
@@ -13,7 +12,7 @@ use std::io::Write;
 use self::android_logger::Filter;
 use log::{Record, Metadata};
 
-use self::libc::{c_void, c_char};
+use libc::{c_void, c_char};
 use std::ffi::CString;
 use std::ptr;
 

--- a/libindy/tests/utils/callback.rs
+++ b/libindy/tests/utils/callback.rs
@@ -1,9 +1,8 @@
-extern crate libc;
 extern crate indy_sys;
 
 use self::indy_sys::Error as ErrorCode;
 
-use self::libc::c_char;
+use super::libc::c_char;
 use std::ffi::CStr;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/libindy/tests/utils/mod.rs
+++ b/libindy/tests/utils/mod.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, unused_macros)]
 
+extern crate libc;
+
 use utils::constants::WALLET_CREDENTIALS;
 
 pub mod callback;

--- a/libindy/tests/utils/payments.rs
+++ b/libindy/tests/utils/payments.rs
@@ -1,6 +1,5 @@
 extern crate futures;
 extern crate indy_sys;
-extern crate libc;
 
 use indy::{IndyError, ErrorCode};
 use indy::payments;
@@ -9,7 +8,7 @@ use self::indy_sys::{payments as payments_sys};
 
 use std::collections::VecDeque;
 use std::ffi::CString;
-use self::libc::c_char;
+use super::libc::c_char;
 use std::sync::{Once, ONCE_INIT, Mutex};
 
 use utils::callback;

--- a/libindy/tests/utils/wallet.rs
+++ b/libindy/tests/utils/wallet.rs
@@ -1,5 +1,4 @@
 extern crate futures;
-extern crate libc;
 
 use serde_json;
 
@@ -14,7 +13,7 @@ use utils::inmem_wallet::InmemWallet;
 use std::collections::HashSet;
 use std::sync::Mutex;
 use std::ffi::CString;
-use self::libc::c_char;
+use super::libc::c_char;
 
 use utils::constants::{TYPE, INMEM_TYPE, WALLET_CREDENTIALS};
 


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

This PR removes some `extern crate` from the code because 
https://doc.rust-lang.org/reference/items/extern-crates.html
says this is unidiomatic since rust 2018.

```


    Edition Differences: In the 2015 edition, crates in the extern prelude cannot be
referenced via use declarations, so it is generally standard practice to include 
extern crate declarations to bring them into scope.

    Beginning in the 2018 edition, use declarations can reference crates in the 
extern prelude, so it is considered unidiomatic to use extern crate.
```