### PR TITLE
new macro prepare_result_CString

### DIFF
--- a/libindy/src/api/anoncreds.rs
+++ b/libindy/src/api/anoncreds.rs
@@ -90,10 +90,8 @@ pub extern fn indy_issuer_create_schema(command_handle: CommandHandle,
                     version,
                     attrs,
                     Box::new(move |result| {
-                        let (err, id, schema_json) = prepare_result_2!(result, String::new(), String::new());
+                        let (err, id, schema_json) = prepare_result_CString2!(result);
                         trace!("ursa_cl_credential_public_key_to_json: id: {:?}, schema_json: {:?}", id, schema_json);
-                        let id = ctypes::string_to_cstring(id);
-                        let schema_json = ctypes::string_to_cstring(schema_json);
                         cb(command_handle, err, id.as_ptr(), schema_json.as_ptr())
                     })
                 ))));
@@ -191,10 +189,8 @@ pub extern fn indy_issuer_create_and_store_credential_def(command_handle: Comman
                     signature_type,
                     config_json,
                     Box::new(move |result| {
-                        let (err, cred_def_id, cred_def_json) = prepare_result_2!(result, String::new(), String::new());
+                        let (err, cred_def_id, cred_def_json) = prepare_result_CString2!(result);
                         trace!("indy_issuer_create_and_store_credential_def: cred_def_id: {:?}, cred_def_json: {:?}", cred_def_id, cred_def_json);
-                        let cred_def_id = ctypes::string_to_cstring(cred_def_id);
-                        let cred_def_json = ctypes::string_to_cstring(cred_def_json);
                         cb(command_handle, err, cred_def_id.as_ptr(), cred_def_json.as_ptr())
                     })
                 ))));
@@ -721,8 +717,7 @@ pub extern fn indy_issuer_recover_credential(command_handle: CommandHandle,
                     rev_reg_id,
                     cred_revoc_id,
                     Box::new(move |result| {
-                        let (err, revoc_reg_update_json) = prepare_result_1!(result, String::new());
-                        let revoc_reg_update_json = ctypes::string_to_cstring(revoc_reg_update_json);
+                        let (err, revoc_reg_update_json) = prepare_result_CString!(result);
                         cb(command_handle, err, revoc_reg_update_json.as_ptr())
                     })
                 ))));
@@ -898,10 +893,8 @@ pub extern fn indy_prover_create_credential_req(command_handle: CommandHandle,
                     cred_def_json,
                     master_secret_id,
                     Box::new(move |result| {
-                        let (err, cred_req_json, cred_req_metadata_json) = prepare_result_2!(result, String::new(), String::new());
+                        let (err, cred_req_json, cred_req_metadata_json) = prepare_result_CString2!(result);
                         trace!("indy_prover_create_credential_req: cred_req_json: {:?}, cred_req_metadata_json: {:?}", cred_req_json, cred_req_metadata_json);
-                        let cred_req_json = ctypes::string_to_cstring(cred_req_json);
-                        let cred_req_metadata_json = ctypes::string_to_cstring(cred_req_metadata_json);
                         cb(command_handle, err, cred_req_json.as_ptr(), cred_req_metadata_json.as_ptr())
                     })
                 ))));

--- a/libindy/src/api/anoncreds.rs
+++ b/libindy/src/api/anoncreds.rs
@@ -23,6 +23,7 @@ use utils::ctypes;
 use libc::c_char;
 use std::ptr;
 use std::collections::HashMap;
