### PR TITLE
Python wrapper raise specific exceptions

### DIFF
--- a/wrappers/python/indy/error.py
+++ b/wrappers/python/indy/error.py
@@ -3,175 +3,177 @@ from typing import Optional
 
 
 class ErrorCode(IntEnum):
-    Success = 0,
+    """ ErrorCode To Enum """
+    Success = 0
 
     # Common errors
 
     # Caller passed invalid value as param 1 (null, invalid json and etc..)
-    CommonInvalidParam1 = 100,
+    CommonInvalidParam1 = 100
 
     # Caller passed invalid value as param 2 (null, invalid json and etc..)
-    CommonInvalidParam2 = 101,
+    CommonInvalidParam2 = 101
 
     # Caller passed invalid value as param 3 (null, invalid json and etc..)
-    CommonInvalidParam3 = 102,
+    CommonInvalidParam3 = 102
 
     # Caller passed invalid value as param 4 (null, invalid json and etc..)
-    CommonInvalidParam4 = 103,
+    CommonInvalidParam4 = 103
 
     # Caller passed invalid value as param 5 (null, invalid json and etc..)
-    CommonInvalidParam5 = 104,
+    CommonInvalidParam5 = 104
 
     # Caller passed invalid value as param 6 (null, invalid json and etc..)
-    CommonInvalidParam6 = 105,
+    CommonInvalidParam6 = 105
 
     # Caller passed invalid value as param 7 (null, invalid json and etc..)
-    CommonInvalidParam7 = 106,
+    CommonInvalidParam7 = 106
 
     # Caller passed invalid value as param 8 (null, invalid json and etc..)
-    CommonInvalidParam8 = 107,
+    CommonInvalidParam8 = 107
 
     # Caller passed invalid value as param 9 (null, invalid json and etc..)
-    CommonInvalidParam9 = 108,
+    CommonInvalidParam9 = 108
 
     # Caller passed invalid value as param 10 (null, invalid json and etc..)
-    CommonInvalidParam10 = 109,
+    CommonInvalidParam10 = 109
 
     # Caller passed invalid value as param 11 (null, invalid json and etc..)
-    CommonInvalidParam11 = 110,
+    CommonInvalidParam11 = 110
 
     # Caller passed invalid value as param 12 (null, invalid json and etc..)
-    CommonInvalidParam12 = 111,
+    CommonInvalidParam12 = 111
 
     # Invalid library state was detected in runtime. It signals library bug
-    CommonInvalidState = 112,
+    CommonInvalidState = 112
 
-    # Object (json, config, key, credential and etc...) passed by library caller has invalid structure
-    CommonInvalidStructure = 113,
+    # Object (json, config, key, credential, etc) passed by library caller has invalid structure
+    CommonInvalidStructure = 113
 
     # IO Error
-    CommonIOError = 114,
+    CommonIOError = 114
 
     # Wallet errors
     # Caller passed invalid wallet handle
-    WalletInvalidHandle = 200,
+    WalletInvalidHandle = 200
 
     # Unknown type of wallet was passed on create_wallet
-    WalletUnknownTypeError = 201,
+    WalletUnknownTypeError = 201
 
     # Attempt to register already existing wallet type
-    WalletTypeAlreadyRegisteredError = 202,
+    WalletTypeAlreadyRegisteredError = 202
 
     # Attempt to create wallet with name used for another exists wallet
-    WalletAlreadyExistsError = 203,
+    WalletAlreadyExistsError = 203
 
     # Requested entity id isn't present in wallet
-    WalletNotFoundError = 204,
+    WalletNotFoundError = 204
 
     # Trying to use wallet with pool that has different name
-    WalletIncompatiblePoolError = 205,
+    WalletIncompatiblePoolError = 205
 
     # Trying to open wallet that was opened already
-    WalletAlreadyOpenedError = 206,
+    WalletAlreadyOpenedError = 206
 
     # Attempt to open encrypted wallet with invalid credentials
-    WalletAccessFailed = 207,
+    WalletAccessFailed = 207
 
     # Input provided to wallet operations is considered not valid
-    WalletInputError = 208,
+    WalletInputError = 208
 
     # Decoding of wallet data during input/output failed
-    WalletDecodingError = 209,
+    WalletDecodingError = 209
 
     # Storage error occurred during wallet operation
-    WalletStorageError = 210,
+    WalletStorageError = 210
 
     # Error during encryption-related operations
-    WalletEncryptionError = 211,
+    WalletEncryptionError = 211
 
     # Requested wallet item not found
-    WalletItemNotFound = 212,
+    WalletItemNotFound = 212
 
     # Returned if wallet's add_record operation is used with record name that already exists
-    WalletItemAlreadyExists = 213,
+    WalletItemAlreadyExists = 213
 
     # Returned if provided wallet query is invalid
-    WalletQueryError = 214,
+    WalletQueryError = 214
 
     # Ledger errors
     # Trying to open pool ledger that wasn't created before
-    PoolLedgerNotCreatedError = 300,
+    PoolLedgerNotCreatedError = 300
 
     # Caller passed invalid pool ledger handle
-    PoolLedgerInvalidPoolHandle = 301,
+    PoolLedgerInvalidPoolHandle = 301
 
     # Pool ledger terminated
-    PoolLedgerTerminated = 302,
+    PoolLedgerTerminated = 302
 
     # No consensus during ledger operation
-    LedgerNoConsensusError = 303,
+    LedgerNoConsensusError = 303
 
     # Attempt to parse invalid transaction response
-    LedgerInvalidTransaction = 304,
+    LedgerInvalidTransaction = 304
 
     # Attempt to send transaction without the necessary privileges
-    LedgerSecurityError = 305,
+    LedgerSecurityError = 305
 
     # Attempt to create pool ledger config with name used for another existing pool
-    PoolLedgerConfigAlreadyExistsError = 306,
+    PoolLedgerConfigAlreadyExistsError = 306
 
     # Timeout for action
-    PoolLedgerTimeout = 307,
+    PoolLedgerTimeout = 307
 
-    # Attempt to open Pool for witch Genesis Transactions are not compatible with set Protocol version.
-    # Call pool.indy_set_protocol_version to set correct Protocol version.
-    PoolIncompatibleProtocolVersion = 308,
+    # Attempt to open Pool for witch Genesis Transactions are not compatible with set Protocol
+    # version. Call pool.indy_set_protocol_version to set correct Protocol version.
+    PoolIncompatibleProtocolVersion = 308
 
     # Item not found on ledger.
-    LedgerNotFound = 309,
+    LedgerNotFound = 309
 
     # Revocation registry is full and creation of new registry is necessary
-    AnoncredsRevocationRegistryFullError = 400,
+    AnoncredsRevocationRegistryFullError = 400
 
-    AnoncredsInvalidUserRevocId = 401,
+    AnoncredsInvalidUserRevocId = 401
 
     # Attempt to generate master secret with duplicated name
-    AnoncredsMasterSecretDuplicateNameError = 404,
+    AnoncredsMasterSecretDuplicateNameError = 404
 
-    AnoncredsProofRejected = 405,
+    AnoncredsProofRejected = 405
 
-    AnoncredsCredentialRevoked = 406,
+    AnoncredsCredentialRevoked = 406
 
     # Attempt to create credential definition with duplicated did schema pair
-    AnoncredsCredDefAlreadyExistsError = 407,
+    AnoncredsCredDefAlreadyExistsError = 407
 
     # Crypto errors
     # Unknown format of DID entity keys
-    UnknownCryptoTypeError = 500,
+    UnknownCryptoTypeError = 500
 
     # Attempt to create duplicate did
-    DidAlreadyExistsError = 600,
+    DidAlreadyExistsError = 600
 
     # Unknown payment method was given
-    PaymentUnknownMethodError = 700,
+    PaymentUnknownMethodError = 700
 
     # No method were scraped from inputs/outputs or more than one were scraped
-    PaymentIncompatibleMethodsError = 701,
+    PaymentIncompatibleMethodsError = 701
 
     # Insufficient funds on inputs
-    PaymentInsufficientFundsError = 702,
+    PaymentInsufficientFundsError = 702
 
     # No such source on a ledger
-    PaymentSourceDoesNotExistError = 703,
+    PaymentSourceDoesNotExistError = 703
 
     # Operation is not supported for payment method
-    PaymentOperationNotSupportedError = 704,
+    PaymentOperationNotSupportedError = 704
 
     # Extra funds on inputs
     PaymentExtraFundsError = 705
 
 
 class IndyError(Exception):
+    """ Base Exception for all errors raised by Indy """
     # error_code: ErrorCode - libindy error code
     # message: Optional[str] - human-readable error description
     # indy_backtrace: Optional[str] - error backtrace.
@@ -180,7 +182,245 @@ class IndyError(Exception):
     #             2) calling `set_runtime_config` function with `collect_backtrace: true`
 
     def __init__(self, error_code: ErrorCode, error_details: Optional[dict] = None):
+        super().__init__()
         self.error_code = error_code
         if error_details:
             self.message = error_details.get('message')
             self.indy_backtrace = error_details.get('backtrace')
