### PR TITLE
added port 80 server alternative to dockerfile

### DIFF
--- a/ci/indy-pool.dockerfile
+++ b/ci/indy-pool.dockerfile
@@ -18,7 +18,8 @@ RUN pip3 install -U \
 	pip==9.0.3 \
 	setuptools
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 || \
+	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88
 ARG indy_stream=master
 RUN echo "deb https://repo.sovrin.org/deb xenial $indy_stream" >> /etc/apt/sources.list
 


### PR DESCRIPTION
Added 80 port to download key when using a proxy.
It allows to run samples smoother.