### PR TITLE
IS-1445: Invalid error message in the libindy logs in case of demoted nodes are on ledger

### DIFF
--- a/libindy/src/services/pool/pool.rs
+++ b/libindy/src/services/pool/pool.rs
@@ -698,7 +698,7 @@ fn _get_nodes_and_remotes(merkle: &MerkleTree) -> IndyResult<(Nodes, Vec<RemoteN
         (HashMap::new(), vec![]), |(mut map, mut vec), res| {
             match res {
                 Err(e) => {
-                    error!("Error during retrieving nodes: {:?}", e);
+                    debug!("Error during retrieving nodes: {:?}", e);
                 }
                 Ok(((alias, verkey), remote)) => {
                     map.insert(alias.clone(), verkey);


### PR DESCRIPTION

Signed-off-by: artem.ivanov <artem.ivanov@dsr-company.com>