### PR TITLE
Fix bug where logo is never set for the agent

### DIFF
--- a/vcx/dummy-cloud-agent/src/actors/agent.rs
+++ b/vcx/dummy-cloud-agent/src/actors/agent.rs
@@ -581,7 +581,7 @@ impl Agent {
     fn handle_update_configs(&mut self, msg: UpdateConfigs) -> ResponseActFuture<Self, (), Error> {
         for config_option in msg.configs {
             match config_option.name.as_str() {
-                "name" | "logo_url" => self.configs.insert(config_option.name, config_option.value),
+                "name" | "logoUrl" => self.configs.insert(config_option.name, config_option.value),
                 _ => continue
             };
         }
@@ -801,7 +801,7 @@ mod tests {
 
                     assert_eq!(configs.len(), 2);
                     assert!(configs.contains(&ConfigOption { name: "name".to_string(), value: "super agent".to_string() }));
-                    assert!(configs.contains(&ConfigOption { name: "logo_url".to_string(), value: "http://logo.url".to_string() }));
+                    assert!(configs.contains(&ConfigOption { name: "logoUrl".to_string(), value: "http://logo.url".to_string() }));
 
                     let msg = compose_remove_configs(e_wallet_handle,
                                                      &agent_did,
@@ -827,7 +827,7 @@ mod tests {
 
                     assert_eq!(configs.len(), 1);
                     assert!(!configs.contains(&ConfigOption { name: "name".to_string(), value: "super agent".to_string() }));
-                    assert!(configs.contains(&ConfigOption { name: "logo_url".to_string(), value: "http://logo.url".to_string() }));
+                    assert!(configs.contains(&ConfigOption { name: "logoUrl".to_string(), value: "http://logo.url".to_string() }));
 
                     wallet::close_wallet(e_wallet_handle).wait().unwrap();
                 })

--- a/vcx/dummy-cloud-agent/src/actors/agent_connection.rs
+++ b/vcx/dummy-cloud-agent/src/actors/agent_connection.rs
@@ -1218,7 +1218,7 @@ impl AgentConnection {
                 verkey: self.user_pairwise_verkey.clone(),
                 agent_key_dlg_proof: msg_detail.key_dlg_proof.clone(),
                 name: self.agent_configs.get("name").cloned(),
-                logo_url: self.agent_configs.get("logo_url").cloned(),
+                logo_url: self.agent_configs.get("logoUrl").cloned(),
                 public_did: Some(self.owner_did.clone()),
             },
             status_code: msg.status_code.clone(),

--- a/vcx/dummy-cloud-agent/src/utils/tests.rs
+++ b/vcx/dummy-cloud-agent/src/utils/tests.rs
@@ -569,7 +569,7 @@ pub fn compose_update_configs(wallet_handle: i32, agent_did: &str, agent_verkey:
             configs: vec![
                 ConfigOption {name: "zoom_zoom".to_string(), value: "value".to_string()},
                 ConfigOption {name: "name".to_string(), value: "super agent".to_string()},
-                ConfigOption {name: "logo_url".to_string(), value: "http://logo.url".to_string()}
+                ConfigOption {name: "logoUrl".to_string(), value: "http://logo.url".to_string()}
             ]
         }))];
 
@@ -584,7 +584,7 @@ pub fn compose_update_configs(wallet_handle: i32, agent_did: &str, agent_verkey:
 pub fn compose_get_configs(wallet_handle: i32, agent_did: &str, agent_verkey: &str) -> BoxedFuture<Vec<u8>, Error> {
     let msgs = [A2AMessage::Version1(A2AMessageV1::GetConfigs(
         GetConfigs {
-            configs: vec![String::from("name"), String::from("logo_url")]
+            configs: vec![String::from("name"), String::from("logoUrl")]
         }))];
 
     let msg = A2AMessage::prepare_authcrypted(wallet_handle,


### PR DESCRIPTION
The presumption was that vcx is sending configuration option "logo_url", whereas vcx is actually sending "logoUrl" as you can see in the configuration builder here:

https://github.com/hyperledger/indy-sdk/blob/master/vcx/libvcx/src/messages/update_profile.rs#L59