### PR TITLE
use hex::encode instead of ursa::encode::bin2hex

### DIFF
--- a/libindy/src/commands/payments.rs
+++ b/libindy/src/commands/payments.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::string::String;
 use std::vec::Vec;
 
-use ursa::encoding::hex;
+use hex;
 
 use serde_json;
 
@@ -688,7 +688,7 @@ impl PaymentsCommandExecutor {
     }
 
     fn sign_with_address(&self, wallet_handle: WalletHandle, address: &str, message: &[u8], cb: Box<Fn(IndyResult<Vec<u8>>) + Send>) {
-        trace!("sign_with_address >>> address: {:?}, message: {:?}", address, hex::bin2hex(message));
+        trace!("sign_with_address >>> address: {:?}, message: {:?}", address, hex::encode(message));
         let method = match self.payments_service.parse_method_from_payment_address(address) {
             Ok(method) => method,
             Err(err) => {
@@ -715,7 +715,7 @@ impl PaymentsCommandExecutor {
     }
 
     fn verify_with_address(&self, address: &str, message: &[u8], signature: &[u8], cb: Box<Fn(IndyResult<bool>) + Send>) {
-        trace!("sign_with_address >>> address: {:?}, message: {:?}, signature: {:?}", address, hex::bin2hex(message), hex::bin2hex(signature));
+        trace!("sign_with_address >>> address: {:?}, message: {:?}, signature: {:?}", address, hex::encode(message), hex::encode(signature));
 
         let method = match self.payments_service.parse_method_from_payment_address(address) {
             Ok(method) => method,

--- a/libindy/src/services/payments.rs
+++ b/libindy/src/services/payments.rs
@@ -7,7 +7,7 @@ use std::ops::Not;
 
 use serde_json;
 
-use ursa::encoding::hex;
+use hex;
 use api::{ErrorCode, WalletHandle};
 use api::payments::*;
 use errors::prelude::*;
@@ -575,7 +575,7 @@ impl PaymentsService {
     }
 
     pub fn sign_with_address(&self, cmd_handle: i32, method: &str, wallet_handle: WalletHandle, address: &str, message: &[u8]) -> IndyResult<()> {
-        trace!("sign_with_address >>> wallet_handle: {:?}, address: {:?}, message: {:?}", wallet_handle, address, hex::bin2hex(message));
+        trace!("sign_with_address >>> wallet_handle: {:?}, address: {:?}, message: {:?}", wallet_handle, address, hex::encode(message));
         let sign_with_address: SignWithAddressCB = self.methods.borrow().get(method)
                     .ok_or(err_msg(IndyErrorKind::UnknownPaymentMethodType, format!("Unknown payment method {}", method)))?.sign_with_address;
 
@@ -589,7 +589,7 @@ impl PaymentsService {
     }
 
     pub fn verify_with_address(&self, cmd_handle: i32, method: &str, address: &str, message: &[u8], signature: &[u8]) -> IndyResult<()> {
-        trace!("verify_with_address >>> address: {:?}, message: {:?}, signature: {:?}", address, hex::bin2hex(message), hex::bin2hex(signature));
+        trace!("verify_with_address >>> address: {:?}, message: {:?}, signature: {:?}", address, hex::encode(message), hex::encode(signature));
         let verify_with_address: VerifyWithAddressCB = self.methods.borrow().get(method)
                     .ok_or(err_msg(IndyErrorKind::UnknownPaymentMethodType, format!("Unknown payment method {}", method)))?.verify_with_address;
 


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>