### PR TITLE
IS-1286: Python wrapper test dependencies through pip extras

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -451,7 +451,7 @@ def linuxPythonTesting(env_name, network_name, testEnv, stashBuildResults) {
             echo "${env_name} Libindy Test: Test python wrapper"
 
             sh '''
-                    python3.5 -m pip install --user -e . pytest==3.6.4 pytest-asyncio
+                    python3.5 -m pip install --user -e .[test]
                     LD_LIBRARY_PATH=./:${LD_LIBRARY_PATH} RUST_LOG=indy::=debug TEST_POOL_IP=10.0.0.2 python3.5 -m pytest
                 '''
         }

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -619,7 +619,7 @@ def linuxPythonTesting(env_name, network_name, testEnv) {
             echo "${env_name} Libindy Test: Test python wrapper"
 
             sh '''
-                python3.5 -m pip install --user -e . pytest==3.6.4 pytest-asyncio
+                python3.5 -m pip install --user -e .[test]
                 LD_LIBRARY_PATH=./:${LD_LIBRARY_PATH} TEST_POOL_IP=10.0.0.2 python3.5 -m pytest
             '''
         }

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -3,6 +3,10 @@ import os
 
 PKG_VERSION = os.environ.get('PACKAGE_VERSION') or '1.9.0'
 
+TEST_DEPS = [
+    'pytest<3.7', 'pytest-asyncio', 'base58'
+]
+
 setup(
     name='python3-indy',
     version=PKG_VERSION,
@@ -13,5 +17,8 @@ setup(
     author_email='vyacheslav.gudkov@dsr-company.com',
     description='This is the official SDK for Hyperledger Indy (https://www.hyperledger.org/projects), which provides a distributed-ledger-based foundation for self-sovereign identity (https://sovrin.org). The major artifact of the SDK is a c-callable library.',
     install_requires=['base58'],
-    tests_require=['pytest<3.7', 'pytest-asyncio', 'base58']
+    tests_require=TEST_DEPS,
+    extras_require={
+        'test': TEST_DEPS
+    }
 )


### PR DESCRIPTION
Install python wrapper test dependencies through pip extras.

Inspired by comments on PR #1683