+use std::ffi::CString;
 
 /*
 These functions wrap the Ursa algorithm as documented in this paper:
@@ -255,9 +256,8 @@ pub extern fn indy_issuer_rotate_credential_def_start(command_handle: CommandHan
                     cred_def_id,
                     config_json,
                     Box::new(move |result| {
-                        let (err, cred_def_json) = prepare_result_1!(result, String::new());
+                        let (err, cred_def_json) = prepare_result_CString!(result);
                         trace!("indy_issuer_rotate_credential_def_start:cred_def_json: {:?}", cred_def_json);
-                        let cred_def_json = ctypes::string_to_cstring(cred_def_json);
                         cb(command_handle, err, cred_def_json.as_ptr())
                     })
                 ))));
@@ -496,9 +496,8 @@ pub extern fn indy_issuer_create_credential_offer(command_handle: CommandHandle,
                     wallet_handle,
                     cred_def_id,
                     Box::new(move |result| {
-                        let (err, cred_offer_json) = prepare_result_1!(result, String::new());
+                        let (err, cred_offer_json) = prepare_result_CString!(result);
                         trace!("indy_issuer_create_credential_offer: cred_offer_json: {:?}", cred_offer_json);
-                        let cred_offer_json = ctypes::string_to_cstring(cred_offer_json);
                         cb(command_handle, err, cred_offer_json.as_ptr())
                     })
                 ))));
@@ -664,9 +663,8 @@ pub extern fn indy_issuer_revoke_credential(command_handle: CommandHandle,
                     rev_reg_id,
                     cred_revoc_id,
                     Box::new(move |result| {
-                        let (err, revoc_reg_update_json) = prepare_result_1!(result, String::new());
+                        let (err, revoc_reg_update_json) = prepare_result_CString!(result);
                         trace!("indy_issuer_revoke_credential: revoc_reg_update_json: {:?}", revoc_reg_update_json);
-                        let revoc_reg_update_json = ctypes::string_to_cstring(revoc_reg_update_json);
                         cb(command_handle, err, revoc_reg_update_json.as_ptr())
                     })
                 ))));
@@ -771,9 +769,8 @@ pub extern fn indy_issuer_merge_revocation_registry_deltas(command_handle: Comma
                     rev_reg_delta_json,
                     other_rev_reg_delta_json,
                     Box::new(move |result| {
-                        let (err, merged_rev_reg_delta) = prepare_result_1!(result, String::new());
+                        let (err, merged_rev_reg_delta) = prepare_result_CString!(result);
                         trace!("indy_issuer_merge_revocation_registry_deltas: merged_rev_reg_delta: {:?}", merged_rev_reg_delta);
-                        let merged_rev_reg_delta = ctypes::string_to_cstring(merged_rev_reg_delta);
                         cb(command_handle, err, merged_rev_reg_delta.as_ptr())
                     })
                 ))));
@@ -820,9 +817,8 @@ pub extern fn indy_prover_create_master_secret(command_handle: CommandHandle,
                     wallet_handle,
                     master_secret_id,
                     Box::new(move |result| {
-                        let (err, out_master_secret_id) = prepare_result_1!(result, String::new());
+                        let (err, out_master_secret_id) = prepare_result_CString!(result);
                         trace!("indy_prover_create_master_secret: out_master_secret_id: {:?}", out_master_secret_id);
-                        let out_master_secret_id = ctypes::string_to_cstring(out_master_secret_id);
                         cb(command_handle, err, out_master_secret_id.as_ptr())
                     })
                 ))));
@@ -1030,9 +1026,8 @@ pub extern fn indy_prover_get_credential_attr_tag_policy(command_handle: Command
                     wallet_handle,
                     cred_def_id,
                     Box::new(move |result| {
-                        let (err, catpol_json) = prepare_result_1!(result, String::new());
+                        let (err, catpol_json) = prepare_result_CString!(result);
                         trace!("indy_prover_get_credential_attr_tag_policy: catpol_json: {:?}", catpol_json);
-                        let catpol_json = ctypes::string_to_cstring(catpol_json);
                         cb(command_handle, err, catpol_json.as_ptr())
                     })
                 ))));
@@ -1112,9 +1107,8 @@ pub extern fn indy_prover_store_credential(command_handle: CommandHandle,
                     cred_def_json,
                     rev_reg_def_json,
                     Box::new(move |result| {
-                        let (err, out_cred_id) = prepare_result_1!(result, String::new());
+                        let (err, out_cred_id) = prepare_result_CString!(result);
                         trace!("indy_prover_store_credential: out_cred_id: {:?}", out_cred_id);
-                        let out_cred_id = ctypes::string_to_cstring(out_cred_id);
                         cb(command_handle, err, out_cred_id.as_ptr())
                     })
                 ))));
@@ -1169,9 +1163,8 @@ pub extern fn indy_prover_get_credential(command_handle: CommandHandle,
                     wallet_handle,
                     cred_id,
                     Box::new(move |result| {
-                        let (err, credential_json) = prepare_result_1!(result, String::new());
+                        let (err, credential_json) = prepare_result_CString!(result);
                         trace!("indy_prover_get_credential: credential_json: {:?}", credential_json);
-                        let credential_json = ctypes::string_to_cstring(credential_json);
                         cb(command_handle, err, credential_json.as_ptr())
                     })
                 ))));
@@ -1283,9 +1276,8 @@ pub extern fn indy_prover_get_credentials(command_handle: CommandHandle,
                     wallet_handle,
                     filter_json,
                     Box::new(move |result| {
-                        let (err, matched_credentials_json) = prepare_result_1!(result, String::new());
+                        let (err, matched_credentials_json) = prepare_result_CString!(result);
                         trace!("indy_prover_get_credentials: matched_credentials_json: {:?}", matched_credentials_json);
-                        let matched_credentials_json = ctypes::string_to_cstring(matched_credentials_json);
                         cb(command_handle, err, matched_credentials_json.as_ptr())
                     })
                 ))));
@@ -1394,9 +1386,8 @@ pub  extern fn indy_prover_fetch_credentials(command_handle: CommandHandle,
                     search_handle,
                     count,
                     Box::new(move |result| {
-                        let (err, credentials_json) = prepare_result_1!(result, String::new());
+                        let (err, credentials_json) = prepare_result_CString!(result);
                         trace!("indy_prover_fetch_credentials: credentials_json: {:?}", credentials_json);
-                        let credentials_json = ctypes::string_to_cstring(credentials_json);
                         cb(command_handle, err, credentials_json.as_ptr())
                     })
                 ))));
@@ -1550,9 +1541,8 @@ pub extern fn indy_prover_get_credentials_for_proof_req(command_handle: CommandH
                     wallet_handle,
                     proof_request_json,
                     Box::new(move |result| {
-                        let (err, credentials_json) = prepare_result_1!(result, String::new());
+                        let (err, credentials_json) = prepare_result_CString!(result);
                         trace!("indy_prover_get_credentials_for_proof_req: credentials_json: {:?}", credentials_json);
-                        let credentials_json = ctypes::string_to_cstring(credentials_json);
                         cb(command_handle, err, credentials_json.as_ptr())
                     })
                 ))));
@@ -1702,9 +1692,8 @@ pub  extern fn indy_prover_fetch_credentials_for_proof_req(command_handle: Comma
                     item_referent,
                     count,
                     Box::new(move |result| {
-                        let (err, credentials_json) = prepare_result_1!(result, String::new());
+                        let (err, credentials_json) = prepare_result_CString!(result);
                         trace!("indy_prover_fetch_credentials_for_proof_request: credentials_json: {:?}", credentials_json);
-                        let credentials_json = ctypes::string_to_cstring(credentials_json);
                         cb(command_handle, err, credentials_json.as_ptr())
                     }),
                 ))));
@@ -1926,9 +1915,8 @@ pub extern fn indy_prover_create_proof(command_handle: CommandHandle,
             credential_defs_json,
             rev_states_json,
             Box::new(move |result| {
-                let (err, proof_json) = prepare_result_1!(result, String::new());
+                let (err, proof_json) = prepare_result_CString!(result);
                 trace!("indy_prover_create_proof: proof_json: {:?}", proof_json);
-                let proof_json = ctypes::string_to_cstring(proof_json);
                 cb(command_handle, err, proof_json.as_ptr())
             })
         ))));
@@ -2128,9 +2116,8 @@ pub extern fn indy_create_revocation_state(command_handle: CommandHandle,
             timestamp,
             cred_rev_id,
             Box::new(move |result| {
-                let (err, rev_state_json) = prepare_result_1!(result, String::new());
+                let (err, rev_state_json) = prepare_result_CString!(result);
                 trace!("indy_create_revocation_state: rev_state_json: {:?}", rev_state_json);
-                let rev_state_json = ctypes::string_to_cstring(rev_state_json);
                 cb(command_handle, err, rev_state_json.as_ptr())
             })
         ))));
@@ -2200,9 +2187,8 @@ pub extern fn indy_update_revocation_state(command_handle: CommandHandle,
             timestamp,
             cred_rev_id,
             Box::new(move |result| {
-                let (err, updated_rev_info_json) = prepare_result_1!(result, String::new());
+                let (err, updated_rev_info_json) = prepare_result_CString!(result);
                 trace!("indy_update_revocation_state: updated_rev_info_json: {:?}", updated_rev_info_json);
-                let updated_rev_info_json = ctypes::string_to_cstring(updated_rev_info_json);
                 cb(command_handle, err, updated_rev_info_json.as_ptr())
             })
         ))));
@@ -2237,9 +2223,8 @@ pub extern fn indy_generate_nonce(command_handle: CommandHandle,
         .send(Command::Anoncreds(AnoncredsCommand::Verifier(
             VerifierCommand::GenerateNonce(
                 Box::new(move |result| {
-                    let (err, nonce) = prepare_result_1!(result, String::new());
+                    let (err, nonce) = prepare_result_CString!(result);
                     trace!("indy_generate_nonce: nonce: {:?}", nonce);
-                    let nonce = ctypes::string_to_cstring(nonce);
                     cb(command_handle, err, nonce.as_ptr())
                 })
             ))));

--- a/libindy/src/api/cache.rs
+++ b/libindy/src/api/cache.rs
@@ -4,9 +4,8 @@ use commands::cache::CacheCommand;
 use errors::prelude::*;
 use utils::ctypes;
 
-use
-libc::c_char;
-
+use libc::c_char;
+use std::ffi::CString;
 
 /// Gets credential definition json data for specified credential definition id.
 /// If data is present inside of cache, cached data is returned.
@@ -54,9 +53,8 @@ pub extern fn indy_get_cred_def(command_handle: CommandHandle,
             id,
             options_json,
             Box::new(move |result| {
-                let (err, cred_def_json) = prepare_result_1!(result, String::new());
+                let (err, cred_def_json) = prepare_result_CString!(result);
                 trace!("indy_get_cred_def: cred_def_json: {:?}", cred_def_json);
-                let cred_def_json = ctypes::string_to_cstring(cred_def_json);
                 cb(command_handle, err, cred_def_json.as_ptr())
             })
         )));
@@ -117,9 +115,8 @@ pub extern fn indy_get_schema(command_handle: CommandHandle,
             id,
             options_json,
             Box::new(move |result| {
-                let (err, schema_json) = prepare_result_1!(result, String::new());
+                let (err, schema_json) = prepare_result_CString!(result);
                 trace!("indy_get_schema: schema_json: {:?}", schema_json);
-                let schema_json = ctypes::string_to_cstring(schema_json);
                 cb(command_handle, err, schema_json.as_ptr())
             })
         )));

--- a/libindy/src/api/crypto.rs
+++ b/libindy/src/api/crypto.rs
@@ -8,7 +8,7 @@ use utils::ctypes;
 
 use serde_json;
 use libc::c_char;
-
+use std::ffi::CString;
 
 /// Creates keys pair and stores in the wallet.
 ///
@@ -53,9 +53,8 @@ pub extern fn indy_create_key(command_handle: CommandHandle,
             wallet_handle,
             key_json,
             Box::new(move |result| {
-                let (err, verkey) = prepare_result_1!(result, String::new());
+                let (err, verkey) = prepare_result_CString!(result);
                 trace!("indy_create_key: verkey: {:?}", verkey);
-                let verkey = ctypes::string_to_cstring(verkey);
                 cb(command_handle, err, verkey.as_ptr())
             })
         )));
@@ -158,9 +157,8 @@ pub  extern fn indy_get_key_metadata(command_handle: CommandHandle,
             wallet_handle,
             verkey,
             Box::new(move |result| {
-                let (err, metadata) = prepare_result_1!(result, String::new());
+                let (err, metadata) = prepare_result_CString!(result);
                 trace!("indy_get_key_metadata: metadata: {:?}", metadata);
-                let metadata = ctypes::string_to_cstring(metadata);
                 cb(command_handle, err, metadata.as_ptr())
             })
         )));

--- a/libindy/src/api/did.rs
+++ b/libindy/src/api/did.rs
@@ -72,10 +72,8 @@ pub  extern fn indy_create_and_store_my_did(command_handle: CommandHandle,
             wallet_handle,
             did_info,
             Box::new(move |result| {
-                let (err, did, verkey) = prepare_result_2!(result, String::new(), String::new());
+                let (err, did, verkey) = prepare_result_CString2!(result);
                 trace!("indy_create_and_store_my_did: did: {:?}, verkey: {:?}", did, verkey);
-                let did = ctypes::string_to_cstring(did);
-                let verkey = ctypes::string_to_cstring(verkey);
                 cb(command_handle, err, did.as_ptr(), verkey.as_ptr())
             }),
         )));

--- a/libindy/src/api/did.rs
+++ b/libindy/src/api/did.rs
@@ -11,6 +11,8 @@ use serde_json;
 use libc::c_char;
 
 use std::ptr;
+use std::ffi::CString;
+
 use domain::ledger::attrib::Endpoint;
 
 
@@ -135,9 +137,8 @@ pub  extern fn indy_replace_keys_start(command_handle: CommandHandle,
             key_info,
             did,
             Box::new(move |result| {
-                let (err, verkey) = prepare_result_1!(result, String::new());
+                let (err, verkey) = prepare_result_CString!(result);
                 trace!("indy_replace_keys_start: verkey: {:?}", verkey);
-                let verkey = ctypes::string_to_cstring(verkey);
                 cb(command_handle, err, verkey.as_ptr())
             })
         )));
@@ -304,9 +305,8 @@ pub extern fn indy_key_for_did(command_handle: CommandHandle,
             wallet_handle,
             did,
             Box::new(move |result| {
-                let (err, key) = prepare_result_1!(result, String::new());
+                let (err, key) = prepare_result_CString!(result);
                 trace!("indy_key_for_did: key: {:?}", key);
-                let key = ctypes::string_to_cstring(key);
                 cb(command_handle, err, key.as_ptr())
             })
         )));
@@ -365,9 +365,8 @@ pub extern fn indy_key_for_local_did(command_handle: CommandHandle,
             wallet_handle,
             did,
             Box::new(move |result| {
-                let (err, key) = prepare_result_1!(result, String::new());
+                let (err, key) = prepare_result_CString!(result);
                 trace!("indy_key_for_local_did: key: {:?}", key);
-                let key = ctypes::string_to_cstring(key);
                 cb(command_handle, err, key.as_ptr())
             })
         )));
@@ -587,9 +586,8 @@ pub extern fn indy_get_did_metadata(command_handle: CommandHandle,
             wallet_handle,
             did,
             Box::new(move |result| {
-                let (err, metadata) = prepare_result_1!(result, String::new());
+                let (err, metadata) = prepare_result_CString!(result);
                 trace!("indy_get_did_metadata: metadata: {:?}", metadata);
-                let metadata = ctypes::string_to_cstring(metadata);
                 cb(command_handle, err, metadata.as_ptr())
             })
         )));
@@ -645,9 +643,8 @@ pub extern fn indy_get_my_did_with_meta(command_handle: CommandHandle,
             wallet_handle,
             my_did,
             Box::new(move |result| {
-                let (err, did_with_meta) = prepare_result_1!(result, String::new());
+                let (err, did_with_meta) = prepare_result_CString!(result);
                 trace!("indy_get_my_did_with_meta: did_with_meta: {:?}", did_with_meta);
-                let did_with_meta = ctypes::string_to_cstring(did_with_meta);
                 cb(command_handle, err, did_with_meta.as_ptr())
             })
         )));
@@ -697,9 +694,8 @@ pub extern fn indy_list_my_dids_with_meta(command_handle: CommandHandle,
         .send(Command::Did(DidCommand::ListMyDidsWithMeta(
             wallet_handle,
             Box::new(move |result| {
-                let (err, dids) = prepare_result_1!(result, String::new());
+                let (err, dids) = prepare_result_CString!(result);
                 trace!("indy_list_my_dids_with_meta: dids: {:?}", dids);
-                let dids = ctypes::string_to_cstring(dids);
                 cb(command_handle, err, dids.as_ptr())
             })
         )));
@@ -749,9 +745,8 @@ pub  extern fn indy_abbreviate_verkey(command_handle: CommandHandle,
             did,
             full_verkey,
             Box::new(move |result| {
-                let (err, verkey) = prepare_result_1!(result, String::new());
+                let (err, verkey) = prepare_result_CString!(result);
                 trace!("indy_abbreviate_verkey: verkey: {:?}", verkey);
-                let verkey = ctypes::string_to_cstring(verkey);
                 cb(command_handle, err, verkey.as_ptr())
             })
         )));

--- a/libindy/src/api/ledger.rs
+++ b/libindy/src/api/ledger.rs
@@ -717,10 +717,8 @@ pub extern fn indy_parse_get_schema_response(command_handle: CommandHandle,
         .send(Command::Ledger(LedgerCommand::ParseGetSchemaResponse(
             get_schema_response,
             Box::new(move |result| {
-                let (err, schema_id, schema_json) = prepare_result_2!(result, String::new(), String::new());
+                let (err, schema_id, schema_json) = prepare_result_CString2!(result);
                 trace!("indy_parse_get_schema_response: schema_id: {:?}, schema_json: {:?}", schema_id, schema_json);
-                let schema_id = ctypes::string_to_cstring(schema_id);
-                let schema_json = ctypes::string_to_cstring(schema_json);
                 cb(command_handle, err, schema_id.as_ptr(), schema_json.as_ptr())
             })
         )));
@@ -879,10 +877,8 @@ pub extern fn indy_parse_get_cred_def_response(command_handle: CommandHandle,
         .send(Command::Ledger(LedgerCommand::ParseGetCredDefResponse(
             get_cred_def_response,
             Box::new(move |result| {
-                let (err, cred_def_id, cred_def_json) = prepare_result_2!(result, String::new(), String::new());
+                let (err, cred_def_id, cred_def_json) = prepare_result_CString2!(result);
                 trace!("indy_parse_get_cred_def_response: cred_def_id: {:?}, cred_def_json: {:?}", cred_def_id, cred_def_json);
-                let cred_def_id = ctypes::string_to_cstring(cred_def_id);
-                let cred_def_json = ctypes::string_to_cstring(cred_def_json);
                 cb(command_handle, err, cred_def_id.as_ptr(), cred_def_json.as_ptr())
             })
         )));
@@ -1385,11 +1381,8 @@ pub extern fn indy_parse_get_revoc_reg_def_response(command_handle: CommandHandl
         .send(Command::Ledger(LedgerCommand::ParseGetRevocRegDefResponse(
             get_revoc_reg_def_response,
             Box::new(move |result| {
-                let (err, revoc_reg_def_id, revoc_reg_def_json) = prepare_result_2!(result, String::new(), String::new());
+                let (err, revoc_reg_def_id, revoc_reg_def_json) = prepare_result_CString2!(result);
                 trace!("indy_parse_get_revoc_reg_def_response: revoc_reg_def_id: {:?}, revoc_reg_def_json: {:?}", revoc_reg_def_id, revoc_reg_def_json);
-
-                let revoc_reg_def_id = ctypes::string_to_cstring(revoc_reg_def_id);
-                let revoc_reg_def_json = ctypes::string_to_cstring(revoc_reg_def_json);
                 cb(command_handle, err, revoc_reg_def_id.as_ptr(), revoc_reg_def_json.as_ptr())
             })
         )));

--- a/libindy/src/api/ledger.rs
+++ b/libindy/src/api/ledger.rs
@@ -13,6 +13,7 @@ use utils::ctypes;
 
 use serde_json;
 use libc::c_char;
+use std::ffi::CString;
 
 /// Signs and submits request message to validator pool.
 ///
@@ -62,9 +63,8 @@ pub extern fn indy_sign_and_submit_request(command_handle: CommandHandle,
             submitter_did,
             request_json,
             Box::new(move |result| {
-                let (err, request_result_json) = prepare_result_1!(result, String::new());
+                let (err, request_result_json) = prepare_result_CString!(result);
                 trace!("indy_sign_and_submit_request: request_result_json: {:?}", request_result_json);
-                let request_result_json = ctypes::string_to_cstring(request_result_json);
                 cb(command_handle, err, request_result_json.as_ptr())
             })
         )));
@@ -111,9 +111,8 @@ pub extern fn indy_submit_request(command_handle: CommandHandle,
             pool_handle,
             request_json,
             Box::new(move |result| {
-                let (err, request_result_json) = prepare_result_1!(result, String::new());
+                let (err, request_result_json) = prepare_result_CString!(result);
                 trace!("indy_submit_request: request_result_json: {:?}", request_result_json);
-                let request_result_json = ctypes::string_to_cstring(request_result_json);
                 cb(command_handle, err, request_result_json.as_ptr())
             })
         )));
@@ -176,9 +175,8 @@ pub extern fn indy_submit_action(command_handle: CommandHandle,
                 nodes,
                 timeout,
                 Box::new(move |result| {
-                    let (err, request_result_json) = prepare_result_1!(result, String::new());
+                    let (err, request_result_json) = prepare_result_CString!(result);
                     trace!("indy_submit_action: request_result_json: {:?}", request_result_json);
-                    let request_result_json = ctypes::string_to_cstring(request_result_json);
                     cb(command_handle, err, request_result_json.as_ptr())
                 })
             )));
@@ -232,9 +230,8 @@ pub extern fn indy_sign_request(command_handle: CommandHandle,
             submitter_did,
             request_json,
             Box::new(move |result| {
-                let (err, signed_request_json) = prepare_result_1!(result, String::new());
+                let (err, signed_request_json) = prepare_result_CString!(result);
                 trace!("indy_sign_request: signed_request_json: {:?}", signed_request_json);
-                let signed_request_json = ctypes::string_to_cstring(signed_request_json);
                 cb(command_handle, err, signed_request_json.as_ptr())
             })
         )));
@@ -287,9 +284,8 @@ pub extern fn indy_multi_sign_request(command_handle: CommandHandle,
             submitter_did,
             request_json,
             Box::new(move |result| {
-                let (err, signed_request_json) = prepare_result_1!(result, String::new());
+                let (err, signed_request_json) = prepare_result_CString!(result);
                 trace!("indy_multi_sign_request: signed_request_json: {:?}", signed_request_json);
-                let signed_request_json = ctypes::string_to_cstring(signed_request_json);
                 cb(command_handle, err, signed_request_json.as_ptr())
             })
         )));
@@ -335,9 +331,8 @@ pub extern fn indy_build_get_ddo_request(command_handle: CommandHandle,
             submitter_did,
             target_did,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_ddo_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -405,9 +400,8 @@ pub extern fn indy_build_nym_request(command_handle: CommandHandle,
             alias,
             role,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_nym_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -452,9 +446,8 @@ pub extern fn indy_build_get_nym_request(command_handle: CommandHandle,
             submitter_did,
             target_did,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_nym_request: >>> request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -514,9 +507,8 @@ pub extern fn indy_build_attrib_request(command_handle: CommandHandle,
             raw,
             enc,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_attrib_request: >>> request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -575,9 +567,8 @@ pub extern fn indy_build_get_attrib_request(command_handle: CommandHandle,
             hash,
             enc,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_attrib_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -630,9 +621,8 @@ pub extern fn indy_build_schema_request(command_handle: CommandHandle,
             submitter_did,
             data,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_schema_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -677,9 +667,8 @@ pub extern fn indy_build_get_schema_request(command_handle: CommandHandle,
             submitter_did,
             id,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_schema_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -789,9 +778,8 @@ pub extern fn indy_build_cred_def_request(command_handle: CommandHandle,
             submitter_did,
             data,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_cred_def_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -837,9 +825,8 @@ pub extern fn indy_build_get_cred_def_request(command_handle: CommandHandle,
             submitter_did,
             id,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_cred_def_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -954,9 +941,8 @@ pub extern fn indy_build_node_request(command_handle: CommandHandle,
             target_did,
             data,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_node_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -992,8 +978,7 @@ pub extern fn indy_build_get_validator_info_request(command_handle: CommandHandl
         .send(Command::Ledger(LedgerCommand::BuildGetValidatorInfoRequest(
             submitter_did,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
-                let request_json = ctypes::string_to_cstring(request_json);
+                let (err, request_json) = prepare_result_CString!(result);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -1041,9 +1026,8 @@ pub extern fn indy_build_get_txn_request(command_handle: CommandHandle,
             ledger_type,
             seq_no,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_txn_request: request_json: {:?}, cmd_handle: {:?}", request_json, command_handle);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -1093,9 +1077,8 @@ pub extern fn indy_build_pool_config_request(command_handle: CommandHandle,
             writes,
             force,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_pool_config_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -1145,9 +1128,8 @@ pub extern fn indy_build_pool_restart_request(command_handle: CommandHandle,
                 action,
                 datetime,
                 Box::new(move |result| {
-                    let (err, request_json) = prepare_result_1!(result, String::new());
+                    let (err, request_json) = prepare_result_CString!(result);
                     trace!("indy_build_pool_restart_request: request_json: {:?}", request_json);
-                    let request_json = ctypes::string_to_cstring(request_json);
                     cb(command_handle, err, request_json.as_ptr())
                 }))));
 
@@ -1236,9 +1218,8 @@ pub extern fn indy_build_pool_upgrade_request(command_handle: CommandHandle,
                 force,
                 package,
                 Box::new(move |result| {
-                    let (err, request_json) = prepare_result_1!(result, String::new());
+                    let (err, request_json) = prepare_result_CString!(result);
                     trace!("indy_build_pool_upgrade_request: request_json: {:?}", request_json);
-                    let request_json = ctypes::string_to_cstring(request_json);
                     cb(command_handle, err, request_json.as_ptr())
                 })
             )));
@@ -1299,9 +1280,8 @@ pub extern fn indy_build_revoc_reg_def_request(command_handle: CommandHandle,
             submitter_did,
             data,
             Box::new(move |result| {
-                let (err, rev_reg_def_req) = prepare_result_1!(result, String::new());
+                let (err, rev_reg_def_req) = prepare_result_CString!(result);
                 trace!("indy_build_revoc_reg_def_request: rev_reg_def_req: {:?}", rev_reg_def_req);
-                let rev_reg_def_req = ctypes::string_to_cstring(rev_reg_def_req);
                 cb(command_handle, err, rev_reg_def_req.as_ptr())
             })
         )));
@@ -1347,9 +1327,8 @@ pub extern fn indy_build_get_revoc_reg_def_request(command_handle: CommandHandle
             submitter_did,
             id,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_revoc_reg_def_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -1478,9 +1457,8 @@ pub extern fn indy_build_revoc_reg_entry_request(command_handle: CommandHandle,
             rev_def_type,
             value,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_revoc_reg_entry_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -1529,9 +1507,8 @@ pub extern fn indy_build_get_revoc_reg_request(command_handle: CommandHandle,
             revoc_reg_def_id,
             timestamp,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_revoc_reg_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -1642,9 +1619,8 @@ pub extern fn indy_build_get_revoc_reg_delta_request(command_handle: CommandHand
             from,
             to,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_revoc_reg_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -1830,10 +1806,8 @@ pub extern fn indy_get_response_metadata(command_handle: CommandHandle,
         .send(Command::Ledger(LedgerCommand::GetResponseMetadata(
             response,
             Box::new(move |result| {
-                let (err, response_metadata) = prepare_result_1!(result, String::new());
+                let (err, response_metadata) = prepare_result_CString!(result);
                 trace!("indy_get_response_metadata: response_metadata: {:?}", response_metadata);
-
-                let response_metadata = ctypes::string_to_cstring(response_metadata);
                 cb(command_handle, err, response_metadata.as_ptr())
             })
         )));
@@ -1923,9 +1897,8 @@ pub extern fn indy_build_auth_rule_request(command_handle: CommandHandle,
             new_value,
             constraint,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_auth_rule_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -1990,9 +1963,8 @@ pub extern fn indy_build_auth_rules_request(command_handle: CommandHandle,
             submitter_did,
             rules,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_auth_rules_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -2062,9 +2034,8 @@ pub extern fn indy_build_get_auth_rule_request(command_handle: CommandHandle,
             old_value,
             new_value,
             Box::new(move |result| {
-                let (err, request_json) = prepare_result_1!(result, String::new());
+                let (err, request_json) = prepare_result_CString!(result);
                 trace!("indy_build_get_auth_rule_request: request_json: {:?}", request_json);
-                let request_json = ctypes::string_to_cstring(request_json);
                 cb(command_handle, err, request_json.as_ptr())
             })
         )));
@@ -2117,9 +2088,8 @@ pub extern fn indy_build_txn_author_agreement_request(command_handle: CommandHan
                 text,
                 version,
                 Box::new(move |result| {
-                    let (err, request_json) = prepare_result_1!(result, String::new());
+                    let (err, request_json) = prepare_result_CString!(result);
                     trace!("indy_build_txn_author_agreement_request: request_json: {:?}", request_json);
-                    let request_json = ctypes::string_to_cstring(request_json);
                     cb(command_handle, err, request_json.as_ptr())
                 })
             )));
@@ -2175,9 +2145,8 @@ pub extern fn indy_build_get_txn_author_agreement_request(command_handle: Comman
                 submitter_did,
                 data,
                 Box::new(move |result| {
-                    let (err, request_json) = prepare_result_1!(result, String::new());
+                    let (err, request_json) = prepare_result_CString!(result);
                     trace!("indy_build_get_txn_author_agreement_request: request_json: {:?}", request_json);
-                    let request_json = ctypes::string_to_cstring(request_json);
                     cb(command_handle, err, request_json.as_ptr())
                 })
             )));
@@ -2247,9 +2216,8 @@ pub extern fn indy_build_acceptance_mechanisms_request(command_handle: CommandHa
                 version,
                 aml_context,
                 Box::new(move |result| {
-                    let (err, request_json) = prepare_result_1!(result, String::new());
+                    let (err, request_json) = prepare_result_CString!(result);
                     trace!("indy_build_acceptance_mechanisms_request: request_json: {:?}", request_json);
-                    let request_json = ctypes::string_to_cstring(request_json);
                     cb(command_handle, err, request_json.as_ptr())
                 })
             )));
@@ -2305,9 +2273,8 @@ pub extern fn indy_build_get_acceptance_mechanisms_request(command_handle: Comma
                 timestamp,
                 version,
                 Box::new(move |result| {
-                    let (err, request_json) = prepare_result_1!(result, String::new());
+                    let (err, request_json) = prepare_result_CString!(result);
                     trace!("indy_build_get_acceptance_mechanisms_request: request_json: {:?}", request_json);
-                    let request_json = ctypes::string_to_cstring(request_json);
                     cb(command_handle, err, request_json.as_ptr())
                 })
             )));
@@ -2380,9 +2347,8 @@ pub extern fn indy_append_txn_author_agreement_acceptance_to_request(command_han
                 mechanism,
                 time,
                 Box::new(move |result| {
-                    let (err, request_json) = prepare_result_1!(result, String::new());
+                    let (err, request_json) = prepare_result_CString!(result);
                     trace!("indy_append_txn_author_agreement_acceptance_to_request: request_json: {:?}", request_json);
-                    let request_json = ctypes::string_to_cstring(request_json);
                     cb(command_handle, err, request_json.as_ptr())
                 })
             )));
@@ -2435,9 +2401,8 @@ pub extern fn indy_append_request_endorser(command_handle: CommandHandle,
                 request_json,
                 endorser_did,
                 Box::new(move |result| {
-                    let (err, request_json) = prepare_result_1!(result, String::new());
+                    let (err, request_json) = prepare_result_CString!(result);
                     trace!("indy_append_request_endorser: request_json: {:?}", request_json);
-                    let request_json = ctypes::string_to_cstring(request_json);
                     cb(command_handle, err, request_json.as_ptr())
                 })
             )));

--- a/libindy/src/api/non_secrets.rs
+++ b/libindy/src/api/non_secrets.rs
@@ -8,6 +8,7 @@ use utils::ctypes;
 
 use serde_json;
 use libc::c_char;
+use std::ffi::CString;
 
 /// Create a new non-secret record in the wallet
 ///
@@ -356,9 +357,8 @@ pub  extern fn indy_get_wallet_record(command_handle: CommandHandle,
                 id,
                 options_json,
                 Box::new(move |result| {
-                    let (err, record_json) = prepare_result_1!(result, String::new());
+                    let (err, record_json) = prepare_result_CString!(result);
                     trace!("indy_get_wallet_record: record_json: {:?}", record_json);
-                    let record_json = ctypes::string_to_cstring(record_json);
                     cb(command_handle, err, record_json.as_ptr())
                 })
             )));
@@ -476,9 +476,8 @@ pub  extern fn indy_fetch_wallet_search_next_records(command_handle: CommandHand
                 wallet_search_handle,
                 count,
                 Box::new(move |result| {
-                    let (err, records_json) = prepare_result_1!(result, String::new());
+                    let (err, records_json) = prepare_result_CString!(result);
                     trace!("indy_fetch_wallet_search_next_records: records_json: {:?}", records_json);
-                    let records_json = ctypes::string_to_cstring(records_json);
                     cb(command_handle, err, records_json.as_ptr())
                 })
             )));

--- a/libindy/src/api/pairwise.rs
+++ b/libindy/src/api/pairwise.rs
@@ -5,7 +5,7 @@ use errors::prelude::*;
 use utils::ctypes;
 
 use libc::c_char;
-
+use std::ffi::CString;
 
 /// Check if pairwise is exists.
 ///
@@ -135,9 +135,8 @@ pub  extern fn indy_list_pairwise(command_handle: CommandHandle,
         .send(Command::Pairwise(PairwiseCommand::ListPairwise(
             wallet_handle,
             Box::new(move |result| {
-                let (err, list_pairwise) = prepare_result_1!(result, String::new());
+                let (err, list_pairwise) = prepare_result_CString!(result);
                 trace!("indy_list_pairwise: list_pairwise: {:?}", list_pairwise);
-                let list_pairwise = ctypes::string_to_cstring(list_pairwise);
                 cb(command_handle, err, list_pairwise.as_ptr())
             })
         )));
@@ -182,9 +181,8 @@ pub  extern fn indy_get_pairwise(command_handle: CommandHandle,
             wallet_handle,
             their_did,
             Box::new(move |result| {
-                let (err, pairwise_info_json) = prepare_result_1!(result, String::new());
+                let (err, pairwise_info_json) = prepare_result_CString!(result);
                 trace!("indy_get_pairwise: pairwise_info_json: {:?}", pairwise_info_json);
-                let pairwise_info_json = ctypes::string_to_cstring(pairwise_info_json);
                 cb(command_handle, err, pairwise_info_json.as_ptr())
             })
         )));

--- a/libindy/src/api/payments.rs
+++ b/libindy/src/api/payments.rs
@@ -1,4 +1,5 @@
 use libc::c_char;
+use std::ffi::CString;
 use api::{ErrorCode, CommandHandle, WalletHandle};
 use commands::{Command, CommandExecutor};
 use commands::payments::PaymentsCommand;
@@ -492,9 +493,8 @@ pub extern fn indy_create_payment_address(command_handle: CommandHandle,
                     payment_method,
                     config,
                     Box::new(move |result| {
-                        let (err, address) = prepare_result_1!(result, String::new());
+                        let (err, address) = prepare_result_CString!(result);
                         trace!("indy_create_payment_address: address: {:?}", address);
-                        let address = ctypes::string_to_cstring(address);
                         cb(command_handle, err, address.as_ptr());
                     }))
             ));
@@ -532,9 +532,8 @@ pub extern fn indy_list_payment_addresses(command_handle: CommandHandle,
                 PaymentsCommand::ListAddresses(
                     wallet_handle,
                     Box::new(move |result| {
-                        let (err, addresses_json) = prepare_result_1!(result, String::new());
+                        let (err, addresses_json) = prepare_result_CString!(result);
                         trace!("indy_list_payment_address: addresses_json: {:?}", addresses_json);
-                        let addresses_json = ctypes::string_to_cstring(addresses_json);
                         cb(command_handle, err, addresses_json.as_ptr());
                     }))
             ));
@@ -660,9 +659,8 @@ pub extern fn indy_parse_response_with_fees(command_handle: CommandHandle,
             Command::Payments(
                 PaymentsCommand::ParseResponseWithFees(
                     payment_method, resp_json, Box::new(move |result| {
-                        let (err, receipts_json) = prepare_result_1!(result, String::new());
+                        let (err, receipts_json) = prepare_result_CString!(result);
                         trace!("indy_parse_response_with_fees: receipts_json: {:?}", receipts_json);
-                        let receipts_json = ctypes::string_to_cstring(receipts_json);
                         cb(command_handle, err, receipts_json.as_ptr());
                     }))
             ));

--- a/libindy/src/api/payments.rs
+++ b/libindy/src/api/payments.rs
@@ -610,10 +610,8 @@ pub extern fn indy_add_request_fees(command_handle: CommandHandle,
                     outputs_json,
                     extra,
                     Box::new(move |result| {
-                        let (err, req_with_fees_json, payment_method) = prepare_result_2!(result, String::new(), String::new());
+                        let (err, req_with_fees_json, payment_method) = prepare_result_CString2!(result);
                         trace!("indy_add_request_fees: req_with_fees_json: {:?}, payment_method: {:?}", req_with_fees_json, payment_method);
-                        let req_with_fees_json = ctypes::string_to_cstring(req_with_fees_json);
-                        let payment_method = ctypes::string_to_cstring(payment_method);
                         cb(command_handle, err, req_with_fees_json.as_ptr(), payment_method.as_ptr());
                     }))
             ));
@@ -709,10 +707,8 @@ pub extern fn indy_build_get_payment_sources_request(command_handle: CommandHand
                     payment_address,
                     None,
                     Box::new(move |result| {
-                        let (err, get_sources_txn_json, payment_method) = prepare_result_2!(result, String::new(), String::new());
+                        let (err, get_sources_txn_json, payment_method) = prepare_result_CString2!(result);
                         trace!("indy_build_get_payment_sources_request: get_sources_txn_json: {:?}, payment_method: {:?}", get_sources_txn_json, payment_method);
-                        let get_sources_txn_json = ctypes::string_to_cstring(get_sources_txn_json);
-                        let payment_method = ctypes::string_to_cstring(payment_method);
                         cb(command_handle, err, get_sources_txn_json.as_ptr(), payment_method.as_ptr());
                     }))
             ));
@@ -832,10 +828,8 @@ pub extern fn indy_build_payment_req(command_handle: CommandHandle,
                     outputs_json,
                     extra,
                     Box::new(move |result| {
-                        let (err, payment_req_json, payment_method) = prepare_result_2!(result, String::new(), String::new());
+                        let (err, payment_req_json, payment_method) = prepare_result_CString2!(result);
                         trace!("indy_build_payment_req: payment_req_json: {:?}, payment_method: {:?}", payment_req_json, payment_method);
-                        let payment_req_json = ctypes::string_to_cstring(payment_req_json);
-                        let payment_method = ctypes::string_to_cstring(payment_method);
                         cb(command_handle, err, payment_req_json.as_ptr(), payment_method.as_ptr());
                     }))
             ));
@@ -883,9 +877,8 @@ pub extern fn indy_parse_payment_response(command_handle: CommandHandle,
                     payment_method,
                     resp_json,
                     Box::new(move |result| {
-                        let (err, receipts_json) = prepare_result_1!(result, String::new());
+                        let (err, receipts_json) = prepare_result_CString!(result);
                         trace!("indy_parse_payment_response: receipts_json: {:?}", receipts_json);
-                        let receipts_json = ctypes::string_to_cstring(receipts_json);
                         cb(command_handle, err, receipts_json.as_ptr());
                     }))
             ));
@@ -956,9 +949,8 @@ pub extern fn indy_prepare_payment_extra_with_acceptance_data(command_handle: Co
                 mechanism,
                 time,
                 Box::new(move |result| {
-                    let (err, extra_with_acceptance) = prepare_result_1!(result, String::new());
+                    let (err, extra_with_acceptance) = prepare_result_CString!(result);
                     trace!("indy_prepare_payment_extra_with_acceptance_data: extra_with_acceptance: {:?}", extra_with_acceptance);
-                    let extra_with_acceptance = ctypes::string_to_cstring(extra_with_acceptance);
                     cb(command_handle, err, extra_with_acceptance.as_ptr())
                 })
             )));
@@ -1014,10 +1006,8 @@ pub extern fn indy_build_mint_req(command_handle: CommandHandle,
                     outputs_json,
                     extra,
                     Box::new(move |result| {
-                        let (err, mint_req_json, payment_method) = prepare_result_2!(result, String::new(), String::new());
+                        let (err, mint_req_json, payment_method) = prepare_result_CString2!(result);
                         trace!("indy_build_mint_req: mint_req_json: {:?}, payment_method: {:?}", mint_req_json, payment_method);
-                        let mint_req_json = ctypes::string_to_cstring(mint_req_json);
-                        let payment_method = ctypes::string_to_cstring(payment_method);
                         cb(command_handle, err, mint_req_json.as_ptr(), payment_method.as_ptr());
                     }))
             ));
@@ -1070,9 +1060,8 @@ pub extern fn indy_build_set_txn_fees_req(command_handle: CommandHandle,
                     payment_method,
                     fees_json,
                     Box::new(move |result| {
-                        let (err, set_txn_fees_json) = prepare_result_1!(result, String::new());
+                        let (err, set_txn_fees_json) = prepare_result_CString!(result);
                         trace!("indy_build_set_txn_fees_req: set_txn_fees_json: {:?}", set_txn_fees_json);
-                        let set_txn_fees_json = ctypes::string_to_cstring(set_txn_fees_json);
                         cb(command_handle, err, set_txn_fees_json.as_ptr());
                     }))
             ));
@@ -1117,9 +1106,8 @@ pub extern fn indy_build_get_txn_fees_req(command_handle: CommandHandle,
                     submitter_did,
                     payment_method,
                     Box::new(move |result| {
-                        let (err, get_txn_fees_json) = prepare_result_1!(result, String::new());
+                        let (err, get_txn_fees_json) = prepare_result_CString!(result);
                         trace!("indy_build_get_txn_fees_req: entities >>> get_txn_fees_json: {:?}", get_txn_fees_json);
-                        let get_txn_fees_json = ctypes::string_to_cstring(get_txn_fees_json);
                         cb(command_handle, err, get_txn_fees_json.as_ptr());
                     }))
             ));
@@ -1166,9 +1154,8 @@ pub extern fn indy_parse_get_txn_fees_response(command_handle: CommandHandle,
                     payment_method,
                     resp_json,
                     Box::new(move |result| {
-                        let (err, fees_json) = prepare_result_1!(result, String::new());
+                        let (err, fees_json) = prepare_result_CString!(result);
                         trace!("indy_parse_get_txn_fees_response: fees_json: {:?}", fees_json);
-                        let fees_json = ctypes::string_to_cstring(fees_json);
                         cb(command_handle, err, fees_json.as_ptr());
                     }))
             ));
@@ -1214,10 +1201,8 @@ pub extern fn indy_build_verify_payment_req(command_handle: CommandHandle,
                 submitter_did,
                 receipt,
                 Box::new(move |result| {
-                    let (err, verify_txn_json, payment_method) = prepare_result_2!(result, String::new(), String::new());
+                    let (err, verify_txn_json, payment_method) = prepare_result_CString2!(result);
                     trace!("indy_build_verify_payment_req: verify_txn_json: {:?}, payment_method: {:?}", verify_txn_json, payment_method);
-                    let verify_txn_json = ctypes::string_to_cstring(verify_txn_json);
-                    let payment_method = ctypes::string_to_cstring(payment_method);
                     cb(command_handle, err, verify_txn_json.as_ptr(), payment_method.as_ptr());
                 })
             )));
@@ -1266,9 +1251,8 @@ pub extern fn indy_parse_verify_payment_response(command_handle: CommandHandle,
                 payment_method,
                 resp_json,
                 Box::new(move |result| {
-                    let (err, txn_json) = prepare_result_1!(result, String::new());
+                    let (err, txn_json) = prepare_result_CString!(result);
                     trace!("indy_parse_verify_payment_response: txn_json: {:?}", txn_json);
-                    let txn_json = ctypes::string_to_cstring(txn_json);
                     cb(command_handle, err, txn_json.as_ptr());
                 })
             )));
@@ -1336,9 +1320,8 @@ pub extern fn indy_get_request_info(command_handle: CommandHandle,
                 requester_info_json,
                 fees_json,
                 Box::new(move |result| {
-                    let (err, request_info_json) = prepare_result_1!(result, String::new());
+                    let (err, request_info_json) = prepare_result_CString!(result);
                     trace!("indy_get_request_info: request_info_json: {:?}", request_info_json);
-                    let request_info_json = ctypes::string_to_cstring(request_info_json);
                     cb(command_handle, err, request_info_json.as_ptr());
                 })
             )));

--- a/libindy/src/api/payments_v2.rs
+++ b/libindy/src/api/payments_v2.rs
@@ -7,6 +7,7 @@ use commands::Command;
 use commands::payments::PaymentsCommand;
 use utils::ctypes;
 use errors::prelude::*;
+use std::ffi::CString;
 
 /// Builds Indy request for getting sources list for payment address
 /// according to this payment method.
@@ -49,10 +50,8 @@ pub extern fn indy_build_get_payment_sources_with_from_request(command_handle: C
                     payment_address,
                     from,
                     Box::new(move |result| {
-                        let (err, get_sources_txn_json, payment_method) = prepare_result_2!(result, String::new(), String::new());
+                        let (err, get_sources_txn_json, payment_method) = prepare_result_CString2!(result);
                         trace!("indy_build_get_payment_sources_with_from_request: get_sources_txn_json: {:?}, payment_method: {:?}", get_sources_txn_json, payment_method);
-                        let get_sources_txn_json = ctypes::string_to_cstring(get_sources_txn_json);
-                        let payment_method = ctypes::string_to_cstring(payment_method);
                         cb(command_handle, err, get_sources_txn_json.as_ptr(), payment_method.as_ptr());
                     }))
             ));

--- a/libindy/src/api/pool.rs
+++ b/libindy/src/api/pool.rs
@@ -8,6 +8,7 @@ use utils::ctypes;
 
 use serde_json;
 use libc::c_char;
+use std::ffi::CString;
 
 /// Creates a new local pool ledger configuration that can be used later to connect pool nodes.
 ///
@@ -174,9 +175,8 @@ pub extern fn indy_list_pools(command_handle: CommandHandle,
     let result = CommandExecutor::instance()
         .send(Command::Pool(PoolCommand::List(
             Box::new(move |result| {
-                let (err, pools) = prepare_result_1!(result, String::new());
+                let (err, pools) = prepare_result_CString!(result);
                 trace!("indy_list_pools: pools: {:?}", pools);
-                let pools = ctypes::string_to_cstring(pools);
                 cb(command_handle, err, pools.as_ptr())
             })
         )));

--- a/libindy/src/api/wallet.rs
+++ b/libindy/src/api/wallet.rs
@@ -8,7 +8,7 @@ use utils::ctypes;
 
 use serde_json;
 use libc::c_char;
-
+use std::ffi::CString;
 
 /// Register custom wallet storage implementation.
 ///
@@ -572,9 +572,8 @@ pub extern fn indy_generate_wallet_key(command_handle: CommandHandle,
         .send(Command::Wallet(WalletCommand::GenerateKey(
             config,
             Box::new(move |result| {
-                let (err, key) = prepare_result_1!(result, String::new());
+                let (err, key) = prepare_result_CString!(result);
                 trace!("indy_generate_wallet_key: key: {:?}", key);
-                let key = ctypes::string_to_cstring(key);
                 cb(command_handle, err, key.as_ptr())
             })
         )));

--- a/libindy/src/utils/result.rs
+++ b/libindy/src/utils/result.rs
@@ -20,6 +20,18 @@ macro_rules! prepare_result_1 {
     }}
 }
 
+macro_rules! prepare_result_CString {
+    ($result:ident) => {{
+        trace!("prepare_result_1: >>> {:?}", $result);
+        match $result {
+            Ok(res) => (ErrorCode::Success, ctypes::string_to_cstring(res)),
+            Err(err) => {
+                (err.into(), CString::default())
+            }
+        }
+    }}
+}
+
 macro_rules! prepare_result_2 {
     ($result:ident, $default_value1:expr, $default_value2:expr) => {{
         trace!("prepare_result_2: >>> {:?}", $result);

--- a/libindy/src/utils/result.rs
+++ b/libindy/src/utils/result.rs
@@ -22,7 +22,7 @@ macro_rules! prepare_result_1 {
 
 macro_rules! prepare_result_CString {
     ($result:ident) => {{
-        trace!("prepare_result_1: >>> {:?}", $result);
+        trace!("prepare_result_CString: >>> {:?}", $result);
         match $result {
             Ok(res) => (ErrorCode::Success, ctypes::string_to_cstring(res)),
             Err(err) => {
@@ -39,6 +39,18 @@ macro_rules! prepare_result_2 {
             Ok((res1, res2)) => (ErrorCode::Success, res1, res2),
             Err(err) => {
                 (err.into(), $default_value1, $default_value2)
+            }
+        }
+    }}
+}
+
+macro_rules! prepare_result_CString2 {
+    ($result:ident) => {{
+        trace!("prepare_result_CString2: >>> {:?}", $result);
+        match $result {
+            Ok((res1, res2)) => (ErrorCode::Success, ctypes::string_to_cstring(res1), ctypes::string_to_cstring(res2)),
+            Err(err) => {
+                (err.into(), CString::default(), CString::default())
             }
         }
     }}


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

new macro `prepare_result_CString` to handle the case where libindy returns one CString which is empty in the error case. The macro avoids creating an empty Rust string that is then converted into a CString. Overall fewer code lines.