### PR TITLE
Produce useful logs in debug level in dummy cloud agency

### DIFF
--- a/vcx/dummy-cloud-agent/src/actors/agent.rs
+++ b/vcx/dummy-cloud-agent/src/actors/agent.rs
@@ -261,7 +261,7 @@ impl Agent {
     fn handle_agent_msg_v1(&mut self,
                            sender_vk: String,
                            msg: A2AMessageV1) -> ResponseActFuture<Self, Vec<u8>, Error> {
-        trace!("Agent::handle_agent_msg_v1 >> {:?}, {:?}", sender_vk, msg);
+        debug!("Agent::handle_agent_msg_v1 >> {:?}, {:?}", sender_vk, msg);
 
         match msg {
             A2AMessageV1::CreateKey(msg) => self.handle_create_key_v1(msg),
@@ -285,7 +285,7 @@ impl Agent {
     fn handle_agent_msg_v2(&mut self,
                            sender_vk: String,
                            msg: A2AMessageV2) -> ResponseActFuture<Self, Vec<u8>, Error> {
-        trace!("Agent::handle_agent_msg_v2 >> {:?}, {:?}", sender_vk, msg);
+        debug!("Agent::handle_agent_msg_v2 >> {:?}, {:?}", sender_vk, msg);
 
         match msg {
             A2AMessageV2::CreateKey(msg) => self.handle_create_key_v2(msg),

--- a/vcx/dummy-cloud-agent/src/actors/agent_connection.rs
+++ b/vcx/dummy-cloud-agent/src/actors/agent_connection.rs
@@ -219,6 +219,7 @@ impl AgentConnection {
                     .into_actor(slf)
             })
             .and_then(|(sender_vk, msg, msgs), slf, _| {
+                debug!("AgentConnection::handle_a2a_msg >> {:?}", msg);
                 match msg {
                     Some(A2AMessage::Version1(msg)) => {
                         match msg {


### PR DESCRIPTION
Previously `debug` level basically didn't produce any logs whereas `trace` prints out too low level data (such as exact bytes in all vectors passed around).

Signed-off-by: Patrik Stas <patrik.stas@absa.co.za>