### PR TITLE
update url of wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ functions in the SDK can be used to construct rich clients: [Indy-SDK Getting-St
 
 * A recent webinar explaining self-sovereign identity using Hyperledger Indy and Sovrin: [SSI Meetup Webinar](https://youtu.be/RllH91rcFdE?t=4m30s)
 
-* Visit the main resource for all things "Indy" to get acquainted with the code base, helpful resources, and up-to-date information: [Hyperledger Wiki-Indy](https://wiki.hyperledger.org/projects/indy).
+* Visit the main resource for all things "Indy" to get acquainted with the code base, helpful resources, and up-to-date information: [Hyperledger Wiki-Indy](https://wiki.hyperledger.org/display/indy/).
 
 * You may also want to look at the [older guide](https://github.com/hyperledger/indy-node/blob/stable/getting-started.md)
 that explored the ecosystem via command line. That material is being


### PR DESCRIPTION
I found the URL of indy's wiki is broken. Maybe it means https://wiki.hyperledger.org/display/indy/ or https://wiki.hyperledger.org/display/indy/Hyperledger+Indy. and then I try to fix it 