### PR TITLE
getting-started container hangs

### DIFF
--- a/docs/getting-started/getting-started.dockerfile
+++ b/docs/getting-started/getting-started.dockerfile
@@ -20,6 +20,8 @@ RUN pip3 install -U \
 	pip \
 	setuptools \
 	jupyter \
+	tornado==4.5.3 \
+	tornado==4.5.3 \
 	python3-indy==1.8.1-dev-1039
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88 \


### PR DESCRIPTION
There is an issue with asyncio which makes notebook to hang. There may be an incompatability with later versions of tornado which causes the problem. By adding new line "tornado==4.5.3" I was able to fix the problem. There may be a later version that will work but did not explore which version causes the break. Below is a link touching on issue with hanging in general.

https://github.com/dask/distributed/issues/2414