### PR TITLE
Update Nuget package name

### DIFF
--- a/wrappers/dotnet/indy-sdk-dotnet/indy-sdk-dotnet.csproj
+++ b/wrappers/dotnet/indy-sdk-dotnet/indy-sdk-dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452;xamarinios10</TargetFrameworks>
-    <AssemblyName>Hyperledger.Indy.Sdk</AssemblyName>
+    <AssemblyName>Hyperledger.Indy</AssemblyName>
     <RootNamespace>Hyperledger.Indy</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.11.1</Version>
@@ -17,14 +17,14 @@ Please note that to function the C-Callable Hyperledger Indy SDK and its depende
     <RepositoryUrl>https://github.com/hyperledger/indy-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>hyperledger indy sdk</PackageTags>
-    <PackageLicenseUrl>https://github.com/hyperledger/indy-sdk/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl></PackageIconUrl>
     <AssemblyVersion>1.11.1</AssemblyVersion>
     <FileVersion>1.11.1</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Hyperledger.Indy.Sdk.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Hyperledger.Indy.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Package name changed form 'Hyperledger.Indy.Sdk' to 'Hyperledger.Indy' due to conflicts with package updates. The package Hyperledger.Indy is owned by Hyperledger nuget account and we'll be able to do regular updates.
I was not able to establish contact with the owner of 'Hyperledger.Indy.Sdk' @srottem and transfer ownership.

Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>
