### PR TITLE
Remove install dependency of pytest from python wrapper

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -451,7 +451,7 @@ def linuxPythonTesting(env_name, network_name, testEnv, stashBuildResults) {
             echo "${env_name} Libindy Test: Test python wrapper"
 
             sh '''
-                    python3.5 -m pip install --user -e .
+                    python3.5 -m pip install --user -e . pytest==3.6.4 pytest-asyncio
                     LD_LIBRARY_PATH=./:${LD_LIBRARY_PATH} RUST_LOG=indy::=debug TEST_POOL_IP=10.0.0.2 python3.5 -m pytest
                 '''
         }

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -604,7 +604,7 @@ def linuxPythonTesting(env_name, network_name, testEnv) {
             echo "${env_name} Libindy Test: Test python wrapper"
 
             sh '''
-                python3.5 -m pip install --user -e .
+                python3.5 -m pip install --user -e . pytest==3.6.4 pytest-asyncio
                 LD_LIBRARY_PATH=./:${LD_LIBRARY_PATH} TEST_POOL_IP=10.0.0.2 python3.5 -m pytest
             '''
         }

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -12,6 +12,6 @@ setup(
     author='Vyacheslav Gudkov',
     author_email='vyacheslav.gudkov@dsr-company.com',
     description='This is the official SDK for Hyperledger Indy (https://www.hyperledger.org/projects), which provides a distributed-ledger-based foundation for self-sovereign identity (https://sovrin.org). The major artifact of the SDK is a c-callable library.',
-    install_requires=['pytest<3.7', 'pytest-asyncio', 'base58'],
+    install_requires=['base58'],
     tests_require=['pytest<3.7', 'pytest-asyncio', 'base58']
 )


### PR DESCRIPTION
`pytest` and `pytest-asyncio` aren't actually needed to use `python3-indy` as a library.

Hopefully I made the necessary adjustments to the CI/CD but I guess we'll see.