### PR TITLE
Change "command received" INFO messages to DEBUG

### DIFF
--- a/docs/how-tos/how-to-add-a-new-API-call.md
+++ b/docs/how-tos/how-to-add-a-new-API-call.md
@@ -91,7 +91,7 @@ Here you should add a new function for your business logic and a new match claus
         match command {
             // some other clauses
             DidCommand::CreateAndStoreMyDid(wallet_handle, my_did_info, cb) => {
-                info!("CreateAndStoreMyDid command received");
+                debug!("CreateAndStoreMyDid command received");
                 cb(self.create_and_store_my_did(wallet_handle, &my_did_info));
             }
         }
@@ -121,4 +121,4 @@ Here you should add a new function for your business logic and a new match claus
 In the function you should put business logic of your call.
 Notice, that if you have some functionality that can be reused later by other commands, you should put it into the service and execute service call in the function.
 
-Services should stay independent from each other. You can include Services into CommandExecutors.  
+Services should stay independent from each other. You can include Services into CommandExecutors.

--- a/libindy/src/commands/anoncreds/issuer.rs
+++ b/libindy/src/commands/anoncreds/issuer.rs
@@ -171,11 +171,11 @@ impl IssuerCommandExecutor {
     pub fn execute(&self, command: IssuerCommand) {
         match command {
             IssuerCommand::CreateSchema(issuer_did, name, version, attrs, cb) => {
-                info!(target: "issuer_command_executor", "CreateSchema command received");
+                debug!(target: "issuer_command_executor", "CreateSchema command received");
                 cb(self.create_schema(&issuer_did, &name, &version, attrs));
             }
             IssuerCommand::CreateAndStoreCredentialDefinition(wallet_handle, issuer_did, schema, tag, type_, config, cb) => {
-                info!(target: "issuer_command_executor", "CreateAndStoreCredentialDefinition command received");
+                debug!(target: "issuer_command_executor", "CreateAndStoreCredentialDefinition command received");
                 self.create_and_store_credential_definition(wallet_handle, &issuer_did, &SchemaV1::from(schema), &tag,
                                                             type_.as_ref().map(String::as_str), config.as_ref(), cb);
             }
@@ -197,7 +197,7 @@ impl IssuerCommandExecutor {
             }
             IssuerCommand::CreateAndStoreRevocationRegistry(wallet_handle, issuer_did, type_, tag, cred_def_id, config,
                                                             tails_writer_handle, cb) => {
-                info!(target: "issuer_command_executor", "CreateAndStoreRevocationRegistryRegistry command received");
+                debug!(target: "issuer_command_executor", "CreateAndStoreRevocationRegistryRegistry command received");
                 cb(self.create_and_store_revocation_registry(wallet_handle,
                                                              &issuer_did,
                                                              type_.as_ref().map(String::as_str),
@@ -207,23 +207,23 @@ impl IssuerCommandExecutor {
                                                              tails_writer_handle));
             }
             IssuerCommand::CreateCredentialOffer(wallet_handle, cred_def_id, cb) => {
-                info!(target: "issuer_command_executor", "CreateCredentialOffer command received");
+                debug!(target: "issuer_command_executor", "CreateCredentialOffer command received");
                 cb(self.create_credential_offer(wallet_handle, &cred_def_id));
             }
             IssuerCommand::CreateCredential(wallet_handle, cred_offer, cred_req, cred_values, rev_reg_id, blob_storage_reader_handle, cb) => {
-                info!(target: "issuer_command_executor", "CreateCredential command received");
+                debug!(target: "issuer_command_executor", "CreateCredential command received");
                 cb(self.new_credential(wallet_handle, &cred_offer, &cred_req, &cred_values, rev_reg_id.as_ref(), blob_storage_reader_handle));
             }
             IssuerCommand::RevokeCredential(wallet_handle, blob_storage_reader_handle, rev_reg_id, cred_revoc_id, cb) => {
-                info!(target: "issuer_command_executor", "RevokeCredential command received");
+                debug!(target: "issuer_command_executor", "RevokeCredential command received");
                 cb(self.revoke_credential(wallet_handle, blob_storage_reader_handle, &rev_reg_id, &cred_revoc_id));
             }
             /*            IssuerCommand::RecoverCredential(wallet_handle, blob_storage_reader_handle, rev_reg_id, cred_revoc_id, cb) => {
-                            info!(target: "issuer_command_executor", "RecoverCredential command received");
+                            debug!(target: "issuer_command_executor", "RecoverCredential command received");
                             cb(self.recovery_credential(wallet_handle, blob_storage_reader_handle, &rev_reg_id, &cred_revoc_id));
                         }*/
             IssuerCommand::MergeRevocationRegistryDeltas(rev_reg_delta, other_rev_reg_delta, cb) => {
-                info!(target: "issuer_command_executor", "MergeRevocationRegistryDeltas command received");
+                debug!(target: "issuer_command_executor", "MergeRevocationRegistryDeltas command received");
                 cb(self.merge_revocation_registry_deltas(&mut RevocationRegistryDeltaV1::from(rev_reg_delta),
                                                          &RevocationRegistryDeltaV1::from(other_rev_reg_delta)));
             }

--- a/libindy/src/commands/anoncreds/mod.rs
+++ b/libindy/src/commands/anoncreds/mod.rs
@@ -47,15 +47,15 @@ impl AnoncredsCommandExecutor {
     pub fn execute(&self, command: AnoncredsCommand) {
         match command {
             AnoncredsCommand::Issuer(cmd) => {
-                info!(target: "anoncreds_command_executor", "Issuer command received");
+                debug!(target: "anoncreds_command_executor", "Issuer command received");
                 self.issuer_command_cxecutor.execute(cmd);
             }
             AnoncredsCommand::Prover(cmd) => {
-                info!(target: "anoncreds_command_executor", "Prover command received");
+                debug!(target: "anoncreds_command_executor", "Prover command received");
                 self.prover_command_cxecutor.execute(cmd);
             }
             AnoncredsCommand::Verifier(cmd) => {
-                info!(target: "anoncreds_command_executor", "Verifier command received");
+                debug!(target: "anoncreds_command_executor", "Verifier command received");
                 self.verifier_command_cxecutor.execute(cmd);
             }
         };

--- a/libindy/src/commands/anoncreds/prover.rs
+++ b/libindy/src/commands/anoncreds/prover.rs
@@ -172,84 +172,84 @@ impl ProverCommandExecutor {
     pub fn execute(&self, command: ProverCommand) {
         match command {
             ProverCommand::CreateMasterSecret(wallet_handle, master_secret_id, cb) => {
-                info!(target: "prover_command_executor", "CreateMasterSecret command received");
+                debug!(target: "prover_command_executor", "CreateMasterSecret command received");
                 cb(self.create_master_secret(wallet_handle, master_secret_id.as_ref().map(String::as_str)));
             }
             ProverCommand::CreateCredentialRequest(wallet_handle, prover_did, credential_offer,
                                                    credential_def, master_secret_name, cb) => {
-                info!(target: "prover_command_executor", "CreateCredentialRequest command received");
+                debug!(target: "prover_command_executor", "CreateCredentialRequest command received");
                 cb(self.create_credential_request(wallet_handle, &prover_did, &credential_offer,
                                                   &CredentialDefinitionV1::from(credential_def), &master_secret_name));
             }
             ProverCommand::SetCredentialAttrTagPolicy(wallet_handle, cred_def_id, catpol, retroactive, cb) => {
-                info!(target: "prover_command_executor", "SetCredentialAttrTagPolicy command received");
+                debug!(target: "prover_command_executor", "SetCredentialAttrTagPolicy command received");
                 cb(self.set_credential_attr_tag_policy(wallet_handle, &cred_def_id, catpol.as_ref(), retroactive));
             }
             ProverCommand::GetCredentialAttrTagPolicy(wallet_handle, cred_def_id, cb) => {
-                info!(target: "prover_command_executor", "GetCredentialAttrTagPolicy command received");
+                debug!(target: "prover_command_executor", "GetCredentialAttrTagPolicy command received");
                 cb(self.get_credential_attr_tag_policy(wallet_handle, &cred_def_id));
             }
             ProverCommand::StoreCredential(wallet_handle, cred_id, cred_req_metadata, mut cred, cred_def, rev_reg_def, cb) => {
-                info!(target: "prover_command_executor", "StoreCredential command received");
+                debug!(target: "prover_command_executor", "StoreCredential command received");
                 cb(self.store_credential(wallet_handle, cred_id.as_ref().map(String::as_str),
                                          &cred_req_metadata, &mut cred,
                                          &CredentialDefinitionV1::from(cred_def),
                                          rev_reg_def.map(RevocationRegistryDefinitionV1::from).as_ref()));
             }
             ProverCommand::GetCredentials(wallet_handle, filter_json, cb) => {
-                info!(target: "prover_command_executor", "GetCredentials command received");
+                debug!(target: "prover_command_executor", "GetCredentials command received");
                 cb(self.get_credentials(wallet_handle, filter_json.as_ref().map(String::as_str)));
             }
             ProverCommand::GetCredential(wallet_handle, cred_id, cb) => {
-                info!(target: "prover_command_executor", "GetCredential command received");
+                debug!(target: "prover_command_executor", "GetCredential command received");
                 cb(self.get_credential(wallet_handle, &cred_id));
             }
             ProverCommand::DeleteCredential(wallet_handle, cred_id, cb) => {
-                info!(target: "prover_command_executor", "DeleteCredential command received");
+                debug!(target: "prover_command_executor", "DeleteCredential command received");
                 cb(self.delete_credential(wallet_handle, &cred_id));
             }
             ProverCommand::SearchCredentials(wallet_handle, query_json, cb) => {
-                info!(target: "prover_command_executor", "SearchCredentials command received");
+                debug!(target: "prover_command_executor", "SearchCredentials command received");
                 cb(self.search_credentials(wallet_handle, query_json.as_ref().map(String::as_str)));
             }
             ProverCommand::FetchCredentials(search_handle, count, cb) => {
-                info!(target: "prover_command_executor", "FetchCredentials command received");
+                debug!(target: "prover_command_executor", "FetchCredentials command received");
                 cb(self.fetch_credentials(search_handle, count));
             }
             ProverCommand::CloseCredentialsSearch(search_handle, cb) => {
-                info!(target: "prover_command_executor", "CloseCredentialsSearch command received");
+                debug!(target: "prover_command_executor", "CloseCredentialsSearch command received");
                 cb(self.close_credentials_search(search_handle));
             }
             ProverCommand::GetCredentialsForProofReq(wallet_handle, proof_req, cb) => {
-                info!(target: "prover_command_executor", "GetCredentialsForProofReq command received");
+                debug!(target: "prover_command_executor", "GetCredentialsForProofReq command received");
                 cb(self.get_credentials_for_proof_req(wallet_handle, &proof_req));
             }
             ProverCommand::SearchCredentialsForProofReq(wallet_handle, proof_req, extra_query, cb) => {
-                info!(target: "prover_command_executor", "SearchCredentialsForProofReq command received");
+                debug!(target: "prover_command_executor", "SearchCredentialsForProofReq command received");
                 cb(self.search_credentials_for_proof_req(wallet_handle, &proof_req, extra_query.as_ref()));
             }
             ProverCommand::FetchCredentialForProofReq(search_handle, item_ref, count, cb) => {
-                info!(target: "prover_command_executor", "FetchCredentialForProofReq command received");
+                debug!(target: "prover_command_executor", "FetchCredentialForProofReq command received");
                 cb(self.fetch_credential_for_proof_request(search_handle, &item_ref, count));
             }
             ProverCommand::CloseCredentialsSearchForProofReq(search_handle, cb) => {
-                info!(target: "prover_command_executor", "CloseCredentialsSearchForProofReq command received");
+                debug!(target: "prover_command_executor", "CloseCredentialsSearchForProofReq command received");
                 cb(self.close_credentials_search_for_proof_req(search_handle));
             }
             ProverCommand::CreateProof(wallet_handle, proof_req, requested_credentials, master_secret_name,
                                        schemas, cred_defs, rev_states, cb) => {
-                info!(target: "prover_command_executor", "CreateProof command received");
+                debug!(target: "prover_command_executor", "CreateProof command received");
                 cb(self.create_proof(wallet_handle, &proof_req,& requested_credentials, &master_secret_name,
                                      &schemas_map_to_schemas_v1_map(schemas),
                                      &cred_defs_map_to_cred_defs_v1_map(cred_defs),
                                      &rev_states));
             }
             ProverCommand::CreateRevocationState(blob_storage_reader_handle, rev_reg_def, rev_reg_delta, timestamp, cred_rev_id, cb) => {
-                info!(target: "prover_command_executor", "CreateRevocationState command received");
+                debug!(target: "prover_command_executor", "CreateRevocationState command received");
                 cb(self.create_revocation_state(blob_storage_reader_handle, rev_reg_def, rev_reg_delta, timestamp, &cred_rev_id));
             }
             ProverCommand::UpdateRevocationState(blob_storage_reader_handle, rev_state, rev_reg_def, rev_reg_delta, timestamp, cred_rev_id, cb) => {
-                info!(target: "prover_command_executor", "UpdateRevocationState command received");
+                debug!(target: "prover_command_executor", "UpdateRevocationState command received");
                 cb(self.update_revocation_state(blob_storage_reader_handle, rev_state, rev_reg_def, rev_reg_delta, timestamp, &cred_rev_id));
             }
         };

--- a/libindy/src/commands/anoncreds/verifier.rs
+++ b/libindy/src/commands/anoncreds/verifier.rs
@@ -37,7 +37,7 @@ impl VerifierCommandExecutor {
     pub fn execute(&self, command: VerifierCommand) {
         match command {
             VerifierCommand::VerifyProof(proof_request, proof, schemas, credential_defs, rev_reg_defs, rev_regs, cb) => {
-                info!(target: "verifier_command_executor", "VerifyProof command received");
+                debug!(target: "verifier_command_executor", "VerifyProof command received");
                 cb(self.verify_proof(proof_request, proof,
                                      &schemas_map_to_schemas_v1_map(schemas),
                                      &cred_defs_map_to_cred_defs_v1_map(credential_defs),
@@ -45,7 +45,7 @@ impl VerifierCommandExecutor {
                                      &rev_regs_map_to_rev_regs_local_map(rev_regs)));
             }
             VerifierCommand::GenerateNonce(cb) => {
-                info!(target: "verifier_command_executor", "GenerateNonce command received");
+                debug!(target: "verifier_command_executor", "GenerateNonce command received");
                 cb(self.generate_nonce());
             }
         };

--- a/libindy/src/commands/blob_storage.rs
+++ b/libindy/src/commands/blob_storage.rs
@@ -28,11 +28,11 @@ impl BlobStorageCommandExecutor {
     pub fn execute(&self, command: BlobStorageCommand) {
         match command {
             BlobStorageCommand::OpenReader(type_, config, cb) => {
-                info!("OpenReader command received");
+                debug!("OpenReader command received");
                 cb(self.open_reader(&type_, &config));
             }
             BlobStorageCommand::OpenWriter(writer_type, writer_config, cb) => {
-                info!("OpenWriter command received");
+                debug!("OpenWriter command received");
                 cb(self.open_writer(&writer_type, &writer_config));
             }
         }

--- a/libindy/src/commands/cache.rs
+++ b/libindy/src/commands/cache.rs
@@ -89,27 +89,27 @@ impl CacheCommandExecutor {
     pub fn execute(&self, command: CacheCommand) {
         match command {
             CacheCommand::GetSchema(pool_handle, wallet_handle, submitter_did, id, options, cb) => {
-                info!(target: "non_secrets_command_executor", "GetSchema command received");
+                debug!(target: "non_secrets_command_executor", "GetSchema command received");
                 self.get_schema(pool_handle, wallet_handle, &submitter_did, &id, options, cb);
             }
             CacheCommand::GetSchemaContinue(wallet_handle, ledger_response, options, cb_id) => {
-                info!(target: "non_secrets_command_executor", "GetSchemaContinue command received");
+                debug!(target: "non_secrets_command_executor", "GetSchemaContinue command received");
                 self._get_schema_continue(wallet_handle, ledger_response, options, cb_id);
             }
             CacheCommand::GetCredDef(pool_handle, wallet_handle, submitter_did, id, options, cb) => {
-                info!(target: "non_secrets_command_executor", "GetCredDef command received");
+                debug!(target: "non_secrets_command_executor", "GetCredDef command received");
                 self.get_cred_def(pool_handle, wallet_handle, &submitter_did, &id, options, cb);
             }
             CacheCommand::GetCredDefContinue(wallet_handle, ledger_response, options, cb_id) => {
-                info!(target: "non_secrets_command_executor", "GetCredDefContinue command received");
+                debug!(target: "non_secrets_command_executor", "GetCredDefContinue command received");
                 self._get_cred_def_continue(wallet_handle, ledger_response, options, cb_id);
             }
             CacheCommand::PurgeSchemaCache(wallet_handle, options, cb) => {
-                info!(target: "non_secrets_command_executor", "PurgeSchemaCache command received");
+                debug!(target: "non_secrets_command_executor", "PurgeSchemaCache command received");
                 cb(self.purge_schema_cache(wallet_handle, options));
             }
             CacheCommand::PurgeCredDefCache(wallet_handle, options, cb) => {
-                info!(target: "non_secrets_command_executor", "PurgeCredDefCache command received");
+                debug!(target: "non_secrets_command_executor", "PurgeCredDefCache command received");
                 cb(self.purge_cred_def_cache(wallet_handle, options));
             }
         }

--- a/libindy/src/commands/crypto.rs
+++ b/libindy/src/commands/crypto.rs
@@ -104,47 +104,47 @@ impl CryptoCommandExecutor {
     pub fn execute(&self, command: CryptoCommand) {
         match command {
             CryptoCommand::CreateKey(wallet_handle, key_info, cb) => {
-                info!("CreateKey command received");
+                debug!("CreateKey command received");
                 cb(self.create_key(wallet_handle, &key_info));
             }
             CryptoCommand::SetKeyMetadata(wallet_handle, verkey, metadata, cb) => {
-                info!("SetKeyMetadata command received");
+                debug!("SetKeyMetadata command received");
                 cb(self.set_key_metadata(wallet_handle, &verkey, &metadata));
             }
             CryptoCommand::GetKeyMetadata(wallet_handle, verkey, cb) => {
-                info!("GetKeyMetadata command received");
+                debug!("GetKeyMetadata command received");
                 cb(self.get_key_metadata(wallet_handle, &verkey));
             }
             CryptoCommand::CryptoSign(wallet_handle, my_vk, msg, cb) => {
-                info!("CryptoSign command received");
+                debug!("CryptoSign command received");
                 cb(self.crypto_sign(wallet_handle, &my_vk, &msg));
             }
             CryptoCommand::CryptoVerify(their_vk, msg, signature, cb) => {
-                info!("CryptoVerify command received");
+                debug!("CryptoVerify command received");
                 cb(self.crypto_verify(&their_vk, &msg, &signature));
             }
             CryptoCommand::AuthenticatedEncrypt(wallet_handle, my_vk, their_vk, msg, cb) => {
-                info!("AuthenticatedEncrypt command received");
+                debug!("AuthenticatedEncrypt command received");
                 cb(self.authenticated_encrypt(wallet_handle, &my_vk, &their_vk, &msg));
             }
             CryptoCommand::AuthenticatedDecrypt(wallet_handle, my_vk, encrypted_msg, cb) => {
-                info!("AuthenticatedDecrypt command received");
+                debug!("AuthenticatedDecrypt command received");
                 cb(self.authenticated_decrypt(wallet_handle, &my_vk, &encrypted_msg));
             }
             CryptoCommand::AnonymousEncrypt(their_vk, msg, cb) => {
-                info!("AnonymousEncrypt command received");
+                debug!("AnonymousEncrypt command received");
                 cb(self.anonymous_encrypt(&their_vk, &msg));
             }
             CryptoCommand::AnonymousDecrypt(wallet_handle, my_vk, encrypted_msg, cb) => {
-                info!("AnonymousDecrypt command received");
+                debug!("AnonymousDecrypt command received");
                 cb(self.anonymous_decrypt(wallet_handle, &my_vk, &encrypted_msg));
             }
             CryptoCommand::PackMessage(message, receivers, sender_vk, wallet_handle, cb) => {
-                info!("PackMessage command received");
+                debug!("PackMessage command received");
                 cb(self.pack_msg(message, receivers, sender_vk, wallet_handle));
             }
             CryptoCommand::UnpackMessage(jwe_json, wallet_handle, cb) => {
-                info!("UnpackMessage command received");
+                debug!("UnpackMessage command received");
                 cb(self.unpack_msg(jwe_json, wallet_handle));
             }
         };

--- a/libindy/src/commands/did.rs
+++ b/libindy/src/commands/did.rs
@@ -121,63 +121,63 @@ impl DidCommandExecutor {
     pub fn execute(&self, command: DidCommand) {
         match command {
             DidCommand::CreateAndStoreMyDid(wallet_handle, my_did_info, cb) => {
-                info!("CreateAndStoreMyDid command received");
+                debug!("CreateAndStoreMyDid command received");
                 cb(self.create_and_store_my_did(wallet_handle, &my_did_info));
             }
             DidCommand::ReplaceKeysStart(wallet_handle, key_info, did, cb) => {
-                info!("ReplaceKeysStart command received");
+                debug!("ReplaceKeysStart command received");
                 cb(self.replace_keys_start(wallet_handle, &key_info, &did));
             }
             DidCommand::ReplaceKeysApply(wallet_handle, did, cb) => {
-                info!("ReplaceKeysApply command received");
+                debug!("ReplaceKeysApply command received");
                 cb(self.replace_keys_apply(wallet_handle, &did));
             }
             DidCommand::StoreTheirDid(wallet_handle, their_did_info, cb) => {
-                info!("StoreTheirDid command received");
+                debug!("StoreTheirDid command received");
                 cb(self.store_their_did(wallet_handle, &their_did_info));
             }
             DidCommand::GetMyDidWithMeta(wallet_handle, my_did, cb) => {
-                info!("GetMyDidWithMeta command received");
+                debug!("GetMyDidWithMeta command received");
                 cb(self.get_my_did_with_meta(wallet_handle, &my_did))
             }
             DidCommand::ListMyDidsWithMeta(wallet_handle, cb) => {
-                info!("ListMyDidsWithMeta command received");
+                debug!("ListMyDidsWithMeta command received");
                 cb(self.list_my_dids_with_meta(wallet_handle));
             }
             DidCommand::KeyForDid(pool_handle, wallet_handle, did, cb) => {
-                info!("KeyForDid command received");
+                debug!("KeyForDid command received");
                 self.key_for_did(pool_handle, wallet_handle, did, cb);
             }
             DidCommand::KeyForLocalDid(wallet_handle, did, cb) => {
-                info!("KeyForLocalDid command received");
+                debug!("KeyForLocalDid command received");
                 cb(self.key_for_local_did(wallet_handle, &did));
             }
             DidCommand::SetEndpointForDid(wallet_handle, did, endpoint, cb) => {
-                info!("SetEndpointForDid command received");
+                debug!("SetEndpointForDid command received");
                 cb(self.set_endpoint_for_did(wallet_handle, &did, &endpoint));
             }
             DidCommand::GetEndpointForDid(wallet_handle, pool_handle, did, cb) => {
-                info!("GetEndpointForDid command received");
+                debug!("GetEndpointForDid command received");
                 self.get_endpoint_for_did(wallet_handle, pool_handle, did, cb);
             }
             DidCommand::SetDidMetadata(wallet_handle, did, metadata, cb) => {
-                info!("SetDidMetadata command received");
+                debug!("SetDidMetadata command received");
                 cb(self.set_did_metadata(wallet_handle, &did, metadata));
             }
             DidCommand::GetDidMetadata(wallet_handle, did, cb) => {
-                info!("GetDidMetadata command received");
+                debug!("GetDidMetadata command received");
                 cb(self.get_did_metadata(wallet_handle, &did));
             }
             DidCommand::AbbreviateVerkey(did, verkey, cb) => {
-                info!("AbbreviateVerkey command received");
+                debug!("AbbreviateVerkey command received");
                 cb(self.abbreviate_verkey(&did, verkey));
             }
             DidCommand::GetNymAck(wallet_handle, result, deferred_cmd_id) => {
-                info!("GetNymAck command received");
+                debug!("GetNymAck command received");
                 self.get_nym_ack(wallet_handle, result, deferred_cmd_id);
             }
             DidCommand::GetAttribAck(wallet_handle, result, deferred_cmd_id) => {
-                info!("GetAttribAck command received");
+                debug!("GetAttribAck command received");
                 self.get_attrib_ack(wallet_handle, result, deferred_cmd_id);
             }
         };

--- a/libindy/src/commands/ledger.rs
+++ b/libindy/src/commands/ledger.rs
@@ -293,15 +293,15 @@ impl LedgerCommandExecutor {
     pub fn execute(&self, command: LedgerCommand) {
         match command {
             LedgerCommand::SignAndSubmitRequest(pool_handle, wallet_handle, submitter_did, request_json, cb) => {
-                info!(target: "ledger_command_executor", "SignAndSubmitRequest command received");
+                debug!(target: "ledger_command_executor", "SignAndSubmitRequest command received");
                 self.sign_and_submit_request(pool_handle, wallet_handle, &submitter_did, &request_json, cb);
             }
             LedgerCommand::SubmitRequest(handle, request_json, cb) => {
-                info!(target: "ledger_command_executor", "SubmitRequest command received");
+                debug!(target: "ledger_command_executor", "SubmitRequest command received");
                 self.submit_request(handle, &request_json, cb);
             }
             LedgerCommand::SubmitAck(handle, result) => {
-                info!(target: "ledger_command_executor", "SubmitAck command received");
+                debug!(target: "ledger_command_executor", "SubmitAck command received");
                 match self.send_callbacks.borrow_mut().remove(&handle) {
                     Some(cb) => cb(result.map_err(IndyError::from)),
                     None => {
@@ -311,147 +311,147 @@ impl LedgerCommandExecutor {
                 }
             }
             LedgerCommand::SubmitAction(handle, request_json, nodes, timeout, cb) => {
-                info!(target: "ledger_command_executor", "SubmitRequest command received");
+                debug!(target: "ledger_command_executor", "SubmitRequest command received");
                 self.submit_action(handle, &request_json, nodes.as_ref().map(String::as_str), timeout, cb);
             }
             LedgerCommand::RegisterSPParser(txn_type, parser, free, cb) => {
-                info!(target: "ledger_command_executor", "RegisterSPParser command received");
+                debug!(target: "ledger_command_executor", "RegisterSPParser command received");
                 cb(self.register_sp_parser(&txn_type, parser, free));
             }
             LedgerCommand::SignRequest(wallet_handle, submitter_did, request_json, cb) => {
-                info!(target: "ledger_command_executor", "SignRequest command received");
+                debug!(target: "ledger_command_executor", "SignRequest command received");
                 cb(self.sign_request(wallet_handle, &submitter_did, &request_json));
             }
             LedgerCommand::MultiSignRequest(wallet_handle, submitter_did, request_json, cb) => {
-                info!(target: "ledger_command_executor", "MultiSignRequest command received");
+                debug!(target: "ledger_command_executor", "MultiSignRequest command received");
                 cb(self.multi_sign_request(wallet_handle, &submitter_did, &request_json));
             }
             LedgerCommand::BuildGetDdoRequest(submitter_did, target_did, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetDdoRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetDdoRequest command received");
                 cb(self.build_get_ddo_request(submitter_did.as_ref().map(String::as_str), &target_did));
             }
             LedgerCommand::BuildNymRequest(submitter_did, target_did, verkey, alias, role, cb) => {
-                info!(target: "ledger_command_executor", "BuildNymRequest command received");
+                debug!(target: "ledger_command_executor", "BuildNymRequest command received");
                 cb(self.build_nym_request(&submitter_did, &target_did,
                                           verkey.as_ref().map(String::as_str),
                                           alias.as_ref().map(String::as_str),
                                           role.as_ref().map(String::as_str)));
             }
             LedgerCommand::BuildAttribRequest(submitter_did, target_did, hash, raw, enc, cb) => {
-                info!(target: "ledger_command_executor", "BuildAttribRequest command received");
+                debug!(target: "ledger_command_executor", "BuildAttribRequest command received");
                 cb(self.build_attrib_request(&submitter_did, &target_did,
                                              hash.as_ref().map(String::as_str),
                                              raw.as_ref(),
                                              enc.as_ref().map(String::as_str)));
             }
             LedgerCommand::BuildGetAttribRequest(submitter_did, target_did, raw, hash, enc, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetAttribRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetAttribRequest command received");
                 cb(self.build_get_attrib_request(submitter_did.as_ref().map(String::as_str), &target_did,
                                                  raw.as_ref().map(String::as_str),
                                                  hash.as_ref().map(String::as_str),
                                                  enc.as_ref().map(String::as_str)));
             }
             LedgerCommand::BuildGetNymRequest(submitter_did, target_did, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetNymRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetNymRequest command received");
                 cb(self.build_get_nym_request(submitter_did.as_ref().map(String::as_str), &target_did));
             }
             LedgerCommand::BuildSchemaRequest(submitter_did, data, cb) => {
-                info!(target: "ledger_command_executor", "BuildSchemaRequest command received");
+                debug!(target: "ledger_command_executor", "BuildSchemaRequest command received");
                 cb(self.build_schema_request(&submitter_did, SchemaV1::from(data)));
             }
             LedgerCommand::BuildGetSchemaRequest(submitter_did, id, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetSchemaRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetSchemaRequest command received");
                 cb(self.build_get_schema_request(submitter_did.as_ref().map(String::as_str), &id));
             }
             LedgerCommand::ParseGetSchemaResponse(get_schema_response, cb) => {
-                info!(target: "ledger_command_executor", "ParseGetSchemaResponse command received");
+                debug!(target: "ledger_command_executor", "ParseGetSchemaResponse command received");
                 cb(self.parse_get_schema_response(&get_schema_response));
             }
             LedgerCommand::BuildCredDefRequest(submitter_did, data, cb) => {
-                info!(target: "ledger_command_executor", "BuildCredDefRequest command received");
+                debug!(target: "ledger_command_executor", "BuildCredDefRequest command received");
                 cb(self.build_cred_def_request(&submitter_did, CredentialDefinitionV1::from(data)));
             }
             LedgerCommand::BuildGetCredDefRequest(submitter_did, id, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetCredDefRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetCredDefRequest command received");
                 cb(self.build_get_cred_def_request(submitter_did.as_ref().map(String::as_str), &id));
             }
             LedgerCommand::ParseGetCredDefResponse(get_cred_def_response, cb) => {
-                info!(target: "ledger_command_executor", "ParseGetCredDefResponse command received");
+                debug!(target: "ledger_command_executor", "ParseGetCredDefResponse command received");
                 cb(self.parse_get_cred_def_response(&get_cred_def_response));
             }
             LedgerCommand::BuildNodeRequest(submitter_did, target_did, data, cb) => {
-                info!(target: "ledger_command_executor", "BuildNodeRequest command received");
+                debug!(target: "ledger_command_executor", "BuildNodeRequest command received");
                 cb(self.build_node_request(&submitter_did, &target_did, data));
             }
             LedgerCommand::BuildGetValidatorInfoRequest(submitter_did, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetValidatorInfoRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetValidatorInfoRequest command received");
                 cb(self.build_get_validator_info_request(&submitter_did));
             }
             LedgerCommand::BuildGetTxnRequest(submitter_did, ledger_type, seq_no, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetTxnRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetTxnRequest command received");
                 cb(self.build_get_txn_request(submitter_did.as_ref().map(String::as_str), ledger_type.as_ref().map(String::as_str), seq_no));
             }
             LedgerCommand::BuildPoolConfigRequest(submitter_did, writes, force, cb) => {
-                info!(target: "ledger_command_executor", "BuildPoolConfigRequest command received");
+                debug!(target: "ledger_command_executor", "BuildPoolConfigRequest command received");
                 cb(self.build_pool_config_request(&submitter_did, writes, force));
             }
             LedgerCommand::BuildPoolRestartRequest(submitter_did, action, datetime, cb) => {
-                info!(target: "ledger_command_executor", "BuildPoolRestartRequest command received");
+                debug!(target: "ledger_command_executor", "BuildPoolRestartRequest command received");
                 cb(self.build_pool_restart_request(&submitter_did, &action, datetime.as_ref().map(String::as_str)));
             }
             LedgerCommand::BuildPoolUpgradeRequest(submitter_did, name, version, action, sha256, timeout, schedule, justification, reinstall, force, package, cb) => {
-                info!(target: "ledger_command_executor", "BuildPoolUpgradeRequest command received");
+                debug!(target: "ledger_command_executor", "BuildPoolUpgradeRequest command received");
                 cb(self.build_pool_upgrade_request(&submitter_did, &name, &version, &action, &sha256, timeout,
                                                    schedule,
                                                    justification.as_ref().map(String::as_str),
                                                    reinstall, force, package.as_ref().map(String::as_str)));
             }
             LedgerCommand::BuildRevocRegDefRequest(submitter_did, data, cb) => {
-                info!(target: "ledger_command_executor", "BuildRevocRegDefRequest command received");
+                debug!(target: "ledger_command_executor", "BuildRevocRegDefRequest command received");
                 cb(self.build_revoc_reg_def_request(&submitter_did, RevocationRegistryDefinitionV1::from(data)));
             }
             LedgerCommand::BuildGetRevocRegDefRequest(submitter_did, id, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetRevocRegDefRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetRevocRegDefRequest command received");
                 cb(self.build_get_revoc_reg_def_request(submitter_did.as_ref().map(String::as_str), &id));
             }
             LedgerCommand::ParseGetRevocRegDefResponse(get_revoc_ref_def_response, cb) => {
-                info!(target: "ledger_command_executor", "ParseGetRevocRegDefDefResponse command received");
+                debug!(target: "ledger_command_executor", "ParseGetRevocRegDefDefResponse command received");
                 cb(self.parse_revoc_reg_def_response(&get_revoc_ref_def_response));
             }
             LedgerCommand::BuildRevocRegEntryRequest(submitter_did, revoc_reg_def_id, rev_def_type, value, cb) => {
-                info!(target: "ledger_command_executor", "BuildRevocRegEntryRequest command received");
+                debug!(target: "ledger_command_executor", "BuildRevocRegEntryRequest command received");
                 cb(self.build_revoc_reg_entry_request(&submitter_did, &revoc_reg_def_id, &rev_def_type, RevocationRegistryDeltaV1::from(value)));
             }
             LedgerCommand::BuildGetRevocRegRequest(submitter_did, revoc_reg_def_id, timestamp, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetRevocRegRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetRevocRegRequest command received");
                 cb(self.build_get_revoc_reg_request(submitter_did.as_ref().map(String::as_str), &revoc_reg_def_id, timestamp));
             }
             LedgerCommand::ParseGetRevocRegResponse(get_revoc_reg_response, cb) => {
-                info!(target: "ledger_command_executor", "ParseGetRevocRegResponse command received");
+                debug!(target: "ledger_command_executor", "ParseGetRevocRegResponse command received");
                 cb(self.parse_revoc_reg_response(&get_revoc_reg_response));
             }
             LedgerCommand::BuildGetRevocRegDeltaRequest(submitter_did, revoc_reg_def_id, from, to, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetRevocRegDeltaRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetRevocRegDeltaRequest command received");
                 cb(self.build_get_revoc_reg_delta_request(submitter_did.as_ref().map(String::as_str), &revoc_reg_def_id, from, to));
             }
             LedgerCommand::ParseGetRevocRegDeltaResponse(get_revoc_reg_delta_response, cb) => {
-                info!(target: "ledger_command_executor", "ParseGetRevocRegDeltaResponse command received");
+                debug!(target: "ledger_command_executor", "ParseGetRevocRegDeltaResponse command received");
                 cb(self.parse_revoc_reg_delta_response(&get_revoc_reg_delta_response));
             }
             LedgerCommand::GetResponseMetadata(response, cb) => {
-                info!(target: "ledger_command_executor", "GetResponseMetadata command received");
+                debug!(target: "ledger_command_executor", "GetResponseMetadata command received");
                 cb(self.get_response_metadata(&response));
             }
             LedgerCommand::BuildAuthRuleRequest(submitter_did, txn_type, action, field, old_value, new_value, constraint, cb) => {
-                info!(target: "ledger_command_executor", "BuildAuthRuleRequest command received");
+                debug!(target: "ledger_command_executor", "BuildAuthRuleRequest command received");
                 cb(self.build_auth_rule_request(&submitter_did, &txn_type, &action, &field, old_value.as_ref().map(String::as_str), new_value.as_ref().map(String::as_str), constraint));
             }
             LedgerCommand::BuildAuthRulesRequest(submitter_did, rules, cb) => {
-                info!(target: "ledger_command_executor", "BuildAuthRulesRequest command received");
+                debug!(target: "ledger_command_executor", "BuildAuthRulesRequest command received");
                 cb(self.build_auth_rules_request(&submitter_did, rules));
             }
             LedgerCommand::BuildGetAuthRuleRequest(submitter_did, txn_type, action, field, old_value, new_value, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetAuthRuleRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetAuthRuleRequest command received");
                 cb(self.build_get_auth_rule_request(submitter_did.as_ref().map(String::as_str),
                                                     txn_type.as_ref().map(String::as_str),
                                                     action.as_ref().map(String::as_str),
@@ -460,41 +460,41 @@ impl LedgerCommandExecutor {
                                                     new_value.as_ref().map(String::as_str)));
             }
             LedgerCommand::GetSchema(pool_handle, submitter_did, id, cb) => {
-                info!(target: "ledger_command_executor", "GetSchema command received");
+                debug!(target: "ledger_command_executor", "GetSchema command received");
                 self.get_schema(pool_handle, submitter_did.as_ref().map(String::as_str), &id, cb);
             }
             LedgerCommand::GetSchemaContinue(pool_response, cb_id) => {
-                info!(target: "ledger_command_executor", "GetSchemaContinue command received");
+                debug!(target: "ledger_command_executor", "GetSchemaContinue command received");
                 self._get_schema_continue(pool_response, cb_id);
             }
             LedgerCommand::GetCredDef(pool_handle, submitter_did, id, cb) => {
-                info!(target: "ledger_command_executor", "GetCredDef command received");
+                debug!(target: "ledger_command_executor", "GetCredDef command received");
                 self.get_cred_def(pool_handle, submitter_did.as_ref().map(String::as_str), &id, cb);
             }
             LedgerCommand::GetCredDefContinue(pool_response, cb_id) => {
-                info!(target: "ledger_command_executor", "GetCredDefContinue command received");
+                debug!(target: "ledger_command_executor", "GetCredDefContinue command received");
                 self._get_cred_def_continue(pool_response, cb_id);
             }
             LedgerCommand::BuildTxnAuthorAgreementRequest(submitter_did, text, version, cb) => {
-                info!(target: "ledger_command_executor", "BuildTxnAuthorAgreementRequest command received");
+                debug!(target: "ledger_command_executor", "BuildTxnAuthorAgreementRequest command received");
                 cb(self.build_txn_author_agreement_request(&submitter_did, &text, &version));
             }
             LedgerCommand::BuildGetTxnAuthorAgreementRequest(submitter_did, data, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetTxnAuthorAgreementRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetTxnAuthorAgreementRequest command received");
                 cb(self.build_get_txn_author_agreement_request(submitter_did.as_ref().map(String::as_str), data.as_ref()));
             }
             LedgerCommand::BuildAcceptanceMechanismRequests(submitter_did, aml, version, aml_context, cb) => {
-                info!(target: "ledger_command_executor", "BuildAcceptanceMechanismRequests command received");
+                debug!(target: "ledger_command_executor", "BuildAcceptanceMechanismRequests command received");
                 cb(self.build_acceptance_mechanisms_request(&submitter_did, aml, &version, aml_context.as_ref().map(String::as_str)));
             }
             LedgerCommand::BuildGetAcceptanceMechanismsRequest(submitter_did, timestamp, version, cb) => {
-                info!(target: "ledger_command_executor", "BuildGetAcceptanceMechanismsRequest command received");
+                debug!(target: "ledger_command_executor", "BuildGetAcceptanceMechanismsRequest command received");
                 cb(self.build_get_acceptance_mechanisms_request(submitter_did.as_ref().map(String::as_str),
                                                                 timestamp,
                                                                 version.as_ref().map(String::as_str)));
             }
             LedgerCommand::AppendTxnAuthorAgreementAcceptanceToRequest(request_json, text, version, hash, acc_mech_type, time_of_acceptance, cb) => {
-                info!(target: "ledger_command_executor", "AppendTxnAuthorAgreementAcceptanceToRequest command received");
+                debug!(target: "ledger_command_executor", "AppendTxnAuthorAgreementAcceptanceToRequest command received");
                 cb(self.append_txn_author_agreement_acceptance_to_request(&request_json,
                                                                           text.as_ref().map(String::as_str),
                                                                           version.as_ref().map(String::as_str),
@@ -503,7 +503,7 @@ impl LedgerCommandExecutor {
                                                                           time_of_acceptance));
             }
             LedgerCommand::AppendRequestEndorser(request_json, endorser_did, cb) => {
-                info!(target: "ledger_command_executor", "AppendRequestEndorser command received");
+                debug!(target: "ledger_command_executor", "AppendRequestEndorser command received");
                 cb(self.append_request_endorser(&request_json,
                                                 &endorser_did));
             }

--- a/libindy/src/commands/mod.rs
+++ b/libindy/src/commands/mod.rs
@@ -123,51 +123,51 @@ impl CommandExecutor {
                 loop {
                     match receiver.recv() {
                         Ok(Command::Anoncreds(cmd)) => {
-                            info!("AnoncredsCommand command received");
+                            debug!("AnoncredsCommand command received");
                             anoncreds_command_executor.execute(cmd);
                         }
                         Ok(Command::BlobStorage(cmd)) => {
-                            info!("BlobStorageCommand command received");
+                            debug!("BlobStorageCommand command received");
                             blob_storage_command_executor.execute(cmd);
                         }
                         Ok(Command::Crypto(cmd)) => {
-                            info!("CryptoCommand command received");
+                            debug!("CryptoCommand command received");
                             crypto_command_executor.execute(cmd);
                         }
                         Ok(Command::Ledger(cmd)) => {
-                            info!("LedgerCommand command received");
+                            debug!("LedgerCommand command received");
                             ledger_command_executor.execute(cmd);
                         }
                         Ok(Command::Pool(cmd)) => {
-                            info!("PoolCommand command received");
+                            debug!("PoolCommand command received");
                             pool_command_executor.execute(cmd);
                         }
                         Ok(Command::Did(cmd)) => {
-                            info!("DidCommand command received");
+                            debug!("DidCommand command received");
                             did_command_executor.execute(cmd);
                         }
                         Ok(Command::Wallet(cmd)) => {
-                            info!("WalletCommand command received");
+                            debug!("WalletCommand command received");
                             wallet_command_executor.execute(cmd);
                         }
                         Ok(Command::Pairwise(cmd)) => {
-                            info!("PairwiseCommand command received");
+                            debug!("PairwiseCommand command received");
                             pairwise_command_executor.execute(cmd);
                         }
                         Ok(Command::NonSecrets(cmd)) => {
-                            info!("NonSecretCommand command received");
+                            debug!("NonSecretCommand command received");
                             non_secret_command_executor.execute(cmd);
                         }
                         Ok(Command::Payments(cmd)) => {
-                            info!("PaymentsCommand command received");
+                            debug!("PaymentsCommand command received");
                             payments_command_executor.execute(cmd);
                         }
                         Ok(Command::Cache(cmd)) => {
-                            info!("CacheCommand command received");
+                            debug!("CacheCommand command received");
                             cache_command_executor.execute(cmd);
                         }
                         Ok(Command::Exit) => {
-                            info!("Exit command received");
+                            debug!("Exit command received");
                             break
                         }
                         Err(err) => {

--- a/libindy/src/commands/non_secrets.rs
+++ b/libindy/src/commands/non_secrets.rs
@@ -74,43 +74,43 @@ impl NonSecretsCommandExecutor {
     pub fn execute(&self, command: NonSecretsCommand) {
         match command {
             NonSecretsCommand::AddRecord(handle, type_, id, value, tags, cb) => {
-                info!(target: "non_secrets_command_executor", "AddRecord command received");
+                debug!(target: "non_secrets_command_executor", "AddRecord command received");
                 cb(self.add_record(handle, &type_, &id, &value, tags.as_ref()));
             }
             NonSecretsCommand::UpdateRecordValue(handle, type_, id, value, cb) => {
-                info!(target: "non_secrets_command_executor", "UpdateRecordValue command received");
+                debug!(target: "non_secrets_command_executor", "UpdateRecordValue command received");
                 cb(self.update_record_value(handle, &type_, &id, &value));
             }
             NonSecretsCommand::UpdateRecordTags(handle, type_, id, tags, cb) => {
-                info!(target: "non_secrets_command_executor", "UpdateRecordTags command received");
+                debug!(target: "non_secrets_command_executor", "UpdateRecordTags command received");
                 cb(self.update_record_tags(handle, &type_, &id, &tags));
             }
             NonSecretsCommand::AddRecordTags(handle, type_, id, tags, cb) => {
-                info!(target: "non_secrets_command_executor", "AddRecordTags command received");
+                debug!(target: "non_secrets_command_executor", "AddRecordTags command received");
                 cb(self.add_record_tags(handle, &type_, &id, &tags));
             }
             NonSecretsCommand::DeleteRecordTags(handle, type_, id, tags_names_json, cb) => {
-                info!(target: "non_secrets_command_executor", "DeleteRecordTags command received");
+                debug!(target: "non_secrets_command_executor", "DeleteRecordTags command received");
                 cb(self.delete_record_tags(handle, &type_, &id, &tags_names_json));
             }
             NonSecretsCommand::DeleteRecord(handle, type_, id, cb) => {
-                info!(target: "non_secrets_command_executor", "DeleteRecord command received");
+                debug!(target: "non_secrets_command_executor", "DeleteRecord command received");
                 cb(self.delete_record(handle, &type_, &id));
             }
             NonSecretsCommand::GetRecord(handle, type_, id, options_json, cb) => {
-                info!(target: "non_secrets_command_executor", "GetRecord command received");
+                debug!(target: "non_secrets_command_executor", "GetRecord command received");
                 cb(self.get_record(handle, &type_, &id, &options_json));
             }
             NonSecretsCommand::OpenSearch(handle, type_, query_json, options_json, cb) => {
-                info!(target: "non_secrets_command_executor", "OpenSearch command received");
+                debug!(target: "non_secrets_command_executor", "OpenSearch command received");
                 cb(self.open_search(handle, &type_, &query_json, &options_json));
             }
             NonSecretsCommand::FetchSearchNextRecords(wallet_handle, wallet_search_handle, count, cb) => {
-                info!(target: "non_secrets_command_executor", "SearchNextRecords command received");
+                debug!(target: "non_secrets_command_executor", "SearchNextRecords command received");
                 cb(self.fetch_search_next_records(wallet_handle, wallet_search_handle, count));
             }
             NonSecretsCommand::CloseSearch(wallet_search_handle, cb) => {
-                info!(target: "non_secrets_command_executor", "CloseSearch command received");
+                debug!(target: "non_secrets_command_executor", "CloseSearch command received");
                 cb(self.close_search(wallet_search_handle));
             }
         };

--- a/libindy/src/commands/pairwise.rs
+++ b/libindy/src/commands/pairwise.rs
@@ -47,23 +47,23 @@ impl PairwiseCommandExecutor {
     pub fn execute(&self, command: PairwiseCommand) {
         match command {
             PairwiseCommand::PairwiseExists(wallet_handle, their_did, cb) => {
-                info!(target: "pairwise_command_executor", "PairwiseExists command received");
+                debug!(target: "pairwise_command_executor", "PairwiseExists command received");
                 cb(self.pairwise_exists(wallet_handle, &their_did));
             }
             PairwiseCommand::CreatePairwise(wallet_handle, their_did, my_did, metadata, cb) => {
-                info!(target: "pairwise_command_executor", "CreatePairwise command received");
+                debug!(target: "pairwise_command_executor", "CreatePairwise command received");
                 cb(self.create_pairwise(wallet_handle, &their_did, &my_did, metadata.as_ref().map(String::as_str)));
             }
             PairwiseCommand::ListPairwise(wallet_handle, cb) => {
-                info!(target: "pairwise_command_executor", "ListPairwise command received");
+                debug!(target: "pairwise_command_executor", "ListPairwise command received");
                 cb(self.list_pairwise(wallet_handle));
             }
             PairwiseCommand::GetPairwise(wallet_handle, their_did, cb) => {
-                info!(target: "pairwise_command_executor", "GetPairwise command received");
+                debug!(target: "pairwise_command_executor", "GetPairwise command received");
                 cb(self.get_pairwise(wallet_handle, &their_did));
             }
             PairwiseCommand::SetPairwiseMetadata(wallet_handle, their_did, metadata, cb) => {
-                info!(target: "pairwise_command_executor", "SetPairwiseMetadata command received");
+                debug!(target: "pairwise_command_executor", "SetPairwiseMetadata command received");
                 cb(self.set_pairwise_metadata(wallet_handle, &their_did, metadata.as_ref().map(String::as_str)));
             }
         };

--- a/libindy/src/commands/payments.rs
+++ b/libindy/src/commands/payments.rs
@@ -194,71 +194,71 @@ impl PaymentsCommandExecutor {
     pub fn execute(&self, command: PaymentsCommand) {
         match command {
             PaymentsCommand::RegisterMethod(type_, method_cbs, cb) => {
-                info!(target: "payments_command_executor", "RegisterMethod command received");
+                debug!(target: "payments_command_executor", "RegisterMethod command received");
                 cb(self.register_method(&type_, method_cbs));
             }
             PaymentsCommand::CreateAddress(wallet_handle, type_, config, cb) => {
-                info!(target: "payments_command_executor", "CreateAddress command received");
+                debug!(target: "payments_command_executor", "CreateAddress command received");
                 self.create_address(wallet_handle, &type_, &config, cb);
             }
             PaymentsCommand::CreateAddressAck(handle, wallet_handle, result) => {
-                info!(target: "payments_command_executor", "CreateAddressAck command received");
+                debug!(target: "payments_command_executor", "CreateAddressAck command received");
                 self.create_address_ack(handle, wallet_handle, result);
             }
             PaymentsCommand::ListAddresses(wallet_handle, cb) => {
-                info!(target: "payments_command_executor", "ListAddresses command received");
+                debug!(target: "payments_command_executor", "ListAddresses command received");
                 self.list_addresses(wallet_handle, cb);
             }
             PaymentsCommand::AddRequestFees(wallet_handle, submitter_did, req, inputs, outputs, extra, cb) => {
-                info!(target: "payments_command_executor", "AddRequestFees command received");
+                debug!(target: "payments_command_executor", "AddRequestFees command received");
                 self.add_request_fees(wallet_handle, submitter_did.as_ref().map(String::as_str), &req, &inputs, &outputs, extra.as_ref().map(String::as_str), cb);
             }
             PaymentsCommand::AddRequestFeesAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "AddRequestFeesAck command received");
+                debug!(target: "payments_command_executor", "AddRequestFeesAck command received");
                 self.add_request_fees_ack(cmd_handle, result);
             }
             PaymentsCommand::ParseResponseWithFees(type_, response, cb) => {
-                info!(target: "payments_command_executor", "ParseResponseWithFees command received");
+                debug!(target: "payments_command_executor", "ParseResponseWithFees command received");
                 self.parse_response_with_fees(&type_, &response, cb);
             }
             PaymentsCommand::ParseResponseWithFeesAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "ParseResponseWithFeesAck command received");
+                debug!(target: "payments_command_executor", "ParseResponseWithFeesAck command received");
                 self.parse_response_with_fees_ack(cmd_handle, result);
             }
             PaymentsCommand::BuildGetPaymentSourcesRequest(wallet_handle, submitter_did, payment_address, from, cb) => {
-                info!(target: "payments_command_executor", "BuildGetPaymentSourcesRequest command received");
+                debug!(target: "payments_command_executor", "BuildGetPaymentSourcesRequest command received");
                 self.build_get_payment_sources_request(wallet_handle, submitter_did.as_ref().map(String::as_str), &payment_address, from, cb);
             }
             PaymentsCommand::BuildGetPaymentSourcesRequestAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "BuildGetPaymentSourcesRequestAck command received");
+                debug!(target: "payments_command_executor", "BuildGetPaymentSourcesRequestAck command received");
                 self.build_get_payment_sources_request_ack(cmd_handle, result);
             }
             PaymentsCommand::ParseGetPaymentSourcesResponse(type_, response, cb) => {
-                info!(target: "payments_command_executor", "ParseGetPaymentSourcesResponse command received");
+                debug!(target: "payments_command_executor", "ParseGetPaymentSourcesResponse command received");
                 self.parse_get_payment_sources_response(&type_, &response, cb);
             }
             PaymentsCommand::ParseGetPaymentSourcesResponseAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "ParseGetPaymentSourcesResponseAck command received");
+                debug!(target: "payments_command_executor", "ParseGetPaymentSourcesResponseAck command received");
                 self.parse_get_payment_sources_response_ack(cmd_handle, result);
             }
             PaymentsCommand::BuildPaymentReq(wallet_handle, submitter_did, inputs, outputs, extra, cb) => {
-                info!(target: "payments_command_executor", "BuildPaymentReq command received");
+                debug!(target: "payments_command_executor", "BuildPaymentReq command received");
                 self.build_payment_req(wallet_handle, submitter_did.as_ref().map(String::as_str), &inputs, &outputs, extra.as_ref().map(String::as_str), cb);
             }
             PaymentsCommand::BuildPaymentReqAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "BuildPaymentReqAck command received");
+                debug!(target: "payments_command_executor", "BuildPaymentReqAck command received");
                 self.build_payment_req_ack(cmd_handle, result);
             }
             PaymentsCommand::ParsePaymentResponse(payment_method, response, cb) => {
-                info!(target: "payments_command_executor", "ParsePaymentResponse command received");
+                debug!(target: "payments_command_executor", "ParsePaymentResponse command received");
                 self.parse_payment_response(&payment_method, &response, cb);
             }
             PaymentsCommand::ParsePaymentResponseAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "ParsePaymentResponseAck command received");
+                debug!(target: "payments_command_executor", "ParsePaymentResponseAck command received");
                 self.parse_payment_response_ack(cmd_handle, result);
             }
             PaymentsCommand::AppendTxnAuthorAgreementAcceptanceToExtra(extra, text, version, taa_digest, mechanism, time, cb) => {
-                info!(target: "payments_command_executor", "AppendTxnAuthorAgreementAcceptanceToExtra command received");
+                debug!(target: "payments_command_executor", "AppendTxnAuthorAgreementAcceptanceToExtra command received");
                 cb(self.append_txn_author_agreement_acceptance_to_extra(extra.as_ref().map(String::as_str),
                                                                         text.as_ref().map(String::as_str),
                                                                         version.as_ref().map(String::as_str),
@@ -267,71 +267,71 @@ impl PaymentsCommandExecutor {
                                                                         time));
             }
             PaymentsCommand::BuildMintReq(wallet_handle, submitter_did, outputs, extra, cb) => {
-                info!(target: "payments_command_executor", "BuildMintReq command received");
+                debug!(target: "payments_command_executor", "BuildMintReq command received");
                 self.build_mint_req(wallet_handle, submitter_did.as_ref().map(String::as_str), &outputs, extra.as_ref().map(String::as_str), cb);
             }
             PaymentsCommand::BuildMintReqAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "BuildMintReqAck command received");
+                debug!(target: "payments_command_executor", "BuildMintReqAck command received");
                 self.build_mint_req_ack(cmd_handle, result);
             }
             PaymentsCommand::BuildSetTxnFeesReq(wallet_handle, submitter_did, type_, fees, cb) => {
-                info!(target: "payments_command_executor", "BuildSetTxnFeesReq command received");
+                debug!(target: "payments_command_executor", "BuildSetTxnFeesReq command received");
                 self.build_set_txn_fees_req(wallet_handle, submitter_did.as_ref().map(String::as_str), &type_, &fees, cb);
             }
             PaymentsCommand::BuildSetTxnFeesReqAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "BuildSetTxnFeesReqAck command received");
+                debug!(target: "payments_command_executor", "BuildSetTxnFeesReqAck command received");
                 self.build_set_txn_fees_req_ack(cmd_handle, result);
             }
             PaymentsCommand::BuildGetTxnFeesReq(wallet_handle, submitter_did, type_, cb) => {
-                info!(target: "payments_command_executor", "BuildGetTxnFeesReq command received");
+                debug!(target: "payments_command_executor", "BuildGetTxnFeesReq command received");
                 self.build_get_txn_fees_req(wallet_handle, submitter_did.as_ref().map(String::as_str), &type_, cb);
             }
             PaymentsCommand::BuildGetTxnFeesReqAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "BuildGetTxnFeesReqAck command received");
+                debug!(target: "payments_command_executor", "BuildGetTxnFeesReqAck command received");
                 self.build_get_txn_fees_req_ack(cmd_handle, result);
             }
             PaymentsCommand::ParseGetTxnFeesResponse(type_, response, cb) => {
-                info!(target: "payments_command_executor", "ParseGetTxnFeesResponse command received");
+                debug!(target: "payments_command_executor", "ParseGetTxnFeesResponse command received");
                 self.parse_get_txn_fees_response(&type_, &response, cb);
             }
             PaymentsCommand::ParseGetTxnFeesResponseAck(cmd_handle, result) => {
-                info!(target: "payments_command_executor", "ParseGetTxnFeesResponseAck command received");
+                debug!(target: "payments_command_executor", "ParseGetTxnFeesResponseAck command received");
                 self.parse_get_txn_fees_response_ack(cmd_handle, result);
             }
             PaymentsCommand::BuildVerifyPaymentReq(wallet_handle, submitter_did, receipt, cb) => {
-                info!(target: "payments_command_executor", "BuildVerifyPaymentReq command received");
+                debug!(target: "payments_command_executor", "BuildVerifyPaymentReq command received");
                 self.build_verify_payment_request(wallet_handle, submitter_did.as_ref().map(String::as_str), &receipt, cb);
             }
             PaymentsCommand::BuildVerifyPaymentReqAck(command_handle, result) => {
-                info!(target: "payments_command_executor", "BuildVerifyReqAck command received");
+                debug!(target: "payments_command_executor", "BuildVerifyReqAck command received");
                 self.build_verify_payment_request_ack(command_handle, result);
             }
             PaymentsCommand::ParseVerifyPaymentResponse(payment_method, resp_json, cb) => {
-                info!(target: "payments_command_executor", "ParseVerifyPaymentResponse command received");
+                debug!(target: "payments_command_executor", "ParseVerifyPaymentResponse command received");
                 self.parse_verify_payment_response(&payment_method, &resp_json, cb);
             }
             PaymentsCommand::ParseVerifyPaymentResponseAck(command_handle, result) => {
-                info!(target: "payments_command_executor", "ParseVerifyResponseAck command received");
+                debug!(target: "payments_command_executor", "ParseVerifyResponseAck command received");
                 self.parse_verify_payment_response_ack(command_handle, result);
             }
             PaymentsCommand::GetRequestInfo(get_auth_rule_response_json, requester_info, fees_json, cb) => {
-                info!(target: "payments_command_executor", "GetRequestInfo command received");
+                debug!(target: "payments_command_executor", "GetRequestInfo command received");
                 cb(self.get_request_info(&get_auth_rule_response_json, requester_info, &fees_json));
 	        },
             PaymentsCommand::SignWithAddressReq(wallet_handle, address, message, cb) => {
-                info!(target: "payments_command_executor", "SignWithAddressReq command received");
+                debug!(target: "payments_command_executor", "SignWithAddressReq command received");
                 self.sign_with_address(wallet_handle, &address, message.as_slice(), cb);
             },
             PaymentsCommand::SignWithAddressAck(command_handle, result) => {
-                info!(target: "payments_command_executor", "SignWithAddressAck command received");
+                debug!(target: "payments_command_executor", "SignWithAddressAck command received");
                 self.sign_with_address_ack(command_handle, result);
             },
             PaymentsCommand::VerifyWithAddressReq(address, message, signature, cb) => {
-                info!(target: "payments_command_executor", "VerifyWithAddressReq command received");
+                debug!(target: "payments_command_executor", "VerifyWithAddressReq command received");
                 self.verify_with_address(&address, message.as_slice(), signature.as_slice(), cb);
             },
             PaymentsCommand::VerifyWithAddressAck(command_handle, result) => {
-                 info!(target: "payments_command_executor", "VerifyWithAddressAck command received");
+                 debug!(target: "payments_command_executor", "VerifyWithAddressAck command received");
                 self.verify_with_address_ack(command_handle, result);
             }
         }

--- a/libindy/src/commands/pool.rs
+++ b/libindy/src/commands/pool.rs
@@ -60,15 +60,15 @@ impl PoolCommandExecutor {
     pub fn execute(&self, command: PoolCommand) {
         match command {
             PoolCommand::Create(name, config, cb) => {
-                info!(target: "pool_command_executor", "Create command received");
+                debug!(target: "pool_command_executor", "Create command received");
                 cb(self.create(&name, config));
             }
             PoolCommand::Delete(name, cb) => {
-                info!(target: "pool_command_executor", "Delete command received");
+                debug!(target: "pool_command_executor", "Delete command received");
                 cb(self.delete(&name));
             }
             PoolCommand::Open(name, config, cb) => {
-                info!(target: "pool_command_executor", "Open command received");
+                debug!(target: "pool_command_executor", "Open command received");
                 self.open(&name, config, cb);
             }
             PoolCommand::OpenAck(handle, pool_id, result) => {
@@ -88,15 +88,15 @@ impl PoolCommandExecutor {
                 }
             }
             PoolCommand::List(cb) => {
-                info!(target: "pool_command_executor", "List command received");
+                debug!(target: "pool_command_executor", "List command received");
                 cb(self.list());
             }
             PoolCommand::Close(handle, cb) => {
-                info!(target: "pool_command_executor", "Close command received");
+                debug!(target: "pool_command_executor", "Close command received");
                 self.close(handle, cb);
             }
             PoolCommand::CloseAck(handle, result) => {
-                info!(target: "pool_command_executor", "CloseAck command received");
+                debug!(target: "pool_command_executor", "CloseAck command received");
                 match self.close_callbacks.try_borrow_mut() {
                     Ok(mut cbs) => {
                         match cbs.remove(&handle) {
@@ -110,11 +110,11 @@ impl PoolCommandExecutor {
                 }
             }
             PoolCommand::Refresh(handle, cb) => {
-                info!(target: "pool_command_executor", "Refresh command received");
+                debug!(target: "pool_command_executor", "Refresh command received");
                 self.refresh(handle, cb);
             }
             PoolCommand::RefreshAck(handle, result) => {
-                info!(target: "pool_command_executor", "RefreshAck command received");
+                debug!(target: "pool_command_executor", "RefreshAck command received");
                 match self.refresh_callbacks.try_borrow_mut() {
                     Ok(mut cbs) => {
                         match cbs.remove(&handle) {
@@ -129,7 +129,7 @@ impl PoolCommandExecutor {
                 }
             }
             PoolCommand::SetProtocolVersion(protocol_version, cb) => {
-                info!(target: "pool_command_executor", "SetProtocolVersion command received");
+                debug!(target: "pool_command_executor", "SetProtocolVersion command received");
                 cb(self.set_protocol_version(protocol_version));
             }
         };


### PR DESCRIPTION
Production systems typically log at an INFO level. The number of
"command received" messages is high which creates a great deal of "noise" in the
logs. The "command received" log messages feel better suited for debugging and
thus have been moved to the DEBUG level.

Signed-off-by: Corin Kochenower <corin.kochenower@evernym.com>