### PR TITLE
[libindy] Add missing transaction type for XFER_PUBLIC

### DIFF
--- a/libindy/src/domain/ledger/constants.rs
+++ b/libindy/src/domain/ledger/constants.rs
@@ -25,11 +25,12 @@ pub const AUTH_RULE: &str = "120";
 pub const GET_AUTH_RULE: &str = "121";
 pub const AUTH_RULES: &str = "122";
 pub const GET_DDO: &str = "120";//TODO change number
+pub const XFER_PUBLIC: &str = "10001";
 
-pub const REQUESTS: [&str; 25] = [NODE, NYM, GET_TXN, ATTRIB, SCHEMA, CRED_DEF, GET_ATTR, GET_NYM, GET_SCHEMA,
+pub const REQUESTS: [&str; 26] = [NODE, NYM, GET_TXN, ATTRIB, SCHEMA, CRED_DEF, GET_ATTR, GET_NYM, GET_SCHEMA,
     GET_CRED_DEF, POOL_UPGRADE, POOL_RESTART, POOL_CONFIG, REVOC_REG_DEF, REVOC_REG_ENTRY, GET_REVOC_REG_DEF,
     GET_REVOC_REG, GET_REVOC_REG_DELTA, GET_VALIDATOR_INFO, AUTH_RULE, GET_DDO, TXN_AUTHR_AGRMT, TXN_AUTHR_AGRMT_AML,
-    GET_TXN_AUTHR_AGRMT, GET_TXN_AUTHR_AGRMT_AML];
+    GET_TXN_AUTHR_AGRMT, GET_TXN_AUTHR_AGRMT_AML, XFER_PUBLIC];
 
 pub const TRUSTEE: &str = "0";
 pub const STEWARD: &str = "2";
@@ -70,6 +71,7 @@ pub fn txn_name_to_code(txn: &str) -> Option<&str> {
         "TXN_AUTHR_AGRMT_AML" => Some(TXN_AUTHR_AGRMT_AML),
         "GET_TXN_AUTHR_AGRMT" => Some(GET_TXN_AUTHR_AGRMT),
         "GET_TXN_AUTHR_AGRMT_AML" => Some(GET_TXN_AUTHR_AGRMT_AML),
+        "XFER_PUBLIC" => Some(XFER_PUBLIC),
         val => Some(val)
     }
 }


### PR DESCRIPTION
This PR adds a missing txn type that makes calls to `ledger.build_auth_rule_request` fail if `constraint` contains `auth_type = "10001"`, because the requested txn_type cannot be resolved in the list of known types.
I'm not sure if wrappers are intended to call this function directly, if not, I can abandon this PR.
I came across the bug when writing unit tests for testing fee payments when making XFER_PUBLIC transaction type. The proposed fix addressed my issue and I was able to properly update auth rules and set fees for txn_type = 10001.

Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>