### PR TITLE
Fix incorrect reference to "log" on error. Also add payment_method to provision script output.

### DIFF
--- a/vcx/libvcx/scripts/provision_agent_keys.py
+++ b/vcx/libvcx/scripts/provision_agent_keys.py
@@ -17,7 +17,7 @@ def parse_args():
     parser.add_argument("--wallet-type", help="optional type of libindy wallet")
     parser.add_argument("--agent-seed", help="optional seed used to create enterprise->agent DID/VK")
     parser.add_argument("--enterprise-seed", help="optional seed used to create enterprise DID/VK")
-    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
     return parser.parse_args()
 
 def get_agency_info(agency_url):

--- a/vcx/libvcx/scripts/provision_agent_keys.py
+++ b/vcx/libvcx/scripts/provision_agent_keys.py
@@ -70,15 +70,18 @@ def register_agent(args):
     rc = vcx.vcx_provision_agent(c_json)
 
     if rc == 0:
-        sys.stderr.write("could not register agent, see log\n")
+        sys.stderr.write("could not register agent.  Try again with '-v' for more details\n")
         print(json.dumps({
             'provisioned': False,
-            'provisioned_status': 'Failed: Could not register agent, see log\n'
+            'provisioned_status': "Failed: Could not register agent.  Try again with '-v' for more details"
         },indent=2))
     else:
         pointer = c_int(rc)
         string = cast(pointer.value, c_char_p)
         new_config = json.loads(string.value.decode('utf-8'))
+
+        if 'payment_method' not in new_config:
+            new_config['payment_method'] = 'null'
 
         print(json.dumps(new_config, indent=2, sort_keys=True))
 


### PR DESCRIPTION
Instead of saying "see log" when said log doesn't exist, the provision script now says "Try again with '-v' for more details.

The payment_method is added to the provision script output with a default value of "null".  This should eventually be added to libvcx, and when that happens the value output by libvcx will not be overwritten.