### PR TITLE
Fix state restoration bug in dummy cloud agent

### DIFF
--- a/vcx/dummy-cloud-agent/src/actors/agent_connection.rs
+++ b/vcx/dummy-cloud-agent/src/actors/agent_connection.rs
@@ -191,10 +191,19 @@ impl AgentConnection {
 
                 let agent_connection = agent_connection.start();
 
-                router
+                let add_route_f = router
                     .send(AddA2ARoute(agent_pairwise_did.clone(), agent_connection.clone().recipient()))
                     .from_err()
-                    .map_err(|err: Error| err.context("Can't add route for Agent Connection.").into())
+                    .map_err(|err: Error| err.context("Can't add A2A route for Agent Connection.").into());
+
+                let add_conn_route_f = router
+                    .send(AddA2ConnRoute(agent_pairwise_did.clone(), agent_connection.clone().recipient()))
+                    .from_err()
+                    .map_err(|err: Error| err.context("Can't add A2AConnection route for Agent Connection.").into());
+
+                add_route_f
+                    .join(add_conn_route_f)
+                    .map(|_| ())
             })
             .into_box()
     }


### PR DESCRIPTION
Agent connections were not properly registered in Router actor on restoration. Agent connections can now be still used after agency restart.