### PR TITLE
[IS-1382] Makes pyzmq version 17.0.0 dependency explicit

### DIFF
--- a/ci/indy-pool.dockerfile
+++ b/ci/indy-pool.dockerfile
@@ -28,8 +28,10 @@ ARG indy_plenum_ver=1.9.2~dev871
 ARG indy_node_ver=1.9.2~dev1061
 ARG python3_indy_crypto_ver=0.4.5
 ARG indy_crypto_ver=0.4.5
+ARG python3_pyzmq_ver=17.0.0
 
 RUN apt-get update -y && apt-get install -y \
+        python3-pyzmq=${python3_pyzmq_ver} \
         indy-plenum=${indy_plenum_ver} \
         indy-node=${indy_node_ver} \
         python3-indy-crypto=${python3_indy_crypto_ver} \


### PR DESCRIPTION
Building the docker image for running the test pool on localhost (https://github.com/hyperledger/indy-sdk#1-starting-the-test-pool-on-localhost) raised an error: python3-pyzmq version 18.x.x was available, but 17.0.0 needed. This PR makes the dependency on version 17.0.0 explicit.

Solves https://jira.hyperledger.org/browse/IS-1382.