+
+
+class CommonInvalidParam1(IndyError):
+    """ Caller passed invalid value as param 1 (null, invalid json and etc..) """
+
+class CommonInvalidParam2(IndyError):
+    """ Caller passed invalid value as param 2 (null, invalid json and etc..) """
+
+class CommonInvalidParam3(IndyError):
+    """ Caller passed invalid value as param 3 (null, invalid json and etc..) """
+
+class CommonInvalidParam4(IndyError):
+    """ Caller passed invalid value as param 4 (null, invalid json and etc..) """
+
+class CommonInvalidParam5(IndyError):
+    """ Caller passed invalid value as param 5 (null, invalid json and etc..) """
+
+class CommonInvalidParam6(IndyError):
+    """ Caller passed invalid value as param 6 (null, invalid json and etc..) """
+
+class CommonInvalidParam7(IndyError):
+    """ Caller passed invalid value as param 7 (null, invalid json and etc..) """
+
+class CommonInvalidParam8(IndyError):
+    """ Caller passed invalid value as param 8 (null, invalid json and etc..) """
+
+class CommonInvalidParam9(IndyError):
+    """ Caller passed invalid value as param 9 (null, invalid json and etc..) """
+
+class CommonInvalidParam10(IndyError):
+    """ Caller passed invalid value as param 10 (null, invalid json and etc..) """
+
+class CommonInvalidParam11(IndyError):
+    """ Caller passed invalid value as param 11 (null, invalid json and etc..) """
+
+class CommonInvalidParam12(IndyError):
+    """ Caller passed invalid value as param 12 (null, invalid json and etc..) """
+
+class CommonInvalidState(IndyError):
+    """ Invalid library state was detected in runtime. It signals library bug """
+
+class CommonInvalidStructure(IndyError):
+    """ Object (json, config, key, credential, etc) passed by library caller has
+        invalid structure
+    """
+
+class CommonIOError(IndyError):
+    """ IO Error """
+
+# Wallet errors
+class WalletInvalidHandle(IndyError):
+    """ Caller passed invalid wallet handle """
+
+class WalletUnknownTypeError(IndyError):
+    """ Unknown type of wallet was passed on create_wallet """
+
+class WalletTypeAlreadyRegisteredError(IndyError):
+    """ Attempt to register already existing wallet type """
+
+class WalletAlreadyExistsError(IndyError):
+    """ Attempt to create wallet with name used for another exists wallet """
+
+class WalletNotFoundError(IndyError):
+    """ Requested entity id isn't present in wallet """
+
+class WalletIncompatiblePoolError(IndyError):
+    """ Trying to use wallet with pool that has different name """
+
+class WalletAlreadyOpenedError(IndyError):
+    """ Trying to open wallet that was opened already """
+
+class WalletAccessFailed(IndyError):
+    """ Attempt to open encrypted wallet with invalid credentials """
+
+class WalletInputError(IndyError):
+    """ Input provided to wallet operations is considered not valid """
+
+class WalletDecodingError(IndyError):
+    """ Decoding of wallet data during input/output failed """
+
+class WalletStorageError(IndyError):
+    """ Storage error occurred during wallet operation """
+
+class WalletEncryptionError(IndyError):
+    """ Error during encryption-related operations """
+
+class WalletItemNotFound(IndyError):
+    """ Requested wallet item not found """
+
+class WalletItemAlreadyExists(IndyError):
+    """ Returned if wallet's add_record operation is used with record name that
+        already exists
+    """
+
+class WalletQueryError(IndyError):
+    """ Returned if provided wallet query is invalid """
+
+# Ledger errors
+class PoolLedgerNotCreatedError(IndyError):
+    """ Trying to open pool ledger that wasn't created before """
+
+class PoolLedgerInvalidPoolHandle(IndyError):
+    """ Caller passed invalid pool ledger handle """
+
+class PoolLedgerTerminated(IndyError):
+    """ Pool ledger terminated """
+
+class LedgerNoConsensusError(IndyError):
+    """ No consensus during ledger operation """
+
+class LedgerInvalidTransaction(IndyError):
+    """ Attempt to parse invalid transaction response """
+
+class LedgerSecurityError(IndyError):
+    """ Attempt to send transaction without the necessary privileges """
+
+class PoolLedgerConfigAlreadyExistsError(IndyError):
+    """ Attempt to create pool ledger config with name used for another existing pool """
+
+class PoolLedgerTimeout(IndyError):
+    """ Timeout for action """
+
+class PoolIncompatibleProtocolVersion(IndyError):
+    """ Attempt to open Pool for witch Genesis Transactions are not compatible with set
+        Protocol version. Call pool.indy_set_protocol_version to set correct Protocol version.
+    """
+
+class LedgerNotFound(IndyError):
+    """ Item not found on ledger. """
+
+class AnoncredsRevocationRegistryFullError(IndyError):
+    """ Revocation registry is full and creation of new registry is necessary """
+
+class AnoncredsInvalidUserRevocId(IndyError):
+    """ Invalid User Revoc ID"""
+
+class AnoncredsMasterSecretDuplicateNameError(IndyError):
+    """ Attempt to generate master secret with duplicated name """
+
+class AnoncredsProofRejected(IndyError):
+    """ Proof Rejected """
+
+class AnoncredsCredentialRevoked(IndyError):
+    """ Credential Revoked """
+
+class AnoncredsCredDefAlreadyExistsError(IndyError):
+    """ Attempt to create credential definition with duplicated did schema pair """
+
+# Crypto errors
+class UnknownCryptoTypeError(IndyError):
+    """ Unknown format of DID entity keys """
+
+class DidAlreadyExistsError(IndyError):
+    """ Attempt to create duplicate did """
+
+class PaymentUnknownMethodError(IndyError):
+    """ Unknown payment method was given """
+
+class PaymentIncompatibleMethodsError(IndyError):
+    """ No method were scraped from inputs/outputs or more than one were scraped """
+
+class PaymentInsufficientFundsError(IndyError):
+    """ Insufficient funds on inputs """
+
+class PaymentSourceDoesNotExistError(IndyError):
+    """ No such source on a ledger """
+
+class PaymentOperationNotSupportedError(IndyError):
+    """ Operation is not supported for payment method """
+
+class PaymentExtraFundsError(IndyError):
+    """ Extra funds on inputs """
+
+
+def errorcode_to_exception(errorcode):
+    """ Map ErrorCode to an exception class. """
+    return {
+        # Common Errors
+        ErrorCode.CommonInvalidParam1: CommonInvalidParam1,
+        ErrorCode.CommonInvalidParam2: CommonInvalidParam2,
+        ErrorCode.CommonInvalidParam3: CommonInvalidParam3,
+        ErrorCode.CommonInvalidParam4: CommonInvalidParam4,
+        ErrorCode.CommonInvalidParam5: CommonInvalidParam5,
+        ErrorCode.CommonInvalidParam6: CommonInvalidParam6,
+        ErrorCode.CommonInvalidParam7: CommonInvalidParam7,
+        ErrorCode.CommonInvalidParam8: CommonInvalidParam8,
+        ErrorCode.CommonInvalidParam9: CommonInvalidParam9,
+        ErrorCode.CommonInvalidParam10: CommonInvalidParam10,
+        ErrorCode.CommonInvalidParam11: CommonInvalidParam11,
+        ErrorCode.CommonInvalidParam12: CommonInvalidParam12,
+        ErrorCode.CommonInvalidState: CommonInvalidState,
+        ErrorCode.CommonInvalidStructure: CommonInvalidStructure,
+        ErrorCode.CommonIOError: CommonIOError,
+        # Wallet Errors
+        ErrorCode.WalletInvalidHandle: WalletInvalidHandle,
+        ErrorCode.WalletUnknownTypeError: WalletUnknownTypeError,
+        ErrorCode.WalletTypeAlreadyRegisteredError: WalletTypeAlreadyRegisteredError,
+        ErrorCode.WalletAlreadyExistsError: WalletAlreadyExistsError,
+        ErrorCode.WalletNotFoundError: WalletNotFoundError,
+        ErrorCode.WalletIncompatiblePoolError: WalletIncompatiblePoolError,
+        ErrorCode.WalletAlreadyOpenedError: WalletAlreadyOpenedError,
+        ErrorCode.WalletAccessFailed: WalletAccessFailed,
+        ErrorCode.WalletInputError: WalletInputError,
+        ErrorCode.WalletDecodingError: WalletDecodingError,
+        ErrorCode.WalletStorageError: WalletStorageError,
+        ErrorCode.WalletEncryptionError: WalletEncryptionError,
+        ErrorCode.WalletItemNotFound: WalletItemNotFound,
+        ErrorCode.WalletItemAlreadyExists: WalletItemAlreadyExists,
+        ErrorCode.WalletQueryError: WalletQueryError,
+        # Pool Errors
+        ErrorCode.PoolLedgerNotCreatedError: PoolLedgerNotCreatedError,
+        ErrorCode.PoolLedgerInvalidPoolHandle: PoolLedgerInvalidPoolHandle,
+        ErrorCode.PoolLedgerTerminated: PoolLedgerTerminated,
+        ErrorCode.LedgerNoConsensusError: LedgerNoConsensusError,
+        ErrorCode.LedgerInvalidTransaction: LedgerInvalidTransaction,
+        ErrorCode.LedgerSecurityError: LedgerSecurityError,
+        ErrorCode.PoolLedgerConfigAlreadyExistsError: PoolLedgerConfigAlreadyExistsError,
+        ErrorCode.PoolLedgerTimeout: PoolLedgerTimeout,
+        ErrorCode.PoolIncompatibleProtocolVersion: PoolIncompatibleProtocolVersion,
+        ErrorCode.LedgerNotFound: LedgerNotFound,
+        # Anoncreds Errors
+        ErrorCode.AnoncredsRevocationRegistryFullError: AnoncredsRevocationRegistryFullError,
+        ErrorCode.AnoncredsInvalidUserRevocId: AnoncredsInvalidUserRevocId,
+        ErrorCode.AnoncredsMasterSecretDuplicateNameError: AnoncredsMasterSecretDuplicateNameError,
+        ErrorCode.AnoncredsProofRejected: AnoncredsProofRejected,
+        ErrorCode.AnoncredsCredentialRevoked: AnoncredsCredentialRevoked,
+        ErrorCode.AnoncredsCredDefAlreadyExistsError: AnoncredsCredDefAlreadyExistsError,
+        # Crypto Errors
+        ErrorCode.UnknownCryptoTypeError: UnknownCryptoTypeError,
+        ErrorCode.DidAlreadyExistsError: DidAlreadyExistsError,
+        ErrorCode.PaymentUnknownMethodError: PaymentUnknownMethodError,
+        ErrorCode.PaymentIncompatibleMethodsError: PaymentIncompatibleMethodsError,
+        ErrorCode.PaymentInsufficientFundsError: PaymentInsufficientFundsError,
+        ErrorCode.PaymentSourceDoesNotExistError: PaymentSourceDoesNotExistError,
+        ErrorCode.PaymentOperationNotSupportedError: PaymentOperationNotSupportedError,
+        ErrorCode.PaymentExtraFundsError: PaymentExtraFundsError,
+    }.get(errorcode, None)

--- a/wrappers/python/indy/libindy.py
+++ b/wrappers/python/indy/libindy.py
@@ -1,15 +1,15 @@
+from logging import ERROR, WARNING, INFO, DEBUG, CRITICAL
+import logging
+from typing import Optional
+import asyncio
+import itertools
 import json
+import sys
 
-from .error import ErrorCode, IndyError
+from .error import ErrorCode, IndyError, errorcode_to_exception
 
 from ctypes import *
 
-import asyncio
-import sys
-import itertools
-import logging
-from logging import ERROR, WARNING, INFO, DEBUG, CRITICAL
-from typing import Optional
 
 TRACE = 5
 
@@ -67,12 +67,13 @@ def create_cb(cb_type: CFUNCTYPE, transform_fn=None):
 
 
 def _get_indy_error(err: int) -> IndyError:
-    if err == ErrorCode.Success:
-        return IndyError(ErrorCode(err))
-    else:
-        error_details = _get_error_details()
-        error = IndyError(ErrorCode(err), error_details)
-        return error
+    errorcode = ErrorCode(err)
+    if errorcode == ErrorCode.Success:
+        return IndyError(errorcode)
+
+    error_details = _get_error_details()
+    error = errorcode_to_exception(errorcode)(errorcode, error_details)
+    return error
 
 
 def _get_error_details() -> Optional[dict]:

--- a/wrappers/python/indy/libindy.py
+++ b/wrappers/python/indy/libindy.py
@@ -72,7 +72,11 @@ def _get_indy_error(err: int) -> IndyError:
         return IndyError(errorcode)
 
     error_details = _get_error_details()
-    error = errorcode_to_exception(errorcode)(errorcode, error_details)
+    error_class = errorcode_to_exception(errorcode)
+    if error_class:
+        error = error_class(errorcode, error_details)
+    else:
+        error = IndyError(errorcode, error_details)
     return error
 
 

--- a/wrappers/python/tests/anoncreds/test_issuer_create_and_store_credential_def.py
+++ b/wrappers/python/tests/anoncreds/test_issuer_create_and_store_credential_def.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from indy.anoncreds import issuer_create_and_store_credential_def
-from indy.error import ErrorCode, IndyError
+from indy import error
 
 
 @pytest.mark.asyncio
@@ -17,18 +17,16 @@ async def test_issuer_create_and_store_credential_def_works_for_invalid_wallet(w
                                                                                default_cred_def_config):
     invalid_wallet_handle = wallet_handle + 100
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await issuer_create_and_store_credential_def(invalid_wallet_handle, issuer_did, gvt_schema_json, tag, "CL",
                                                      default_cred_def_config)
 
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_issuer_create_and_store_credential_def_works_for_duplicate(wallet_handle, prepopulated_wallet,
                                                                           issuer_did, gvt_schema, tag,
                                                                           default_cred_def_config):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.AnoncredsCredDefAlreadyExistsError):
         await issuer_create_and_store_credential_def(wallet_handle, issuer_did, json.dumps(gvt_schema), tag, "CL",
                                                      default_cred_def_config)
