### PR TITLE
Revert "Remove devscirpts from Ubuntu 18.04 CI dockerimage to avoid 2 versions of libssl in the setup.".

### DIFF
--- a/libindy/ci/ubuntu18.dockerfile
+++ b/libindy/ci/ubuntu18.dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
       cmake \
       python3-pip \
       debhelper \
+      devscripts \
       libncursesw5-dev \
       libzmq3-dev \
       libsodium-dev


### PR DESCRIPTION
This reverts commit 6347534.