### PR TITLE
protected header field values

### DIFF
--- a/libindy/src/commands/crypto.rs
+++ b/libindy/src/commands/crypto.rs
@@ -13,6 +13,11 @@ use utils::crypto::chacha20poly1305_ietf;
 use domain::crypto::combo_box::ComboBox;
 use api::WalletHandle;
 
+pub const PROTECTED_HEADER_ENC: &str = "xchacha20poly1305_ietf";
+pub const PROTECTED_HEADER_TYP: &str = "JWM/1.0";
+pub const PROTECTED_HEADER_ALG_AUTH: &str = "Authcrypt";
+pub const PROTECTED_HEADER_ALG_ANON: &str = "Anoncrypt";
+
 pub enum CryptoCommand {
     CreateKey(
         WalletHandle,
@@ -446,12 +451,12 @@ impl CryptoCommandExecutor {
     }
 
     fn _base64_encode_protected(&self, encrypted_recipients_struct: Vec<Recipient>, alg_is_authcrypt: bool) -> IndyResult<String> {
-        let alg_val = if alg_is_authcrypt { String::from("Authcrypt") } else { String::from("Anoncrypt") };
+        let alg_val = if alg_is_authcrypt { String::from(PROTECTED_HEADER_ALG_AUTH) } else { String::from(PROTECTED_HEADER_ALG_ANON) };
 
         //structure protected and base64URL encode it
         let protected_struct = Protected {
-            enc: "xchacha20poly1305_ietf".to_string(),
-            typ: "JWM/1.0".to_string(),
+            enc: PROTECTED_HEADER_ENC.to_string(),
+            typ: PROTECTED_HEADER_TYP.to_string(),
             alg: alg_val,
             recipients: encrypted_recipients_struct,
         };


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

Move the values that are part of the JWE protected header into constants to make it possible for the receiver of the encrypted message to (later) check those protected values whether they match the protocol.