-    assert ErrorCode.AnoncredsCredDefAlreadyExistsError == e.value.error_code

--- a/wrappers/python/tests/anoncreds/test_issuer_create_credential.py
+++ b/wrappers/python/tests/anoncreds/test_issuer_create_credential.py
@@ -1,8 +1,7 @@
 import pytest
 
-from indy import wallet
+from indy import wallet, error
 from indy.anoncreds import issuer_create_credential
-from indy.error import ErrorCode, IndyError
 
 
 # noinspection PyUnusedLocal
@@ -17,10 +16,9 @@ async def test_issuer_create_credential_works_for_credential_values_not_correspo
         wallet_handle, prepopulated_wallet, xyz_cred_values_json):
     _, cred_offer, cred_req, _, _ = prepopulated_wallet
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await issuer_create_credential(wallet_handle, cred_offer, cred_req, xyz_cred_values_json, None, None)
 
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 # noinspection PyUnusedLocal
@@ -31,7 +29,5 @@ async def test_issuer_create_credential_works_for_for_invalid_wallet_handle(
 
     invalid_wallet_handle = wallet_handle + 100
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await issuer_create_credential(invalid_wallet_handle, cred_offer, cred_req, gvt_cred_values_json, None, None)
-
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/anoncreds/test_prover_create_credential_req.py
+++ b/wrappers/python/tests/anoncreds/test_prover_create_credential_req.py
@@ -1,7 +1,7 @@
-from indy.anoncreds import prover_create_credential_req
-from indy.error import ErrorCode, IndyError
-
 import pytest
+
+from indy.anoncreds import prover_create_credential_req
+from indy import error
 
 
 @pytest.mark.asyncio
@@ -15,8 +15,6 @@ async def test_prover_create_credential_req_works_for_invalid_wallet(wallet_hand
     credential_def_json, credential_offer, _, _, _ = prepopulated_wallet
     invalid_wallet_handle = wallet_handle + 100
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await prover_create_credential_req(invalid_wallet_handle, prover_did, credential_offer, credential_def_json,
                                            master_secret_id)
-
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/anoncreds/test_prover_create_master_secret.py
+++ b/wrappers/python/tests/anoncreds/test_prover_create_master_secret.py
@@ -1,7 +1,7 @@
-from indy.anoncreds import prover_create_master_secret
-from indy.error import ErrorCode, IndyError
-
 import pytest
+
+from indy.anoncreds import prover_create_master_secret
+from indy import error
 
 
 # noinspection PyUnusedLocal
@@ -14,7 +14,5 @@ async def test_prover_create_master_secret_works(wallet_handle, prepopulated_wal
 async def test_prover_create_master_secret_works_invalid_wallet_handle(wallet_handle):
     invalid_wallet_handle = wallet_handle + 100
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await prover_create_master_secret(invalid_wallet_handle, "master_secret_name")
-
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/anoncreds/test_prover_create_proof.py
+++ b/wrappers/python/tests/anoncreds/test_prover_create_proof.py
@@ -1,8 +1,8 @@
-from indy.anoncreds import prover_create_proof
-from indy.error import ErrorCode, IndyError
-
 import json
 import pytest
+
+from indy.anoncreds import prover_create_proof
+from indy import error
 
 
 @pytest.mark.asyncio
@@ -68,11 +68,10 @@ async def test_prover_create_proof_works_for_using_not_satisfy_credential(wallet
         issuer_1_gvt_cred_def_id: json.loads(credential_def_json)
     }
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await prover_create_proof(wallet_handle, json.dumps(proof_req), json.dumps(requested_credentials),
                                   master_secret_id, json.dumps(schemas), json.dumps(credential_defs), "{}")
 
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -101,8 +100,7 @@ async def test_prover_create_proof_works_for_invalid_wallet_handle(wallet_handle
 
     invalid_wallet_handle = wallet_handle + 100
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await prover_create_proof(invalid_wallet_handle, json.dumps(proof_req), json.dumps(requested_credentials),
                                   master_secret_id, json.dumps(schemas), json.dumps(credential_defs), "{}")
 
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/anoncreds/test_prover_credential_attr_tag_policy.py
+++ b/wrappers/python/tests/anoncreds/test_prover_credential_attr_tag_policy.py
@@ -1,8 +1,7 @@
-from indy import anoncreds
-from indy.error import ErrorCode, IndyError
-
 import json
 import pytest
+
+from indy import anoncreds, error
 
 
 async def _check_catpol(wallet_handle, cred_def_json, cred_def_id, cred_id, cred_value, offer_json, cred_req,
@@ -346,16 +345,14 @@ async def test_prover_credential_attr_tag_policy_works_for_invalid_wallet(wallet
                                                                           issuer_1_gvt_cred_def_id):
     invalid_wallet_handle = wallet_handle + 100
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await anoncreds.prover_set_credential_attr_tag_policy(invalid_wallet_handle,
                                                               issuer_1_gvt_cred_def_id, None, False)
 
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await anoncreds.prover_get_credential_attr_tag_policy(invalid_wallet_handle, issuer_1_gvt_cred_def_id)
 
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 
 # noinspection PyUnusedLocal

--- a/wrappers/python/tests/anoncreds/test_prover_delete_credential.py
+++ b/wrappers/python/tests/anoncreds/test_prover_delete_credential.py
@@ -1,8 +1,8 @@
-from indy.anoncreds import prover_delete_credential, prover_get_credential, prover_store_credential
-from indy.error import IndyError, ErrorCode
-
 import json
 import pytest
+
+from indy.anoncreds import prover_delete_credential, prover_get_credential, prover_store_credential
+from indy import error
 
 # noinspection PyUnusedLocal
 @pytest.mark.asyncio
@@ -10,9 +10,8 @@ async def test_prover_delete_credential_works(wallet_handle, prepopulated_wallet
     invalid_wallet_handle = wallet_handle + 100
     id_credential_x = 'id_credential_x';
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await prover_delete_credential(invalid_wallet_handle, id_credential_x)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
     # Store credential x
     await prover_store_credential(wallet_handle,
@@ -27,10 +26,8 @@ async def test_prover_delete_credential_works(wallet_handle, prepopulated_wallet
     # Delete credential x and check that it's gone
     await prover_delete_credential(wallet_handle, id_credential_x)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await prover_get_credential(wallet_handle, id_credential_x)  # make sure it's gone
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await prover_delete_credential(wallet_handle, id_credential_x)  # exercise double deletion
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/anoncreds/test_prover_get_credentials.py
+++ b/wrappers/python/tests/anoncreds/test_prover_get_credentials.py
@@ -1,8 +1,8 @@
-from indy.anoncreds import prover_get_credentials
-from indy.error import ErrorCode, IndyError
-
 import json
 import pytest
+
+from indy.anoncreds import prover_get_credentials
+from indy import error
 
 
 # noinspection PyUnusedLocal
@@ -66,7 +66,5 @@ async def test_prover_get_credentials_works_for_empty_result(wallet_handle, prep
 async def test_prover_get_credentials_works_for_invalid_wallet_handle(wallet_handle, prepopulated_wallet):
     invalid_wallet_handle = wallet_handle + 100
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await prover_get_credentials(invalid_wallet_handle, '{}')
-
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/anoncreds/test_prover_get_credentials_for_proof_req.py
+++ b/wrappers/python/tests/anoncreds/test_prover_get_credentials_for_proof_req.py
@@ -1,8 +1,8 @@
-from indy.anoncreds import prover_get_credentials_for_proof_req
-from indy.error import ErrorCode, IndyError
-
 import json
 import pytest
+
+from indy.anoncreds import prover_get_credentials_for_proof_req
+from indy import error
 
 
 # noinspection PyUnusedLocal
@@ -570,7 +570,5 @@ async def test_prover_get_credentials_for_proof_req_works_for_invalid_wallet_han
 
     invalid_wallet_handle = wallet_handle + 100
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await prover_get_credentials_for_proof_req(invalid_wallet_handle, json.dumps(proof_req))
-
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/anoncreds/test_prover_store_credential.py
+++ b/wrappers/python/tests/anoncreds/test_prover_store_credential.py
@@ -1,7 +1,7 @@
 import pytest
 
 from indy.anoncreds import prover_store_credential
-from indy.error import ErrorCode, IndyError
+from indy import error
 
 
 @pytest.mark.asyncio
@@ -14,7 +14,6 @@ async def test_prover_store_credential_works_for_invalid_wallet_handle(wallet_ha
     cred_def, _, _, cred_req_metadata, credential_json = prepopulated_wallet
     invalid_wallet_handle = wallet_handle + 100
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await prover_store_credential(invalid_wallet_handle, "id_1", cred_req_metadata,
                                       credential_json, cred_def, None)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/anoncreds/test_verify_proof.py
+++ b/wrappers/python/tests/anoncreds/test_verify_proof.py
@@ -1,8 +1,8 @@
-from indy.anoncreds import verifier_verify_proof
-from indy.error import ErrorCode, IndyError
-
 import json
 import pytest
+
+from indy.anoncreds import verifier_verify_proof
+from indy import error
 
 proof = {
     "proof": {
@@ -123,11 +123,10 @@ async def test_verifier_verify_proof_works_for_proof_does_not_correspond_to_requ
     proof["identifiers"][0]["schema_id"] = gvt_schema_id
     proof["identifiers"][0]["cred_def_id"] = issuer_1_gvt_cred_def_id
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.AnoncredsProofRejected):
         await verifier_verify_proof(json.dumps(xproof_req), json.dumps(proof),
                                     json.dumps(schemas), json.dumps(credential_defs), "{}", "{}")
 
-    assert ErrorCode.AnoncredsProofRejected == e.value.error_code
 
 
 @pytest.mark.asyncio

--- a/wrappers/python/tests/crypto/test_anon_crypt.py
+++ b/wrappers/python/tests/crypto/test_anon_crypt.py
@@ -1,9 +1,6 @@
-from indy import IndyError
-from indy import crypto
-
 import pytest
 
-from indy.error import ErrorCode
+from indy import crypto, error
 
 
 @pytest.mark.asyncio
@@ -13,10 +10,8 @@ async def test_anon_crypt_works(verkey_my2, message):
 
 @pytest.mark.asyncio
 async def test_anon_crypt_works_for_invalid_recipient_vk(message):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await crypto.anon_crypt('invalidVerkeyLength', message)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await crypto.anon_crypt('CnEDk___MnmiHXEV1WFgbV___eYnPqs___TdcZaNhFVW', message)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code

--- a/wrappers/python/tests/crypto/test_anon_decrypt.py
+++ b/wrappers/python/tests/crypto/test_anon_decrypt.py
@@ -1,9 +1,6 @@
-from indy import IndyError
-from indy import crypto
+from indy import crypto, error
 
 import pytest
-
-from indy.error import ErrorCode
 
 
 @pytest.mark.asyncio
@@ -18,24 +15,21 @@ async def test_anon_decrypt_works(wallet_handle, identity_trustee1, message):
 async def test_anon_decrypt_works_for_invalid_anonymous_msg(wallet_handle, identity_trustee1):
     (_, verkey) = identity_trustee1
     msg = "unencrypted message"
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await crypto.anon_decrypt(wallet_handle, verkey, msg.encode('utf-8'))
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_parse_msg_msg_works_for_unknown_recipient_vk(wallet_handle, verkey_my1, message):
     encrypted_msg = await crypto.anon_crypt(verkey_my1, message)
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await crypto.anon_decrypt(wallet_handle, verkey_my1, encrypted_msg)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_anon_decrypt_works_for_invalid_handle(wallet_handle, identity_trustee1, message):
     (_, verkey) = identity_trustee1
     encrypted_msg = await crypto.anon_crypt(verkey, message)
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await crypto.anon_decrypt(invalid_wallet_handle, verkey, encrypted_msg)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/crypto/test_auth_crypt.py
+++ b/wrappers/python/tests/crypto/test_auth_crypt.py
@@ -1,11 +1,8 @@
 import json
 
-from indy import IndyError
-from indy import crypto, did
-
 import pytest
 
-from indy.error import ErrorCode
+from indy import crypto, did, error
 
 
 @pytest.mark.asyncio
@@ -28,22 +25,19 @@ async def test_auth_crypt_works_for_created_did_as_cid(wallet_handle, seed_my1, 
 
 @pytest.mark.asyncio
 async def test_auth_crypt_works_for_unknown_sender_verkey(wallet_handle, verkey_my1, verkey_my2, message):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await crypto.auth_crypt(wallet_handle, verkey_my1, verkey_my2, message)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_auth_crypt_works_for_invalid_handle(wallet_handle, verkey_my1, verkey_my2, message):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await crypto.auth_crypt(invalid_wallet_handle, verkey_my1, verkey_my2, message)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_auth_crypt_works_for_invalid_recipient_vk(wallet_handle, identity_trustee1, message):
     (_, key) = identity_trustee1
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await crypto.auth_crypt(wallet_handle, key, 'CnEDk___MnmiHXEV1WFgbV___eYnPqs___TdcZaNhFVW', message)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code

--- a/wrappers/python/tests/crypto/test_auth_decrypt.py
+++ b/wrappers/python/tests/crypto/test_auth_decrypt.py
@@ -1,11 +1,8 @@
 import json
 
-from indy import IndyError
-from indy import crypto
-
 import pytest
 
-from indy.error import ErrorCode
+from indy import crypto, error
 
 
 @pytest.mark.asyncio
@@ -30,18 +27,16 @@ async def test_auth_decrypt_works_for_invalid_msg(wallet_handle, identity_stewar
                 108, 252, 30, 210, 202, 183, 215, 102, 93, 101, 185, 51, 114, 89, 24, 207, 123, 156, 228, 6, 39, 55,
                 250, 172]
     })
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await crypto.auth_decrypt(wallet_handle, my_verkey, msg.encode('utf-8'))
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_auth_decrypt_works_for_unknown_recipient_vk(wallet_handle, identity_steward1, verkey_my1, message):
     (_, my_verkey) = identity_steward1
     encrypted_msg = await crypto.auth_crypt(wallet_handle, my_verkey, verkey_my1, message)
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await crypto.auth_decrypt(wallet_handle, verkey_my1, encrypted_msg)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -49,7 +44,6 @@ async def test_auth_decrypt_works_for_invalid_handle(wallet_handle, identity_ste
     (_, my_verkey) = identity_steward1
     (_, their_verkey) = identity_trustee1
     encrypted_msg = await crypto.auth_crypt(wallet_handle, my_verkey, their_verkey, message)
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await crypto.auth_decrypt(invalid_wallet_handle, their_verkey, encrypted_msg)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/crypto/test_create_key.py
+++ b/wrappers/python/tests/crypto/test_create_key.py
@@ -1,11 +1,9 @@
 import json
 
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import base58
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -22,15 +20,13 @@ async def test_create_key_works_without_seed(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_create_my_did_works_for_invalid_seed(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await did.create_key(wallet_handle, json.dumps({'seed': 'invalidSeedLength'}))
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 
 @pytest.mark.asyncio
 async def test_create_my_did_works_for_invalid_handle(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await did.create_key(invalid_wallet_handle, '{}')
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/crypto/test_crypto_sign.py
+++ b/wrappers/python/tests/crypto/test_crypto_sign.py
@@ -1,8 +1,6 @@
-from indy import IndyError
-from indy import crypto, did
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import crypto, did, error
 
 
 @pytest.mark.asyncio
@@ -18,14 +16,12 @@ async def test_crypto_sign_works(wallet_handle, key_my1, message):
 
 @pytest.mark.asyncio
 async def test_crypto_sign_works_for_unknown_signer(wallet_handle, message, verkey_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await crypto.crypto_sign(wallet_handle, verkey_my1, message)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_crypto_sign_works_for_invalid_handle(wallet_handle, message):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         key = await did.create_key(wallet_handle, "{}")
         await crypto.crypto_sign(wallet_handle + 1, key, message)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/crypto/test_crypto_verify.py
+++ b/wrappers/python/tests/crypto/test_crypto_verify.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import IndyError, crypto
-from indy.error import ErrorCode
+from indy import crypto, error
 
 signature = bytes(
     [169, 215, 8, 225, 7, 107, 110, 9, 193, 162, 202, 214, 162, 66, 238, 211, 63, 209, 12, 196, 8, 211, 55, 27, 120, 94,
@@ -29,8 +28,7 @@ async def test_crypto_verify_works_for_other_signer(verkey_my2, message):
 
 
 @pytest.mark.asyncio
-async def test_crypto_verify_works_for_verkey_with_correct_crypto_type(verkey_my1, message):
+async def test_crypto_verify_works_for_verkey_with_incorrect_crypto_type(verkey_my1, message):
     verkey = verkey_my1 + ':unknown_crypto'
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.UnknownCryptoTypeError):
         await crypto.crypto_verify(verkey, message, signature)
-    assert ErrorCode.UnknownCryptoTypeError == e.value.error_code

--- a/wrappers/python/tests/crypto/test_get_key_metadata.py
+++ b/wrappers/python/tests/crypto/test_get_key_metadata.py
@@ -1,8 +1,6 @@
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -23,24 +21,21 @@ async def test_get_key_metadata_works_for_empty_string(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_get_key_metadata_works_for_no_key(wallet_handle, verkey_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.get_key_metadata(wallet_handle, verkey_my1)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_get_key_metadata_works_for_no_metadata(wallet_handle):
     verkey = await did.create_key(wallet_handle, "{}")
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.get_key_metadata(wallet_handle, verkey)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_get_key_metadata_works_for_invalid_handle(wallet_handle, metadata):
     verkey = await did.create_key(wallet_handle, "{}")
     await did.set_key_metadata(wallet_handle, verkey, metadata)
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await did.get_key_metadata(invalid_wallet_handle, verkey)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/crypto/test_pack_message.py
+++ b/wrappers/python/tests/crypto/test_pack_message.py
@@ -1,10 +1,7 @@
 import json
 import pytest
 
-from indy import IndyError
-from indy import crypto
-
-from indy.error import ErrorCode
+from indy import crypto, error
 
 
 @pytest.mark.asyncio
@@ -35,9 +32,8 @@ async def test_pack_message_anoncrypt_works(wallet_handle, verkey_my2, pack_mess
 @pytest.mark.asyncio
 async def test_pack_message_invalid_sender_verkey(wallet_handle, verkey_my2, pack_message):
     receiver_verkeys = [verkey_my2]
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await crypto.pack_message(wallet_handle, pack_message, receiver_verkeys, "INVALID_SENDER_VERKEY")
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -45,15 +41,13 @@ async def test_pack_message_invalid_receiver_verkey(wallet_handle, verkey_my2, i
     _, sender_verkey = identity_my1
     # This test is expected to fail because the type is not a list
     receiver_verkeys = verkey_my2
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidParam4):
         await crypto.pack_message(wallet_handle, pack_message, receiver_verkeys, sender_verkey)
-    assert ErrorCode.CommonInvalidParam4 == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_pack_message_invalid_wallet_handle(wallet_handle, verkey_my2, identity_my1, pack_message):
     sender_verkey, _ = identity_my1
     receiver_verkeys = [verkey_my2]
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await crypto.pack_message(wallet_handle + 1, pack_message, receiver_verkeys, sender_verkey)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/crypto/test_set_key_metadata.py
+++ b/wrappers/python/tests/crypto/test_set_key_metadata.py
@@ -1,8 +1,6 @@
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -32,15 +30,13 @@ async def test_set_key_metadata_works_for_empty_string(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_set_key_metadata_works_for_invalid_key(wallet_handle, metadata):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await did.set_key_metadata(wallet_handle, 'invalid_base58string', metadata)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_set_key_metadata_works_for_invalid_handle(wallet_handle, metadata):
     verkey = await did.create_key(wallet_handle, "{}")
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await did.set_key_metadata(invalid_wallet_handle, verkey, metadata)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/crypto/test_unpack_message.py
+++ b/wrappers/python/tests/crypto/test_unpack_message.py
@@ -1,10 +1,7 @@
 import json
 import pytest
 
-from indy import IndyError
-from indy import crypto
-
-from indy.error import ErrorCode
+from indy import crypto, error
 
 
 @pytest.mark.asyncio
@@ -52,6 +49,5 @@ async def test_pack_message_and_unpack_message_missing_verkey(wallet_handle, ide
     # run pack and unpack
     packed_message = await crypto.pack_message(wallet_handle, pack_message, recipient_verkeys, sender_vk)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await crypto.unpack_message(wallet_handle, packed_message)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/did/test_create_and_store_my_did.py
+++ b/wrappers/python/tests/did/test_create_and_store_my_did.py
@@ -1,11 +1,10 @@
 import json
 
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import base58
 import pytest
+
+from indy import error
+from indy import did
 
 
 @pytest.mark.asyncio
@@ -45,28 +44,24 @@ async def test_create_my_did_works_for_correct_type(wallet_handle, seed_my1, did
 
 @pytest.mark.asyncio
 async def test_create_my_did_works_for_invalid_seed(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await did.create_and_store_my_did(wallet_handle, json.dumps({'seed': 'aaaaaaaaaaa'}))
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_create_my_did_works_for_invalid_crypto_type(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.UnknownCryptoTypeError):
         await did.create_and_store_my_did(wallet_handle, json.dumps({'crypto_type': 'crypto_type'}))
-    assert ErrorCode.UnknownCryptoTypeError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_create_my_did_works_for_invalid_handle(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await did.create_and_store_my_did(wallet_handle + 1, '{}')
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_create_my_did_works_for_duplicate(wallet_handle):
     (_did, _) = await did.create_and_store_my_did(wallet_handle, '{}')
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.DidAlreadyExistsError):
         await did.create_and_store_my_did(wallet_handle, json.dumps({'did': _did}))
-    assert ErrorCode.DidAlreadyExistsError == e.value.error_code

--- a/wrappers/python/tests/did/test_get_did_metadata.py
+++ b/wrappers/python/tests/did/test_get_did_metadata.py
@@ -1,8 +1,6 @@
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -23,23 +21,20 @@ async def test_get_did_metadata_works_for_empty_string(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_get_did_metadata_works_for_no_metadata(wallet_handle, did_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.get_did_metadata(wallet_handle, did_my1)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_get_did_metadata_works_for_invalid_handle(wallet_handle, metadata):
     (_did, _) = await did.create_and_store_my_did(wallet_handle, "{}")
     await did.set_did_metadata(wallet_handle, _did, metadata)
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await did.get_did_metadata(invalid_wallet_handle, _did)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_get_did_metadata_works_for_not_found_did(wallet_handle, did_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.get_did_metadata(wallet_handle, did_my1)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/did/test_get_endpoint_for_did.py
+++ b/wrappers/python/tests/did/test_get_endpoint_for_did.py
@@ -1,12 +1,9 @@
 import json
-
 import time
 
-from indy import IndyError
-from indy import did, ledger
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, ledger, error
 
 
 @pytest.mark.asyncio
@@ -35,9 +32,8 @@ async def test_get_endpoint_for_did_works_from_ledger(pool_handle, wallet_handle
 
 @pytest.mark.asyncio
 async def test_get_endpoint_for_did_works_for_unknown_did(pool_handle, wallet_handle, did_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidState):
         await did.get_endpoint_for_did(wallet_handle, pool_handle, did_my1)
-    assert ErrorCode.CommonInvalidState == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -45,16 +41,14 @@ async def test_get_endpoint_for_did_works_invalid_wallet_handle(pool_handle, wal
                                                                 identity_trustee1, endpoint):
     (_did, key) = identity_trustee1
     await did.set_endpoint_for_did(wallet_handle, _did, endpoint, key)
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await did.get_endpoint_for_did(invalid_wallet_handle, pool_handle, _did)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_get_endpoint_for_did_works_invalid_pool_handle(pool_handle, wallet_handle, identity_trustee1, endpoint):
     (_did, key) = identity_trustee1
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PoolLedgerInvalidPoolHandle):
         invalid_pool_handle = pool_handle + 1
         await did.get_endpoint_for_did(wallet_handle, invalid_pool_handle, _did)
-    assert ErrorCode.PoolLedgerInvalidPoolHandle == e.value.error_code

--- a/wrappers/python/tests/did/test_get_my_did_with_meta.py
+++ b/wrappers/python/tests/did/test_get_my_did_with_meta.py
@@ -1,11 +1,8 @@
 import json
 
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
-import base58
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -22,12 +19,10 @@ async def test_get_my_did_works(wallet_handle, seed_my1, did_my1, verkey_my1, me
 
 @pytest.mark.asyncio
 async def test_get_my_dids_works_for_invalid_handle(wallet_handle, did_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await did.get_my_did_with_meta(wallet_handle + 1, did_my1)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 @pytest.mark.asyncio
 async def test_get_my_did_with_metadata_works_for_no_metadata(wallet_handle, did_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.get_my_did_with_meta(wallet_handle, did_my1)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/did/test_key_for_did.py
+++ b/wrappers/python/tests/did/test_key_for_did.py
@@ -1,11 +1,9 @@
 import json
 
-from indy import IndyError
-from indy import did
-from indy import wallet
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, error
+
 
 
 @pytest.mark.asyncio
@@ -24,22 +22,19 @@ async def test_key_for_did_works_for_their_did(wallet_handle, did_my1, verkey_my
 
 @pytest.mark.asyncio
 async def test_key_for_did_works_for_unknown_did(pool_handle, wallet_handle, did_my2):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.key_for_did(pool_handle, wallet_handle, did_my2)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_key_for_did_works_for_invalid_pool_handle(pool_handle, wallet_handle, did_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PoolLedgerInvalidPoolHandle):
         await did.key_for_did(pool_handle + 1, wallet_handle, did_my1)
-    assert ErrorCode.PoolLedgerInvalidPoolHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_key_for_did_works_for_invalid_wallet_handle(wallet_handle, identity_trustee1):
     (_did, _) = identity_trustee1
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await did.key_for_did(-1, invalid_wallet_handle, _did)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/did/test_key_for_local_did.py
+++ b/wrappers/python/tests/did/test_key_for_local_did.py
@@ -2,9 +2,7 @@ import json
 
 import pytest
 
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -23,15 +21,13 @@ async def test_key_for_local_did_works_for_their_did(wallet_handle, did_my1, ver
 
 @pytest.mark.asyncio
 async def test_key_for_local_did_works_for_unknown_did(wallet_handle, did_my2):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.key_for_local_did(wallet_handle, did_my2)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_key_for_local_did_works_for_invalid_wallet_handle(wallet_handle, identity_trustee1):
     (_did, _) = identity_trustee1
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await did.key_for_local_did(invalid_wallet_handle, _did)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/did/test_list_my_dids_with_meta.py
+++ b/wrappers/python/tests/did/test_list_my_dids_with_meta.py
@@ -1,10 +1,8 @@
 import json
 
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -22,6 +20,5 @@ async def test_list_my_dids_works(wallet_handle, seed_my1, did_my1, verkey_my1, 
 
 @pytest.mark.asyncio
 async def test_list_my_dids_works_for_invalid_handle(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await did.list_my_dids_with_meta(wallet_handle + 1)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/did/test_replace_keys_apply.py
+++ b/wrappers/python/tests/did/test_replace_keys_apply.py
@@ -1,8 +1,6 @@
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -15,24 +13,21 @@ async def test_replace_keys_apply_works(wallet_handle):
 @pytest.mark.asyncio
 async def test_replace_keys_apply_works_without_calling_replace_start(wallet_handle):
     (_did, _) = await did.create_and_store_my_did(wallet_handle, "{}")
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.replace_keys_apply(wallet_handle, _did)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_replace_keys_apply_works_for_unknown_did(wallet_handle, did_my1):
     (_did, _) = await did.create_and_store_my_did(wallet_handle, "{}")
     await did.replace_keys_start(wallet_handle, _did, "{}")
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.replace_keys_apply(wallet_handle, did_my1)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_replace_keys_apply_works_invalid_wallet_handle(wallet_handle):
     (_did, _) = await did.create_and_store_my_did(wallet_handle, "{}")
     await did.replace_keys_start(wallet_handle, _did, "{}")
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await did.replace_keys_apply(wallet_handle + 1, _did)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/did/test_replace_keys_start.py
+++ b/wrappers/python/tests/did/test_replace_keys_start.py
@@ -1,10 +1,8 @@
 import json
 
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -31,22 +29,19 @@ async def test_replace_keys_start_works_for_correct_crypto_type(wallet_handle, c
 
 @pytest.mark.asyncio
 async def test_replace_keys_start_works_for_not_exists_did(wallet_handle, did_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await did.replace_keys_start(wallet_handle, did_my1, "{}")
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_replace_keys_start_works_for_invalid_handle(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         (_did, _) = await did.create_and_store_my_did(wallet_handle, "{}")
         await did.replace_keys_start(wallet_handle + 1, _did, "{}")
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_replace_keys_works_start_for_invalid_crypto_type(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.UnknownCryptoTypeError):
         (_did, _) = await did.create_and_store_my_did(wallet_handle, "{}")
         await did.replace_keys_start(wallet_handle, _did, '{"crypto_type": "type"}')
-    assert ErrorCode.UnknownCryptoTypeError == e.value.error_code

--- a/wrappers/python/tests/did/test_set_did_metadata.py
+++ b/wrappers/python/tests/did/test_set_did_metadata.py
@@ -1,8 +1,6 @@
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -33,10 +31,9 @@ async def test_set_did_metadata_works_for_empty_string(wallet_handle):
 @pytest.mark.asyncio
 async def test_set_did_metadata_works_for_invalid_handle(wallet_handle, did_my1, metadata):
     (_did, _) = await did.create_and_store_my_did(wallet_handle, "{}")
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await did.set_did_metadata(invalid_wallet_handle, did_my1, metadata)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 
 @pytest.mark.asyncio

--- a/wrappers/python/tests/did/test_set_endpoint_for_did.py
+++ b/wrappers/python/tests/did/test_set_endpoint_for_did.py
@@ -1,8 +1,6 @@
-from indy import IndyError
-from indy import did
-from indy.error import ErrorCode
-
 import pytest
+
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -29,23 +27,20 @@ async def test_set_endpoint_for_did_works_for_replace(pool_handle,wallet_handle,
 
 @pytest.mark.asyncio
 async def test_set_endpoint_for_did_works_for_invalid_did(wallet_handle, verkey_my1, endpoint):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await did.set_endpoint_for_did(wallet_handle, 'invalid_base58string', endpoint, verkey_my1)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_set_endpoint_for_did_works_for_invalid_transport_key(wallet_handle, identity_trustee1, endpoint):
     (_did, _) = identity_trustee1
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await did.set_endpoint_for_did(wallet_handle, _did, endpoint, 'CnEDk___MnmiHXEV1WFgbV___eYnPqs___TdcZaNhFVW')
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_set_endpoint_for_did_works_for_invalid_handle(wallet_handle, identity_trustee1, endpoint):
     (_did, key) = identity_trustee1
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await did.set_endpoint_for_did(invalid_wallet_handle, _did, endpoint, key)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/did/test_store_their_did.py
+++ b/wrappers/python/tests/did/test_store_their_did.py
@@ -1,11 +1,8 @@
 import json
 
-from indy import IndyError
-from indy import did
-
 import pytest
 
-from indy.error import ErrorCode
+from indy import did, error
 
 
 @pytest.mark.asyncio
@@ -15,16 +12,14 @@ async def test_store_their_did_works(wallet_handle, did_my):
 
 @pytest.mark.asyncio
 async def test_store_their_did_works_for_invalid_json(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await did.store_their_did(wallet_handle, '{"field":"value"}')
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_store_their_did_works_for_invalid_handle(wallet_handle, did_my):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await did.store_their_did(wallet_handle + 1, json.dumps({"did": did_my}))
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -34,13 +29,11 @@ async def test_store_their_did_works_with_verkey(wallet_handle, did_my1, verkey_
 
 @pytest.mark.asyncio
 async def test_store_their_did_works_without_did(wallet_handle, verkey_my1):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await did.store_their_did(wallet_handle, json.dumps({"verkey": verkey_my1}))
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_store_their_did_works_for_invalid_did(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await did.store_their_did(wallet_handle, '{"did": "invalid_base58_string"}')
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code

--- a/wrappers/python/tests/error/test_error.py
+++ b/wrappers/python/tests/error/test_error.py
@@ -1,12 +1,9 @@
 import json
 
-from indy import IndyError
-from indy import crypto, did
-from indy.libindy import set_runtime_config
-
 import pytest
 
-from indy.error import ErrorCode
+from indy import crypto, did, error
+from indy.libindy import set_runtime_config
 
 
 @pytest.mark.asyncio
@@ -17,17 +14,14 @@ async def test_error(wallet_handle, identity_trustee1, verkey_my2, message):
     invalid_wallet_handle = crypto.auth_crypt(wallet_handle + 1, key, verkey_my2, message)
     empty_key = crypto.auth_crypt(wallet_handle, "", verkey_my2, message)
 
-    with pytest.raises(IndyError) as e1:
+    with pytest.raises(error.CommonInvalidStructure) as e1:
         await invalid_key
-    assert ErrorCode.CommonInvalidStructure == e1.value.error_code
     assert e1.value.message
 
-    with pytest.raises(IndyError) as e2:
+    with pytest.raises(error.CommonInvalidParam3) as e2:
         await empty_key
-    assert ErrorCode.CommonInvalidParam3 == e2.value.error_code
     assert e2.value.message
 
-    with pytest.raises(IndyError) as e3:
+    with pytest.raises(error.WalletInvalidHandle) as e3:
         await invalid_wallet_handle
-    assert ErrorCode.WalletInvalidHandle == e3.value.error_code
     assert e3.value.message

--- a/wrappers/python/tests/ledger/test_build_attrib_request.py
+++ b/wrappers/python/tests/ledger/test_build_attrib_request.py
@@ -1,8 +1,7 @@
-from indy import ledger
-from indy.error import *
-
 import json
 import pytest
+
+from indy import ledger, error
 
 
 @pytest.mark.asyncio
@@ -67,8 +66,5 @@ async def test_build_attrib_request_works_for_missed_attribute():
     identifier = "Th7MpTaRZVRYnPiabds81Y"
     destination = "Th7MpTaRZVRYnPiabds81Y"
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await ledger.build_attrib_request(identifier, destination, None, None, None)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
-
-

--- a/wrappers/python/tests/ledger/test_build_node_request.py
+++ b/wrappers/python/tests/ledger/test_build_node_request.py
@@ -1,8 +1,7 @@
-from indy import ledger
-from indy.error import ErrorCode, IndyError
-
 import json
 import pytest
+
+from indy import ledger, error
 
 
 @pytest.mark.asyncio
@@ -10,9 +9,8 @@ async def test_build_node_request_works_for_missed_fields_in_data_json(did_trust
     destination = "destination"
     data = { }
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await ledger.build_node_request(did_trustee, destination, json.dumps(data))
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio

--- a/wrappers/python/tests/ledger/test_build_nym_request.py
+++ b/wrappers/python/tests/ledger/test_build_nym_request.py
@@ -1,10 +1,9 @@
-from indy import ledger, did
-from indy.error import ErrorCode, IndyError
-
-from tests.ledger.test_submit_request import ensure_previous_request_applied
-
 import json
 import pytest
+
+from indy import ledger, did, error
+
+from tests.ledger.test_submit_request import ensure_previous_request_applied
 
 
 @pytest.mark.asyncio
@@ -12,9 +11,8 @@ async def test_build_nym_request_works_for_invalid_identifier():
     identifier = "invalid_base58_identifier"
     dest = "FYmoFw55GeQH7SRFa37dkx1d2dZ3zUF8ckg7wmL7ofN4"
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await ledger.build_nym_request(identifier, dest, None, None, None)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -85,6 +83,5 @@ async def test_nym_request_works_for_invalid_role(identity_trustee1, identity_my
     (trustee_did, _) = identity_trustee1
     (my_did, _) = identity_my1
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await ledger.build_nym_request(trustee_did, my_did, None, None, "WRONG_ROLE")
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code

--- a/wrappers/python/tests/ledger/test_multi_sign_request.py
+++ b/wrappers/python/tests/ledger/test_multi_sign_request.py
@@ -1,9 +1,7 @@
-from indy import IndyError
-from indy import did, ledger
-from indy.error import ErrorCode
-
 import json
 import pytest
+
+from indy import did, ledger, error
 
 
 @pytest.mark.asyncio
@@ -33,23 +31,20 @@ async def test_multi_sign_works(wallet_handle, seed_trustee1, seed_my1):
 
 @pytest.mark.asyncio
 async def test_multi_sign_works_for_unknown_did(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await ledger.multi_sign_request(wallet_handle, '8wZcEriaNLNKtteJvx7f8i',
                                         json.dumps({"reqId": 1496822211362017764}))
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_multi_sign_works_for_invalid_message_format(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         (_did, _) = await did.create_and_store_my_did(wallet_handle, '{}')
         await ledger.multi_sign_request(wallet_handle, _did, '"reqId":1495034346617224651')
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_multi_sign_works_for_invalid_handle(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         (_did, _) = await did.create_and_store_my_did(wallet_handle, '{}')
         await ledger.multi_sign_request(wallet_handle + 1, _did, json.dumps({"reqId": 1496822211362017764}))
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/ledger/test_sign_and_submit_request.py
+++ b/wrappers/python/tests/ledger/test_sign_and_submit_request.py
@@ -1,8 +1,8 @@
 import json
 
-from indy import wallet, did, ledger
-from indy.error import ErrorCode, IndyError
 import pytest
+
+from indy import wallet, did, ledger, error
 
 
 @pytest.mark.asyncio
@@ -23,11 +23,9 @@ async def test_sign_and_submit_request_works_for_invalid_pool_handle(wallet_hand
     nym_request = await ledger.build_nym_request(trustee_did, my_did, None, None, None)
     invalid_pool_handle = pool_handle + 1
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PoolLedgerInvalidPoolHandle):
         await ledger.sign_and_submit_request(invalid_pool_handle, wallet_handle, trustee_did,
                                              nym_request)
-
-    assert ErrorCode.PoolLedgerInvalidPoolHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -39,8 +37,6 @@ async def test_sign_and_submit_request_works_for_invalid_wallet_handle(wallet_ha
     nym_request = await ledger.build_nym_request(trustee_did, my_did, None, None, None)
     invalid_wallet_handle = wallet_handle + 1
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await ledger.sign_and_submit_request(pool_handle, invalid_wallet_handle, trustee_did,
                                              nym_request)
-
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/ledger/test_sign_request.py
+++ b/wrappers/python/tests/ledger/test_sign_request.py
@@ -1,9 +1,7 @@
-from indy import IndyError
-from indy import did, ledger
-from indy.error import ErrorCode
-
 import json
 import pytest
+
+from indy import did, ledger, error
 
 
 @pytest.mark.asyncio
@@ -28,22 +26,19 @@ async def test_sign_works(wallet_handle, seed_trustee1):
 
 @pytest.mark.asyncio
 async def test_sign_works_for_unknown_did(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await ledger.sign_request(wallet_handle, '8wZcEriaNLNKtteJvx7f8i', json.dumps({"reqId": 1496822211362017764}))
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_sign_works_for_invalid_message_format(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         (_did, _) = await did.create_and_store_my_did(wallet_handle, '{}')
         await ledger.sign_request(wallet_handle, _did, '"reqId":1495034346617224651')
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_sign_works_for_invalid_handle(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         (_did, _) = await did.create_and_store_my_did(wallet_handle, '{}')
         await ledger.sign_request(wallet_handle + 1, _did, json.dumps({"reqId": 1496822211362017764}))
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/ledger/test_submit_request.py
+++ b/wrappers/python/tests/ledger/test_submit_request.py
@@ -5,8 +5,7 @@ import time
 
 import pytest
 
-from indy import ledger, anoncreds, blob_storage
-from indy.error import ErrorCode, IndyError
+from indy import ledger, anoncreds, blob_storage, error
 
 
 @pytest.mark.asyncio
@@ -48,9 +47,8 @@ async def test_submit_request_works_for_invalid_pool_handle(pool_handle, identit
     get_nym_request = await ledger.build_get_nym_request(my_did, my_did)
     invalid_pool_handle = pool_handle + 1
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PoolLedgerInvalidPoolHandle):
         await ledger.submit_request(invalid_pool_handle, get_nym_request)
-    assert ErrorCode.PoolLedgerInvalidPoolHandle == e.value.error_code
 
 
 @pytest.mark.asyncio

--- a/wrappers/python/tests/non_secrets/test_add_wallet_record.py
+++ b/wrappers/python/tests/non_secrets/test_add_wallet_record.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import IndyError
-from indy.error import ErrorCode
+from indy import error
 from tests.non_secrets.common import *
 
 
@@ -20,6 +19,5 @@ async def test_add_wallet_record_works_for_different_ids(wallet_handle):
 @pytest.mark.asyncio
 async def test_add_wallet_record_works_for_duplicate(wallet_handle):
     await non_secrets.add_wallet_record(wallet_handle, type_, id1, value1, tags1)
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemAlreadyExists):
         await non_secrets.add_wallet_record(wallet_handle, type_, id1, value1, tags1)
-    assert ErrorCode.WalletItemAlreadyExists == e.value.error_code

--- a/wrappers/python/tests/non_secrets/test_add_wallet_record_tags.py
+++ b/wrappers/python/tests/non_secrets/test_add_wallet_record_tags.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import IndyError
-from indy.error import ErrorCode
+from indy import error
 from tests.non_secrets.common import *
 
 
@@ -32,6 +31,5 @@ async def test_add_wallet_record_tags_works_for_twice(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_add_wallet_record_tags_works_for_not_found_record(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await non_secrets.add_wallet_record_tags(wallet_handle, type_, id1, tags1)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/non_secrets/test_delete_wallet_record.py
+++ b/wrappers/python/tests/non_secrets/test_delete_wallet_record.py
@@ -1,8 +1,6 @@
-
 import pytest
 
-from indy import IndyError
-from indy.error import ErrorCode
+from indy import error
 from tests.non_secrets.common import *
 
 
@@ -10,22 +8,19 @@ from tests.non_secrets.common import *
 async def test_delete_wallet_record_works(wallet_handle):
     await non_secrets.add_wallet_record(wallet_handle, type_, id1, value1, tags1)
     await non_secrets.delete_wallet_record(wallet_handle, type_, id1)
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await non_secrets.get_wallet_record(wallet_handle, type_, id1, "{}")
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 @pytest.mark.asyncio
 async def test_delete_wallet_record_works_for_twice(wallet_handle):
     await non_secrets.add_wallet_record(wallet_handle, type_, id1, value1, tags1)
     await non_secrets.delete_wallet_record(wallet_handle, type_, id1)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await non_secrets.delete_wallet_record(wallet_handle, type_, id1)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_delete_wallet_record_works_for_not_found_record(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await non_secrets.delete_wallet_record(wallet_handle, type_, id1)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/non_secrets/test_delete_wallet_record_tags.py
+++ b/wrappers/python/tests/non_secrets/test_delete_wallet_record_tags.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import IndyError
-from indy.error import ErrorCode
+from indy import error
 from tests.non_secrets.common import *
 
 
@@ -26,6 +25,5 @@ async def test_delete_wallet_record_tags_works_for_delete_all(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_delete_wallet_record_tags_works_for_not_found_record(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await non_secrets.delete_wallet_record_tags(wallet_handle, type_, id1, '["tagName1", "tagName2", "tagName3"]')
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/non_secrets/test_get_wallet_record.py
+++ b/wrappers/python/tests/non_secrets/test_get_wallet_record.py
@@ -1,8 +1,7 @@
 import operator
 import pytest
 
-from indy import IndyError
-from indy.error import ErrorCode
+from indy import error
 from tests.non_secrets.common import *
 
 
@@ -38,6 +37,5 @@ async def test_get_wallet_record_works_for_full_data(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_get_wallet_record_works_for_not_found_record(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await non_secrets.get_wallet_record(wallet_handle, type_, id1, options_empty)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/non_secrets/test_update_wallet_record_tags.py
+++ b/wrappers/python/tests/non_secrets/test_update_wallet_record_tags.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import IndyError
-from indy.error import ErrorCode
+from indy import error
 from tests.non_secrets.common import *
 
 
@@ -28,6 +27,5 @@ async def test_update_wallet_record_tags_works_for_twice(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_update_wallet_record_tags_works_for_not_found_record(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await non_secrets.update_wallet_record_tags(wallet_handle, type_, id1, tags2)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/non_secrets/test_update_wallet_record_value.py
+++ b/wrappers/python/tests/non_secrets/test_update_wallet_record_value.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import IndyError
-from indy.error import ErrorCode
+from indy import error
 from tests.non_secrets.common import *
 
 
@@ -28,6 +27,5 @@ async def test_update_wallet_record_value_works_for_twice(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_update_wallet_record_value_works_for_not_found_record(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await non_secrets.update_wallet_record_value(wallet_handle, type_, id1, value1)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code

--- a/wrappers/python/tests/pairwise/test_create_pairwise.py
+++ b/wrappers/python/tests/pairwise/test_create_pairwise.py
@@ -1,11 +1,7 @@
-from indy import IndyError
-from indy import did
-from indy import pairwise
-
 import pytest
 import json
 
-from indy.error import ErrorCode
+from indy import did, error, pairwise
 
 UNKNOWN_DID = 'NcYxiDXkpYi6ov5FcYDi1e'
 
@@ -27,17 +23,15 @@ async def test_create_pairwise_works_for_empty_metadata(wallet_handle, identity_
 @pytest.mark.asyncio
 async def test_create_pairwise_works_for_not_found_my_did(wallet_handle, identity_trustee1):
     (their_did, _) = identity_trustee1
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await pairwise.create_pairwise(wallet_handle, their_did, UNKNOWN_DID, None)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_create_pairwise_works_for_not_found_their_did(wallet_handle, identity_trustee1):
     (my_did, _) = identity_trustee1
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await pairwise.create_pairwise(wallet_handle, UNKNOWN_DID, my_did, None)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -45,7 +39,6 @@ async def test_create_pairwise_works_for_invalid_handle(wallet_handle, identity_
     (my_did, _) = identity_my2
     (their_did, _) = identity_trustee1
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await pairwise.create_pairwise(invalid_wallet_handle, their_did, my_did, None)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/pairwise/test_get_pairwise.py
+++ b/wrappers/python/tests/pairwise/test_get_pairwise.py
@@ -1,11 +1,7 @@
-from indy import IndyError
-from indy import did
-from indy import pairwise
-
 import pytest
 import json
 
-from indy.error import ErrorCode
+from indy import did, error, pairwise
 
 
 @pytest.mark.asyncio
@@ -31,9 +27,8 @@ async def test_get_pairwise_works_with_metadata(wallet_handle, identity_my2, ide
 async def test_get_pairwise_works_for_not_created_pairwise(wallet_handle, identity_trustee1):
     (their_did, _) = identity_trustee1
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await pairwise.get_pairwise(wallet_handle, their_did)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -42,7 +37,6 @@ async def test_get_pairwise_works_for_invalid_handle(wallet_handle, identity_my2
     (their_did, _) = identity_trustee1
     await pairwise.create_pairwise(wallet_handle, their_did, my_did, None)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await pairwise.get_pairwise(invalid_wallet_handle, their_did)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/pairwise/test_list_pairwise.py
+++ b/wrappers/python/tests/pairwise/test_list_pairwise.py
@@ -1,10 +1,7 @@
-from indy import IndyError
-from indy import pairwise
-
 import pytest
 import json
 
-from indy.error import ErrorCode
+from indy import error, pairwise
 
 
 @pytest.mark.asyncio
@@ -30,7 +27,6 @@ async def test_list_pairwise_works_for_invalid_handle(wallet_handle, identity_my
     (their_did, _) = identity_trustee1
     await pairwise.create_pairwise(wallet_handle, their_did, my_did, None)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await pairwise.list_pairwise(invalid_wallet_handle)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/pairwise/test_pairwise_exists.py
+++ b/wrappers/python/tests/pairwise/test_pairwise_exists.py
@@ -1,9 +1,6 @@
-from indy import IndyError
-from indy import pairwise
-
 import pytest
 
-from indy.error import ErrorCode
+from indy import pairwise, error
 
 
 @pytest.mark.asyncio
@@ -26,7 +23,6 @@ async def test_is_pairwise_exists_works_for_invalid_handle(wallet_handle, identi
     (their_did, _) = identity_trustee1
     await pairwise.create_pairwise(wallet_handle, their_did, my_did, None)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await pairwise.is_pairwise_exists(invalid_wallet_handle, their_did)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/pairwise/test_set_pairwise_metadata.py
+++ b/wrappers/python/tests/pairwise/test_set_pairwise_metadata.py
@@ -1,10 +1,7 @@
-from indy import IndyError
-from indy import pairwise
-
 import pytest
 import json
 
-from indy.error import ErrorCode
+from indy import pairwise, error
 
 
 @pytest.mark.asyncio
@@ -40,9 +37,8 @@ async def test_set_pairwise_metadata_works_for_reset(wallet_handle, identity_my2
 @pytest.mark.asyncio
 async def test_set_pairwise_metadata_works_for_not_created_pairwise(wallet_handle, identity_trustee1, metadata):
     (their_did, _) = identity_trustee1
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletItemNotFound):
         await pairwise.set_pairwise_metadata(wallet_handle, their_did, metadata)
-    assert ErrorCode.WalletItemNotFound == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -51,7 +47,6 @@ async def test_set_pairwise_metadata_works_for_invalid_handle(wallet_handle, ide
     (their_did, _) = identity_trustee1
     await pairwise.create_pairwise(wallet_handle, their_did, my_did, None)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         invalid_wallet_handle = wallet_handle + 1
         await pairwise.set_pairwise_metadata(invalid_wallet_handle, their_did, metadata)
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/payment/test_add_request_fees.py
+++ b/wrappers/python/tests/payment/test_add_request_fees.py
@@ -1,34 +1,28 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_add_request_fees_works_for_unknown_payment_method(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.add_request_fees(wallet_handle, did_trustee, empty_object, inputs, empty_array, None)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_add_request_fees_works_for_empty_inputs(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await payment.add_request_fees(wallet_handle, did_trustee, empty_object, '[]', empty_array, None)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_add_request_fees_works_for_several_methods(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentIncompatibleMethodsError):
         await payment.add_request_fees(wallet_handle, did_trustee, empty_object, incompatible_inputs, empty_array, None)
-    assert ErrorCode.PaymentIncompatibleMethodsError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_add_request_fees_works_for_invalid_input(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await payment.add_request_fees(wallet_handle, did_trustee, empty_object, invalid_inputs, empty_array, None)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code

--- a/wrappers/python/tests/payment/test_build_get_payment_sources_request.py
+++ b/wrappers/python/tests/payment/test_build_get_payment_sources_request.py
@@ -1,20 +1,16 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_build_get_payment_sources_request_works_for_unknown_payment_method(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.build_get_payment_sources_request(wallet_handle, did_trustee, payment_address)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_build_get_payment_sources_request_works_for_invalid_payment_address(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentIncompatibleMethodsError):
         await payment.build_get_payment_sources_request(wallet_handle, did_trustee, "pay:null1")
-    assert ErrorCode.PaymentIncompatibleMethodsError == e.value.error_code

--- a/wrappers/python/tests/payment/test_build_get_txn_fees_request.py
+++ b/wrappers/python/tests/payment/test_build_get_txn_fees_request.py
@@ -1,13 +1,10 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_build_get_txn_fees_request_works_for_unknown_payment_method(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.build_get_txn_fees_req(wallet_handle, did_trustee, payment_method)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code

--- a/wrappers/python/tests/payment/test_build_mint_request.py
+++ b/wrappers/python/tests/payment/test_build_mint_request.py
@@ -1,27 +1,22 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_build_mint_request_works_for_unknown_payment_method(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.build_mint_req(wallet_handle, did_trustee, outputs, None)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_build_mint_request_works_for_empty_outputs(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await payment.build_mint_req(wallet_handle, did_trustee, empty_object, None)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_build_mint_request_works_for_incompatible_outputs(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentIncompatibleMethodsError):
         await payment.build_mint_req(wallet_handle, did_trustee, incompatible_outputs, None)
-    assert ErrorCode.PaymentIncompatibleMethodsError == e.value.error_code

--- a/wrappers/python/tests/payment/test_build_payment_request.py
+++ b/wrappers/python/tests/payment/test_build_payment_request.py
@@ -1,41 +1,34 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_build_payment_request_works_for_unknown_payment_method(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.build_payment_req(wallet_handle, did_trustee, inputs, outputs, None)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_build_payment_request_works_for_empty_inputs(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await payment.build_payment_req(wallet_handle, did_trustee, empty_array, outputs, None)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_build_payment_request_works_for_empty_outputs(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await payment.build_payment_req(wallet_handle, did_trustee, inputs, empty_object, None)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_build_payment_request_works_for_incompatible_payment_methods(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentIncompatibleMethodsError):
         await payment.build_payment_req(wallet_handle, did_trustee, incompatible_inputs, outputs, None)
-    assert ErrorCode.PaymentIncompatibleMethodsError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_build_payment_request_works_for_invalid_input(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await payment.build_payment_req(wallet_handle, did_trustee, invalid_inputs, outputs, None)
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code

--- a/wrappers/python/tests/payment/test_build_set_txn_fees_request.py
+++ b/wrappers/python/tests/payment/test_build_set_txn_fees_request.py
@@ -1,20 +1,16 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_build_set_txn_fees_request_works_for_unknown_payment_method(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.build_set_txn_fees_req(wallet_handle, did_trustee, payment_method, fees)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_build_set_txn_fees_request_works_for_invalid_fees(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await payment.build_set_txn_fees_req(wallet_handle, did_trustee, payment_method, '[txnType1:1, txnType2:2]')
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code

--- a/wrappers/python/tests/payment/test_build_verify_payment_request.py
+++ b/wrappers/python/tests/payment/test_build_verify_payment_request.py
@@ -1,13 +1,10 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_build_verify_payment_request_works_for_unknown_payment_method(wallet_handle, did_trustee):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.build_verify_payment_req(wallet_handle, did_trustee, receipt)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code

--- a/wrappers/python/tests/payment/test_create_payment_address.py
+++ b/wrappers/python/tests/payment/test_create_payment_address.py
@@ -1,12 +1,10 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_create_payment_address_works_for_unknown_payment_method(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.create_payment_address(wallet_handle, payment_method, empty_object)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code

--- a/wrappers/python/tests/payment/test_parse_get_payment_sources_response.py
+++ b/wrappers/python/tests/payment/test_parse_get_payment_sources_response.py
@@ -1,6 +1,4 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
+from indy import payment, error
 from tests.payment.constants import *
 
 import pytest
@@ -8,6 +6,5 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_parse_get_payment_sources_response_works_for_unknown_payment_method():
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.parse_get_payment_sources_response(payment_method, empty_object)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code

--- a/wrappers/python/tests/payment/test_parse_get_txn_fees_response.py
+++ b/wrappers/python/tests/payment/test_parse_get_txn_fees_response.py
@@ -1,13 +1,10 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_parse_get_txn_fees_response_works_for_unknown_payment_method():
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.parse_get_txn_fees_response(payment_method, empty_object)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code

--- a/wrappers/python/tests/payment/test_parse_payment_response.py
+++ b/wrappers/python/tests/payment/test_parse_payment_response.py
@@ -1,13 +1,10 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_parse_payment_response_works_for_unknown_payment_method():
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.parse_payment_response(payment_method, empty_object)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code

--- a/wrappers/python/tests/payment/test_parse_response_with_fees.py
+++ b/wrappers/python/tests/payment/test_parse_response_with_fees.py
@@ -1,13 +1,10 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_parse_response_with_fees_works_for_unknown_payment_method():
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.parse_response_with_fees(payment_method, empty_object)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code

--- a/wrappers/python/tests/payment/test_parse_verify_payment_response.py
+++ b/wrappers/python/tests/payment/test_parse_verify_payment_response.py
@@ -1,13 +1,10 @@
-from indy import IndyError
-from indy import payment
-from indy.error import ErrorCode
-from tests.payment.constants import *
-
 import pytest
+
+from indy import payment, error
+from tests.payment.constants import *
 
 
 @pytest.mark.asyncio
 async def test_parse_verify_payment_response_works_for_unknown_payment_method():
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PaymentUnknownMethodError):
         await payment.parse_payment_response(payment_method, empty_object)
-    assert ErrorCode.PaymentUnknownMethodError == e.value.error_code

--- a/wrappers/python/tests/pool/test_close_pool_ledger.py
+++ b/wrappers/python/tests/pool/test_close_pool_ledger.py
@@ -1,7 +1,6 @@
-from indy import pool
-from indy.error import ErrorCode, IndyError
-
 import pytest
+
+from indy import pool, error
 
 
 # noinspection PyUnusedLocal
@@ -17,10 +16,9 @@ async def test_close_pool_ledger_works(pool_handle, pool_handle_cleanup):
 async def test_close_pool_ledger_works_for_twice(pool_handle, pool_handle_cleanup):
     await pool.close_pool_ledger(pool_handle)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PoolLedgerInvalidPoolHandle):
         await pool.close_pool_ledger(pool_handle)
 
-    assert ErrorCode.PoolLedgerInvalidPoolHandle == e.value.error_code
 
 
 # noinspection PyUnusedLocal

--- a/wrappers/python/tests/pool/test_create_pool_ledger_config.py
+++ b/wrappers/python/tests/pool/test_create_pool_ledger_config.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import pool
-from indy.error import ErrorCode, IndyError
+from indy import pool, error
 
 
 @pytest.mark.asyncio
@@ -11,7 +10,6 @@ async def test_create_pool_ledger_config_works(pool_ledger_config):
 
 @pytest.mark.asyncio
 async def test_create_pool_ledger_config_works_for_empty_name():
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidParam2):
         await pool.create_pool_ledger_config("", None)
 
-    assert ErrorCode.CommonInvalidParam2 == e.value.error_code

--- a/wrappers/python/tests/pool/test_delete_pool_ledger_config.py
+++ b/wrappers/python/tests/pool/test_delete_pool_ledger_config.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import pool
-from indy.error import ErrorCode, IndyError
+from indy import pool, error
 
 
 # noinspection PyUnusedLocal
@@ -14,7 +13,5 @@ async def test_delete_pool_ledger_config_works(pool_name, pool_ledger_config, po
 # noinspection PyUnusedLocal
 @pytest.mark.asyncio
 async def test_delete_pool_ledger_config_works_for_opened(pool_name, pool_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidState):
         await pool.delete_pool_ledger_config(pool_name)
-
-    assert ErrorCode.CommonInvalidState == e.value.error_code

--- a/wrappers/python/tests/pool/test_open_pool_ledger.py
+++ b/wrappers/python/tests/pool/test_open_pool_ledger.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import pool
-from indy.error import ErrorCode, IndyError
+from indy import pool, error
 
 
 @pytest.mark.parametrize(
@@ -14,10 +13,8 @@ async def test_open_pool_ledger_works(pool_handle):
 
 @pytest.mark.asyncio
 async def test_open_pool_ledger_works_for_twice(pool_name, pool_config, pool_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PoolLedgerInvalidPoolHandle):
         await pool.open_pool_ledger(pool_name, pool_config)
-
-    assert ErrorCode.PoolLedgerInvalidPoolHandle == e.value.error_code
 
 
 @pytest.mark.asyncio
@@ -25,9 +22,7 @@ async def test_open_pool_ledger_works_for_incompatible_protocol_version(pool_led
                                                                         protocol_version):
     await pool.set_protocol_version(1)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PoolIncompatibleProtocolVersion):
         await pool.open_pool_ledger(pool_name, None)
-
-    assert ErrorCode.PoolIncompatibleProtocolVersion == e.value.error_code
 
     await pool.set_protocol_version(protocol_version)

--- a/wrappers/python/tests/pool/test_set_protocol_version.py
+++ b/wrappers/python/tests/pool/test_set_protocol_version.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import pool
-from indy.error import ErrorCode, IndyError
+from indy import pool, error
 
 
 # noinspection PyUnusedLocal
@@ -13,7 +12,5 @@ async def test_test_set_protocol_version_works(protocol_version):
 # noinspection PyUnusedLocal
 @pytest.mark.asyncio
 async def test_test_set_protocol_version_works_for_unsupported():
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.PoolIncompatibleProtocolVersion):
         await pool.set_protocol_version(0)
-
-    assert ErrorCode.PoolIncompatibleProtocolVersion == e.value.error_code

--- a/wrappers/python/tests/wallet/test_close_wallet.py
+++ b/wrappers/python/tests/wallet/test_close_wallet.py
@@ -1,8 +1,6 @@
 import pytest
 
-from indy import IndyError
-from indy import wallet
-from indy.error import ErrorCode
+from indy import wallet, error
 
 
 @pytest.mark.asyncio
@@ -17,8 +15,6 @@ async def test_close_wallet_works(wallet_config, wallet_handle, credentials):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("wallet_handle_cleanup", [False])
 async def test_close_wallet_works_for_twice(wallet_handle):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletInvalidHandle):
         await wallet.close_wallet(wallet_handle)
         await wallet.close_wallet(wallet_handle)
-
-    assert ErrorCode.WalletInvalidHandle == e.value.error_code

--- a/wrappers/python/tests/wallet/test_create_wallet.py
+++ b/wrappers/python/tests/wallet/test_create_wallet.py
@@ -1,7 +1,6 @@
 import pytest
 
-from indy import wallet
-from indy.error import IndyError, ErrorCode
+from indy import wallet, error
 
 
 # noinspection PyUnusedLocal
@@ -18,15 +17,12 @@ async def test_create_wallet_works(wallet_config, xwallet):
 @pytest.mark.asyncio
 async def test_create_wallet_works_for_unknown_type(credentials):
     wallet_config = '{"id":"wallet1", "storage_type":"unknown_type"}'
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletUnknownTypeError):
         await wallet.create_wallet(wallet_config, credentials)
-    assert ErrorCode.WalletUnknownTypeError == e.value.error_code
 
 
 # noinspection PyUnusedLocal
 @pytest.mark.asyncio
 async def test_create_wallet_works_for_duplicate_name(xwallet, wallet_config, credentials):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletAlreadyExistsError):
         await wallet.create_wallet(wallet_config, credentials)
-
-    assert ErrorCode.WalletAlreadyExistsError == e.value.error_code

--- a/wrappers/python/tests/wallet/test_delete_wallet.py
+++ b/wrappers/python/tests/wallet/test_delete_wallet.py
@@ -1,8 +1,6 @@
 import pytest
 
-from indy import IndyError
-from indy import wallet
-from indy.error import ErrorCode
+from indy import wallet, error
 
 
 # noinspection PyUnusedLocal
@@ -22,9 +20,8 @@ async def test_delete_wallet_works_for_closed(wallet_config, wallet_handle, cred
 # noinspection PyUnusedLocal
 @pytest.mark.asyncio
 async def test_delete_wallet_works_for_opened(wallet_config, wallet_handle, credentials):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidState):
         await wallet.delete_wallet(wallet_config, credentials)
-    assert ErrorCode.CommonInvalidState == e.value.error_code
 
 
 # noinspection PyUnusedLocal
@@ -33,16 +30,12 @@ async def test_delete_wallet_works_for_opened(wallet_config, wallet_handle, cred
 async def test_delete_wallet_works_for_twice(wallet_config, xwallet, credentials):
     await wallet.delete_wallet(wallet_config, credentials)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletNotFoundError):
         await wallet.delete_wallet(wallet_config, credentials)
-
-    assert ErrorCode.WalletNotFoundError == e.value.error_code
 
 
 # noinspection PyUnusedLocal
 @pytest.mark.asyncio
 async def test_delete_wallet_works_for_not_created(wallet_config, path_home, credentials):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletNotFoundError):
         await wallet.delete_wallet(wallet_config, credentials)
-
-    assert ErrorCode.WalletNotFoundError == e.value.error_code

--- a/wrappers/python/tests/wallet/test_export_wallet.py
+++ b/wrappers/python/tests/wallet/test_export_wallet.py
@@ -2,9 +2,7 @@ import os
 
 import pytest
 
-from indy import IndyError
-from indy import wallet
-from indy.error import ErrorCode
+from indy import wallet, error
 
 
 @pytest.mark.asyncio
@@ -18,7 +16,5 @@ async def test_export_wallet_works_for_path_exists(wallet_handle, export_config,
     os.makedirs(export_path, exist_ok=True)
     os.path.exists(export_path)
 
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonIOError):
         await wallet.export_wallet(wallet_handle, export_config)
-
-    assert ErrorCode.CommonIOError == e.value.error_code

--- a/wrappers/python/tests/wallet/test_import_wallet.py
+++ b/wrappers/python/tests/wallet/test_import_wallet.py
@@ -1,9 +1,6 @@
 import pytest
 
-from indy import IndyError
-from indy import did
-from indy import wallet
-from indy.error import ErrorCode
+from indy import did, error, wallet
 
 
 @pytest.mark.asyncio
@@ -30,6 +27,5 @@ async def test_import_wallet_works(wallet_handle, wallet_config, credentials, ex
 
 @pytest.mark.asyncio
 async def test_import_wallet_works_for_not_exit_path(wallet_config, credentials, export_config):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonIOError):
         await wallet.import_wallet(wallet_config, credentials, export_config)
-    assert ErrorCode.CommonIOError == e.value.error_code

--- a/wrappers/python/tests/wallet/test_open_wallet.py
+++ b/wrappers/python/tests/wallet/test_open_wallet.py
@@ -1,8 +1,6 @@
 import pytest
 
-from indy import IndyError
-from indy import wallet
-from indy.error import ErrorCode
+from indy import wallet, error
 
 
 @pytest.mark.asyncio
@@ -12,24 +10,20 @@ async def test_open_wallet_works(wallet_handle):
 
 @pytest.mark.asyncio
 async def test_open_wallet_works_for_not_created_wallet(wallet_config, credentials):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletNotFoundError):
         await wallet.open_wallet(wallet_config, credentials)
-    assert ErrorCode.WalletNotFoundError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_open_wallet_works_for_twice(wallet_handle, wallet_config, credentials):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.WalletAlreadyOpenedError):
         await wallet.open_wallet(wallet_config, credentials)
-
-    assert ErrorCode.WalletAlreadyOpenedError == e.value.error_code
 
 
 @pytest.mark.asyncio
 async def test_open_wallet_works_for_missed_key(xwallet, wallet_config):
-    with pytest.raises(IndyError) as e:
+    with pytest.raises(error.CommonInvalidStructure):
         await wallet.open_wallet(wallet_config, "{}")
-    assert ErrorCode.CommonInvalidStructure == e.value.error_code
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is an improvement that raises more specific exceptions on errors from the Indy SDK. Before, you had to catch the `IndyError` exception and then test the error code against the specific error you wanted to write a handler for. For example:

```python
try:
    await wallet.create_wallet(wallet_handle, *wallet_config)
except IndyError as err:
    if err.error_code == ErrorCode.WalletAlreadyExists:
        # handling
    else:
        raise err
```

This becomes quite repetitive. With specific exceptions, the above code becomes:

```python
try:
    await wallet.create_wallet(wallet_handle, *wallet_config)
except error.WalletAlreadyExists:
     # handling
```
This is simpler and much more pythonic, allowing python wrapper users to take advantage of pythons built in exception to exception handler matching.

I updated the python wrapper tests to use the specific exceptions to demonstrate that it works.

This is a backwards compatible change. All specific exceptions inherit from `IndyError` so the manual error code checking that was previously required still works and should behave in the same way. I left some instances of the original error code checking in the tests where it seemed appropriate but this also demonstrates that the old method still works.

Minor formatting changes were also made as suggested by pylint.