### PR TITLE
correct facts about aad

### DIFF
--- a/libindy/src/services/crypto/mod.rs
+++ b/libindy/src/services/crypto/mod.rs
@@ -745,7 +745,9 @@ mod tests {
     pub fn test_encrypt_plaintext_and_decrypt_ciphertext_works() {
         let service: CryptoService = CryptoService::new();
         let plaintext = "Hello World".as_bytes().to_vec();
-        let aad = "Random authenticated additional data";
+        // AAD allows the sender to tie extra (protocol) data to the encryption. Example JWE enc and alg
+        // Which the receiver MUST then check before decryption
+        let aad= "some protocol data input to the encryption";
         let cek = gen_key();
 
         let (expected_ciphertext, iv_encoded, tag) = service
@@ -763,7 +765,9 @@ mod tests {
     pub fn test_encrypt_plaintext_decrypt_ciphertext_empty_string_works() {
         let service: CryptoService = CryptoService::new();
         let plaintext = "".as_bytes().to_vec();
-        let aad = "Random authenticated additional data";
+        // AAD allows the sender to tie extra (protocol) data to the encryption. Example JWE enc and alg
+        // Which the receiver MUST then check before decryption
+        let aad= "some protocol data input to the encryption";
         let cek = gen_key();
 
         let (expected_ciphertext, iv_encoded, tag) = service
@@ -780,7 +784,9 @@ mod tests {
     pub fn test_encrypt_plaintext_decrypt_ciphertext_bad_iv_fails() {
         let service: CryptoService = CryptoService::new();
         let plaintext = "Hello World".as_bytes().to_vec();
-        let aad = "Random authenticated additional data";
+        // AAD allows the sender to tie extra (protocol) data to the encryption. Example JWE enc and alg
+        // Which the receiver MUST then check before decryption
+        let aad= "some protocol data input to the encryption";
         let cek = gen_key();
 
         let (expected_ciphertext, _, tag) = service
@@ -798,7 +804,9 @@ mod tests {
     pub fn test_encrypt_plaintext_decrypt_ciphertext_bad_ciphertext_fails() {
         let service: CryptoService = CryptoService::new();
         let plaintext = "Hello World".as_bytes().to_vec();
-        let aad = "Random authenticated additional data";
+        // AAD allows the sender to tie extra (protocol) data to the encryption. Example JWE enc and alg
+        // Which the receiver MUST then check before decryption
+        let aad= "some protocol data input to the encryption";
         let cek = gen_key();
 
         let (_, iv_encoded, tag) = service
@@ -815,7 +823,9 @@ mod tests {
     pub fn test_encrypt_plaintext_and_decrypt_ciphertext_wrong_cek_fails() {
         let service: CryptoService = CryptoService::new();
         let plaintext = "Hello World".as_bytes().to_vec();
-        let aad = "Random authenticated additional data";
+        // AAD allows the sender to tie extra (protocol) data to the encryption. Example JWE enc and alg
+        // Which the receiver MUST then check before decryption
+        let aad= "some protocol data input to the encryption";
         let cek = chacha20poly1305_ietf::gen_key();
 
         let (expected_ciphertext, iv_encoded, tag) = service
@@ -832,7 +842,9 @@ mod tests {
     pub fn test_encrypt_plaintext_and_decrypt_ciphertext_bad_tag_fails() {
         let service: CryptoService = CryptoService::new();
         let plaintext = "Hello World".as_bytes().to_vec();
-        let aad = "Random authenticated additional data";
+        // AAD allows the sender to tie extra (protocol) data to the encryption. Example JWE enc and alg
+        // Which the receiver MUST then check before decryption
+        let aad= "some protocol data input to the encryption";
         let cek = gen_key();
 
         let (expected_ciphertext, iv_encoded, _) = service
@@ -849,7 +861,9 @@ mod tests {
     pub fn test_encrypt_plaintext_and_decrypt_ciphertext_bad_aad_fails() {
         let service: CryptoService = CryptoService::new();
         let plaintext = "Hello World".as_bytes().to_vec();
-        let aad = "Random authenticated additional data";
+        // AAD allows the sender to tie extra (protocol) data to the encryption. Example JWE enc and alg
+        // Which the receiver MUST then check before decryption
+        let aad= "some protocol data input to the encryption";
         let cek = gen_key();
 
         let (expected_ciphertext, iv_encoded, tag) = service

--- a/libindy/src/utils/crypto/chacha20poly1305_ietf/sodium.rs
+++ b/libindy/src/utils/crypto/chacha20poly1305_ietf/sodium.rs
@@ -299,10 +299,12 @@ mod tests {
     pub fn gen_nonce_and_encrypt_detached_decrypt_detached_works() {
         let data = randombytes(100);
         let key = gen_key();
-        let aad= randombytes(100);
+        // AAD allows the sender to tie extra (protocol) data to the encryption. Example JWE enc and alg
+        // Which the receiver MUST then check before decryption
+        let aad= b"some protocol data input to the encryption";
 
-        let (c, nonce, tag) = gen_nonce_and_encrypt_detached(&data, aad.as_slice(), &key);
-        let u = decrypt_detached(&c, &key, &nonce, &tag, Some(aad.as_slice())).unwrap();
+        let (c, nonce, tag) = gen_nonce_and_encrypt_detached(&data, aad, &key);
+        let u = decrypt_detached(&c, &key, &nonce, &tag, Some(aad)).unwrap();
         assert_eq!(data, u);
 }
 


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

This PR corrects information that the previous libindy code suggests about AAD.

1. AAD is NOT random. Randomness is in IV or nonce
2. AAD enables the sender of an encrypted message to tie extra data to the encryption. 
E.g. JWE [RFC 7516](https://tools.ietf.org/html/rfc7516) uses AAD to protect the 'JWE protected header'
AAD should be provided by the application/code using the encryption
libindy uses the verkey from the protected header

This PR removes the generation of random AAD values. 