### PR TITLE
VCX Agency Admin api security/stability optimizations

### DIFF
--- a/vcx/dummy-cloud-agent/config/pgsql-config.json
+++ b/vcx/dummy-cloud-agent/config/pgsql-config.json
@@ -1,7 +1,6 @@
 {
   "app": {
-    "prefix": "/agency",
-    "enable_admin_api": true
+    "prefix": "/agency"
   },
   "forward_agent": {
     "did": "VsKV7grR1BUE29mG2Fm2kX",
@@ -15,6 +14,12 @@
       "127.0.0.1:8080"
     ],
     "workers": 1
+  },
+  "server_admin": {
+    "enabled": false,
+    "addresses": [
+      "127.0.0.1:8090"
+    ]
   },
   "wallet_storage": {
     "config": {

--- a/vcx/dummy-cloud-agent/config/sample-config.json
+++ b/vcx/dummy-cloud-agent/config/sample-config.json
@@ -1,7 +1,6 @@
 {
   "app": {
-    "prefix": "/agency",
-    "enable_admin_api": false
+    "prefix": "/agency"
   },
   "forward_agent": {
     "did": "VsKV7grR1BUE29mG2Fm2kX",
@@ -16,6 +15,12 @@
       "127.0.0.1:8081"
     ],
     "workers": 2
+  },
+  "server_admin": {
+    "enabled": false,
+    "addresses": [
+      "127.0.0.1:8090"
+    ]
   },
   "wallet_storage": {
     "config": null,

--- a/vcx/dummy-cloud-agent/src/actors/forward_agent.rs
+++ b/vcx/dummy-cloud-agent/src/actors/forward_agent.rs
@@ -31,7 +31,6 @@ impl ForwardAgent {
                              admin: Option<Addr<Admin>>) -> ResponseFuture<Addr<ForwardAgent>, Error> {
         debug!("ForwardAgent::create_or_restore >> {:?} {:?}", config, wallet_storage_config);
         let admin1 = admin.clone();
-        let admin2 = admin.clone();
         future::ok(())
             .and_then(move |_| {
                 // Ensure Forward Agent wallet created

--- a/vcx/dummy-cloud-agent/src/app.rs
+++ b/vcx/dummy-cloud-agent/src/app.rs
@@ -6,12 +6,13 @@ use actors::admin::Admin;
 use bytes::Bytes;
 use domain::config::{AppConfig, ServerConfig};
 use domain::admin_message::{AdminQuery, GetDetailAgentParams, GetDetailAgentConnParams};
-use actix_web::web::{Data};
+use actix_web::web::Data;
+use futures::future;
+use futures::future::Either;
 
 pub struct AppData {
     pub forward_agent: Addr<ForwardAgent>,
-    pub admin_agent: Addr<Admin>,
-    pub sometext: String,
+    pub admin_agent: Option<Addr<Admin>>,
 }
 
 #[derive(Deserialize)]
@@ -19,43 +20,42 @@ struct AgentParams {
     did: String,
 }
 
-pub fn start_app_server(server_config: ServerConfig, app_config: AppConfig, forward_agent: Addr<ForwardAgent>, admin_agent: Addr<Admin>) {
-    info!("Forward Agent started");
-    info!("Starting Server with config: {:?}", server_config);
+pub fn start_app_server(server_config: ServerConfig, app_config: AppConfig, forward_agent: Addr<ForwardAgent>, admin_agent: Option<Addr<Admin>>) {
+    info!("Creating HttpServer with config: {:?}", server_config);
     let mut server = HttpServer::new(move || {
         info!("Starting App with config: {:?}", app_config);
+        let enable_admin_api = admin_agent.as_ref().map_or( false, |_| true);
         let app = App::new()
-            .data(AppData { admin_agent: admin_agent.clone(), forward_agent: forward_agent.clone(), sometext: "Footext".to_string() })
+            .data(AppData { admin_agent: admin_agent.clone(), forward_agent: forward_agent.clone() })
             .wrap(middleware::Logger::default())
             .service(
-                web::resource("/agency")
+                web::resource(&app_config.prefix)
                     .route(web::get().to(_get_endpoint_details))
             )
             .service(
-                web::resource("/agency/msg")
+                web::resource(&format!("{}/msg", app_config.prefix))
                     .route(web::post().to(_forward_message))
             );
-        match app_config.enable_admin_api {
-            Some(enable_admin_api) if enable_admin_api => {
-                app
-                    .service(
-                        web::resource("/admin")
-                            .route(web::get().to(_get_actor_overview))
-                    )
-                    .service(
-                        web::resource("/admin/forward-agent")
-                            .route(web::get().to(_get_forward_agent_details))
-                    )
-                    .service(
-                        web::resource("/admin/agent/{did}")
-                            .route(web::get().to(_get_agent_details))
-                    )
-                    .service(
-                        web::resource("/admin/agent-connection/{did}")
-                            .route(web::get().to(_get_agent_connection_details))
-                    )
-            }
-            _ => app
+        if enable_admin_api {
+            app
+                .service(
+                    web::resource("/admin")
+                        .route(web::get().to(_get_actor_overview))
+                )
+                .service(
+                    web::resource("/admin/forward-agent")
+                        .route(web::get().to(_get_forward_agent_details))
+                )
+                .service(
+                    web::resource("/admin/agent/{did}")
+                        .route(web::get().to(_get_agent_details))
+                )
+                .service(
+                    web::resource("/admin/agent-connection/{did}")
+                        .route(web::get().to(_get_agent_connection_details))
+                )
+        } else {
+            app
         }
     });
     if let Some(workers) = server_config.workers {
@@ -83,16 +83,24 @@ fn _get_endpoint_details(state: Data<AppData>) -> Box<Future<Item=HttpResponse, 
 }
 
 fn _send_admin_message(state: Data<AppData>, admin_msg: HandleAdminMessage) -> Box<Future<Item=HttpResponse, Error=Error>> {
-    let f = state.admin_agent
-        .send(admin_msg)
-        .from_err()
-        .map(|res| match res {
-            Ok(agent_details) => HttpResponse::Ok().json(&agent_details),
-            Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)).into(), // FIXME: Better error
-        });
+    let f = match &state.admin_agent {
+        Some(admin) => {
+            Either::A(
+                admin
+                    .send(admin_msg)
+                    .from_err()
+                    .map(|res| match res {
+                        Ok(agent_details) => HttpResponse::Ok().json(&agent_details),
+                        Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)).into(),
+                    }))
+        }
+        None => {
+            Either::B(future::ok(HttpResponse::InternalServerError().body("Admin actor not found.").into()))
+        }
+    };
     Box::new(f)
 }
-//
+
 fn _get_agent_connection_details(state: Data<AppData>, info: web::Path<AgentParams>) -> Box<Future<Item=HttpResponse, Error=Error>> {
     let msg = HandleAdminMessage(AdminQuery::GetDetailAgentConnection(GetDetailAgentConnParams { agent_pairwise_did: info.did.clone() }));
     _send_admin_message(state, msg)

--- a/vcx/dummy-cloud-agent/src/app.rs
+++ b/vcx/dummy-cloud-agent/src/app.rs
@@ -1,31 +1,23 @@
 use actix::prelude::*;
 use actix_web::*;
-use actors::{ForwardA2AMsg, GetEndpoint, HandleAdminMessage};
-use actors::forward_agent::ForwardAgent;
-use actors::admin::Admin;
-use bytes::Bytes;
-use domain::config::{AppConfig, ServerConfig};
-use domain::admin_message::{AdminQuery, GetDetailAgentParams, GetDetailAgentConnParams};
 use actix_web::web::Data;
-use futures::future;
-use futures::future::Either;
+use bytes::Bytes;
+
+use actors::{ForwardA2AMsg, GetEndpoint};
+use actors::admin::Admin;
+use actors::forward_agent::ForwardAgent;
+use domain::config::{AppConfig, ServerConfig};
 
 pub struct AppData {
     pub forward_agent: Addr<ForwardAgent>,
     pub admin_agent: Option<Addr<Admin>>,
 }
 
-#[derive(Deserialize)]
-struct AgentParams {
-    did: String,
-}
-
 pub fn start_app_server(server_config: ServerConfig, app_config: AppConfig, forward_agent: Addr<ForwardAgent>, admin_agent: Option<Addr<Admin>>) {
     info!("Creating HttpServer with config: {:?}", server_config);
     let mut server = HttpServer::new(move || {
         info!("Starting App with config: {:?}", app_config);
-        let enable_admin_api = admin_agent.as_ref().map_or( false, |_| true);
-        let app = App::new()
+        App::new()
             .data(AppData { admin_agent: admin_agent.clone(), forward_agent: forward_agent.clone() })
             .wrap(middleware::Logger::default())
             .service(
@@ -35,28 +27,7 @@ pub fn start_app_server(server_config: ServerConfig, app_config: AppConfig, forw
             .service(
                 web::resource(&format!("{}/msg", app_config.prefix))
                     .route(web::post().to(_forward_message))
-            );
-        if enable_admin_api {
-            app
-                .service(
-                    web::resource("/admin")
-                        .route(web::get().to(_get_actor_overview))
-                )
-                .service(
-                    web::resource("/admin/forward-agent")
-                        .route(web::get().to(_get_forward_agent_details))
-                )
-                .service(
-                    web::resource("/admin/agent/{did}")
-                        .route(web::get().to(_get_agent_details))
-                )
-                .service(
-                    web::resource("/admin/agent-connection/{did}")
-                        .route(web::get().to(_get_agent_connection_details))
-                )
-        } else {
-            app
-        }
+            )
     });
     if let Some(workers) = server_config.workers {
         server = server.workers(workers);
@@ -80,45 +51,6 @@ fn _get_endpoint_details(state: Data<AppData>) -> Box<Future<Item=HttpResponse, 
             Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)).into(), // FIXME: Better error
         });
     Box::new(f)
-}
-
-fn _send_admin_message(state: Data<AppData>, admin_msg: HandleAdminMessage) -> Box<Future<Item=HttpResponse, Error=Error>> {
-    let f = match &state.admin_agent {
-        Some(admin) => {
-            Either::A(
-                admin
-                    .send(admin_msg)
-                    .from_err()
-                    .map(|res| match res {
-                        Ok(agent_details) => HttpResponse::Ok().json(&agent_details),
-                        Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)).into(),
-                    }))
-        }
-        None => {
-            Either::B(future::ok(HttpResponse::InternalServerError().body("Admin actor not found.").into()))
-        }
-    };
-    Box::new(f)
-}
-
-fn _get_agent_connection_details(state: Data<AppData>, info: web::Path<AgentParams>) -> Box<Future<Item=HttpResponse, Error=Error>> {
-    let msg = HandleAdminMessage(AdminQuery::GetDetailAgentConnection(GetDetailAgentConnParams { agent_pairwise_did: info.did.clone() }));
-    _send_admin_message(state, msg)
-}
-
-fn _get_agent_details(state: Data<AppData>, info: web::Path<AgentParams>) -> Box<Future<Item=HttpResponse, Error=Error>> {
-    let msg = HandleAdminMessage(AdminQuery::GetDetailAgent(GetDetailAgentParams { agent_did: info.did.clone() }));
-    _send_admin_message(state, msg)
-}
-
-fn _get_actor_overview(state: Data<AppData>) -> Box<Future<Item=HttpResponse, Error=Error>> {
-    let msg = HandleAdminMessage(AdminQuery::GetActorOverview);
-    _send_admin_message(state, msg)
-}
-
-fn _get_forward_agent_details(state: Data<AppData>) -> Box<Future<Item=HttpResponse, Error=Error>> {
-    let msg = HandleAdminMessage(AdminQuery::GetDetailForwardAgents);
-    _send_admin_message(state, msg)
 }
 
 fn _forward_message(state: Data<AppData>, stream: web::Payload) -> Box<Future<Item=HttpResponse, Error=Error>> {

--- a/vcx/dummy-cloud-agent/src/app_admin.rs
+++ b/vcx/dummy-cloud-agent/src/app_admin.rs
@@ -1,0 +1,81 @@
+use actix::prelude::*;
+use actix_web::*;
+use actix_web::web::Data;
+
+use actors::HandleAdminMessage;
+use actors::admin::Admin;
+use domain::admin_message::{AdminQuery, GetDetailAgentConnParams, GetDetailAgentParams};
+use domain::config::ServerAdminConfig;
+
+pub struct AdminAppData {
+    pub admin_agent: Addr<Admin>,
+}
+
+#[derive(Deserialize)]
+struct AgentParams {
+    did: String,
+}
+
+pub fn start_app_admin_server(server_admin_config: &ServerAdminConfig, admin_agent: Addr<Admin>) {
+    info!("Creating Admin HttpServer using config {:?}", server_admin_config);
+    let mut server = HttpServer::new(move || {
+        App::new()
+            .data(AdminAppData { admin_agent: admin_agent.clone() })
+            .wrap(middleware::Logger::default())
+                .service(
+                    web::resource("/admin")
+                        .route(web::get().to(_get_actor_overview))
+                )
+                .service(
+                    web::resource("/admin/forward-agent")
+                        .route(web::get().to(_get_forward_agent_details))
+                )
+                .service(
+                    web::resource("/admin/agent/{did}")
+                        .route(web::get().to(_get_agent_details))
+                )
+                .service(
+                    web::resource("/admin/agent-connection/{did}")
+                        .route(web::get().to(_get_agent_connection_details))
+                )
+    });
+    for address in &server_admin_config.addresses {
+        server = server
+            .bind(address)
+            .expect(&format!("Can't bind to address {}.", address));
+    }
+    server.start();
+    info!("Admin Server started at addresses: {:?}.", server_admin_config.addresses);
+}
+
+fn _send_admin_message(state: Data<AdminAppData>, admin_msg: HandleAdminMessage) -> Box<Future<Item=HttpResponse, Error=Error>> {
+    let f = state.admin_agent
+                    .send(admin_msg)
+                    .from_err()
+                    .map(|res| match res {
+                        Ok(agent_details) => HttpResponse::Ok().json(&agent_details),
+                        Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)).into(),
+                    });
+    Box::new(f)
+}
+
+fn _get_agent_connection_details(state: Data<AdminAppData>, info: web::Path<AgentParams>) -> Box<Future<Item=HttpResponse, Error=Error>> {
+    let msg = HandleAdminMessage(AdminQuery::GetDetailAgentConnection(GetDetailAgentConnParams { agent_pairwise_did: info.did.clone() }));
+    _send_admin_message(state, msg)
+}
+
+fn _get_agent_details(state: Data<AdminAppData>, info: web::Path<AgentParams>) -> Box<Future<Item=HttpResponse, Error=Error>> {
+    let msg = HandleAdminMessage(AdminQuery::GetDetailAgent(GetDetailAgentParams { agent_did: info.did.clone() }));
+    _send_admin_message(state, msg)
+}
+
+fn _get_actor_overview(state: Data<AdminAppData>) -> Box<Future<Item=HttpResponse, Error=Error>> {
+    let msg = HandleAdminMessage(AdminQuery::GetActorOverview);
+    _send_admin_message(state, msg)
+}
+
+fn _get_forward_agent_details(state: Data<AdminAppData>) -> Box<Future<Item=HttpResponse, Error=Error>> {
+    let msg = HandleAdminMessage(AdminQuery::GetDetailForwardAgents);
+    _send_admin_message(state, msg)
+}
+

--- a/vcx/dummy-cloud-agent/src/domain/config.rs
+++ b/vcx/dummy-cloud-agent/src/domain/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub app: AppConfig,
     pub forward_agent: ForwardAgentConfig,
     pub server: ServerConfig,
+    pub server_admin: Option<ServerAdminConfig>,
     pub wallet_storage: WalletStorageConfig,
     pub protocol_type: Option<ProtocolTypes>,
     pub indy_runtime: Option<IndyRuntimeConfig>
@@ -28,9 +29,7 @@ pub struct ForwardAgentConfig {
 #[derive(Clone, Debug, Deserialize)]
 pub struct AppConfig {
     // Http application prefix
-    pub prefix: String,
-    // enable or disable http api for fetching information about agency status
-    pub enable_admin_api: Option<bool>
+    pub prefix: String
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -39,6 +38,14 @@ pub struct ServerConfig {
     pub addresses: Vec<String>,
     // Amount of http workers (instances of app). By default amount of logical CPU cores.
     pub workers: Option<usize>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ServerAdminConfig {
+    // enable or disable http api for fetching information about agency status
+    pub enabled: bool,
+    // List of ip:port to bind
+    pub addresses: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/vcx/dummy-cloud-agent/src/main.rs
+++ b/vcx/dummy-cloud-agent/src/main.rs
@@ -138,7 +138,7 @@ fn _start(config_path: &str) {
 
         ProtocolType::set(protocol_type_config);
 
-        let admin = Admin::create();
+        let admin = if app_config.enable_admin_api.unwrap_or(false) { Some(Admin::create()) } else { None };
         ForwardAgent::create_or_restore(forward_agent_config, wallet_storage_config, admin.clone())
             .map(move |forward_agent| {
                 start_app_server(server_config, app_config, forward_agent, admin)

--- a/vcx/dummy-cloud-agent/src/utils/tests.rs
+++ b/vcx/dummy-cloud-agent/src/utils/tests.rs
@@ -112,7 +112,7 @@ pub fn run_test<F, B>(f: F)
         Arbiter::spawn_fn(move || {
             future::ok(())
                 .and_then(move |_| {
-                    let admin = Admin::create();
+                    let admin = None;
                     ForwardAgent::create_or_restore(forward_agent_config(), wallet_storage_config(), admin)
                 })
                 .and_then(f)


### PR DESCRIPTION
`First commit:`

- A bit of backward improvement to previously submitted feature. 
If admin api is disabled, don't instantiate and use `admin` actor.
Also as I am submitting separate pull request adding `admin` actor 
unit tests, remove usage of `admin` from original unit tests to 
preserve original code flow where no `admin` is involved at all.
- Currently using hardcoded endpoint /agency instead of using 
prefix specified in config file. The bug was introduced by my 
earlier pull request https://github.com/hyperledger/indy-sdk/pull/1884


`Second commit`

- Removed config option app.enable_admin_api; instead added new
  root configuration field "server_admin" which can be used to
  enable/disable admin API and also to specify addresses where
  admin api http server should be binded to.
- Admin api is still disabled by default
- Can be enabled by specifying in config server_admin.enabled=true



Whichever this pull request or https://github.com/hyperledger/indy-sdk/pull/1940 will happen to be pulled in first, I'll then rebase the other one as there will be conflicts.