### PR TITLE
warning: Matching on `Some` with `ok()` is redundant

### DIFF
--- a/libindy/src/services/pool/state_proof/mod.rs
+++ b/libindy/src/services/pool/state_proof/mod.rs
@@ -652,7 +652,7 @@ fn _verify_proof_range(proofs_rlp: &[u8],
     map.get(root_hash).map(|root| {
         let res = root.get_all_values(&map, Some(prefix.as_bytes())).map_err(map_err_err!());
         trace!("All values from trie: {:?}", res);
-        let vals = if let Some(vals) = res.ok() {
+        let vals = if let Ok(vals) = res {
             vals
         } else {
             error!("Some errors happened while collecting values from state proof");

--- a/libindy/src/services/pool/state_proof/mod.rs
+++ b/libindy/src/services/pool/state_proof/mod.rs
@@ -645,7 +645,7 @@ fn _verify_proof_range(proofs_rlp: &[u8],
                        kvs: &[(String, Option<String>)]) -> bool {
     debug!("verify_proof_range >> from {:?}, prefix {:?}, kvs {:?}", from, prefix, kvs);
     let nodes: Vec<Node> = UntrustedRlp::new(proofs_rlp).as_list().unwrap_or_default(); //default will cause error below
-    let mut map: TrieDB = HashMap::new();
+    let mut map: TrieDB = HashMap::with_capacity(nodes.len());
     for node in &nodes {
         map.insert(node.get_hash(), node);
     }


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

Removing clippy warning
Matching on `Some` with `ok()` is redundant