### PR TITLE
Temporary disable pipelines for MacOS and iOS.

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -49,8 +49,8 @@ def testing() {
                 'centos-test' : { centosTesting() },
                 'android-test': { androidTesting() },
                 'windows-test': { windowsTesting() },
-                'ios-test'    : { iosTesting() },
-                'macos-test'  : { macosTesting() }
+                // 'ios-test'    : { iosTesting() },
+                // 'macos-test'  : { macosTesting() }
         ])
     }
 }
@@ -63,8 +63,8 @@ def publishing() {
                 'ubuntu-files' : { ubuntuPublishing() },
                 'windows-files': { windowsPublishing() },
                 'android-files': { androidPublishing() },
-                'ios-files'    : { iosPublishing() },
-                'macos-files'  : { macOsPublishing() },
+                // 'ios-files'    : { iosPublishing() },
+                // 'macos-files'  : { macOsPublishing() },
         ])
 
         if (publishedVersions['windows-files'] != publishedVersions['ubuntu-files']) { // FIXME check rhel too, IS-307

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -18,8 +18,8 @@ def testing() {
         parallel([
                 'ubuntu-test' : { ubuntuTesting() },
                 'android-test': { androidTesting() },
-                'macos-test'  : { macosTesting() },
-                'ios-test'    : { iosTesting() },
+                // 'macos-test'  : { macosTesting() },
+                // 'ios-test'    : { iosTesting() },
                 // 'centos-test' : { centosTesting() },
                 'windows-test': { windowsTesting() }
         ])


### PR DESCRIPTION
Should be reverted as soon as macos Jenkins worker would be fixed.