### PR TITLE
removed unused pub static mut variable

### DIFF
--- a/libindy/tests/utils/anoncreds.rs
+++ b/libindy/tests/utils/anoncreds.rs
@@ -21,7 +21,6 @@ use crate::utils::domain::anoncreds::credential::{AttributeValues, CredentialInf
 use crate::utils::domain::anoncreds::credential_for_proof_request::CredentialsForProofRequest;
 use crate::utils::domain::crypto::did::DidValue;
 
-pub static mut WALLET_HANDLE: i32 = 0;
 pub static mut CREDENTIAL_DEF_JSON: &'static str = "";
 pub static mut CREDENTIAL_OFFER_JSON: &'static str = "";
 pub static mut CREDENTIAL_REQUEST_JSON: &'static str = "";


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

This variable was unused to it was removed.

In general `pub static mut` are dangerous and an invitation to trouble in a multi-threaded environment like libindy. 