### PR TITLE
Node.js Sample: renamed function utils.pathToIndyClientHome to utils.getPathToIndyCli…

### DIFF
--- a/samples/nodejs/src/util.js
+++ b/samples/nodejs/src/util.js
@@ -33,7 +33,7 @@ async function mkdir(filePath) {
     })
 }
 
-function pathToIndyClientHome() {
+function getPathToIndyClientHome() {
     return require('os').homedir() + "/.indy_client"
 }
 


### PR DESCRIPTION
…entHome. This fixes a crash that occurs when running anoncredsRevocation.js