### PR TITLE
Add pgsql storage strategy sharing connection pool between wallets

### DIFF
--- a/experimental/plugins/postgres_storage/README.md
+++ b/experimental/plugins/postgres_storage/README.md
@@ -75,19 +75,28 @@ cd indy-sdk/experimental/plugins/postgres_storage
 RUST_BACKTRACE=1 cargo test -- --nocapture --test-threads=1
 ```
 
-## Database-per-wallet vs Multi-wallet database
+## Wallet management modes 
+The plug-in supports three modes 
+- `DatabasePerWallet` - each wallet has its own database
+- `MultiWalletSingleTable` - all wallets are stored in single table in single database. Each wallet has its own 
+connection pool.
+- `MultiWalletSingleTableSharedPool` - all wallets are stored in single table in single database. The plugin
+will create only 1 connection pool reused by all wallets. This can be useful if intend to open many different 
+wallets. Postgres has by default limitation of ~100 simultaneous connections and using this strategy you can
+limit number of DB connections significantly.
 
-The plug-in supports two schemes - a database per wallet, or a single database containing multiple wallets.
+By default is used `DatabasePerWallet` mode, however you can override this by specifying 
+value of `wallet_scheme` with value `MultiWalletSingleTable` or `MultiWalletSingleTableSharedPool`. 
+The wallet configuration must be passed into external function
+ `init_storagetype(config, credentials)` when using pgsql as plugin from external code.
 
-Note to use the multi-wallet-database mode you need to call an initial init() function in the plug-in.
-
-In the initial wallet config:
+Here's sample wallet configuration which will initialize plugin to use `MultiWalletSingleTable` strategy.
 
 ```
 {"url":"localhost:5432", "wallet_scheme":"MultiWalletSingleTable"}
 ```
 
-The default if not specified is database-per-wallet.
+If `wallet_scheme` is not defined in wallet configuration, `DatabasePerWallet` scheme is used by default.
 
 To run unit tests in each mode, specify:
 

--- a/experimental/plugins/postgres_storage/src/errors/wallet.rs
+++ b/experimental/plugins/postgres_storage/src/errors/wallet.rs
@@ -180,8 +180,7 @@ pub enum WalletStorageError {
     PluggedStorageError(ErrorCode),
     CommonError(CommonError),
     QueryError(WalletQueryError),
-    GenericError(String),
-    UninitializedStorageError
+    GenericError(String)
 }
 
 impl From<postgres::error::Error> for WalletStorageError {
@@ -238,7 +237,6 @@ impl error::Error for WalletStorageError {
             WalletStorageError::CommonError(ref e) => e.description(),
             WalletStorageError::QueryError(ref e) => e.description(),
             WalletStorageError::GenericError(ref s) => s,
-            WalletStorageError::UninitializedStorageError => "Postgresql wallet was not yet initialized"
 
         }
     }
@@ -256,8 +254,7 @@ impl fmt::Display for WalletStorageError {
             WalletStorageError::PluggedStorageError(err_code) => write!(f, "Plugged storage error: {}", err_code as i32),
             WalletStorageError::CommonError(ref e) => write!(f, "Common error: {}", e.description()),
             WalletStorageError::QueryError(ref e) => write!(f, "Query error: {}", e.description()),
-            WalletStorageError::GenericError(ref s) =>  write!(f, "Generic postgresql error: {}", s),
-            WalletStorageError::UninitializedStorageError => write!(f, "Postgresql wallet was not yet initialized"),
+            WalletStorageError::GenericError(ref s) =>  write!(f, "Generic postgresql error: {}", s)
         }
     }
 }

--- a/experimental/plugins/postgres_storage/src/errors/wallet.rs
+++ b/experimental/plugins/postgres_storage/src/errors/wallet.rs
@@ -180,6 +180,8 @@ pub enum WalletStorageError {
     PluggedStorageError(ErrorCode),
     CommonError(CommonError),
     QueryError(WalletQueryError),
+    GenericError(String),
+    UninitializedStorageError
 }
 
 impl From<postgres::error::Error> for WalletStorageError {
@@ -235,6 +237,9 @@ impl error::Error for WalletStorageError {
             WalletStorageError::IOError(ref s) => s,
             WalletStorageError::CommonError(ref e) => e.description(),
             WalletStorageError::QueryError(ref e) => e.description(),
+            WalletStorageError::GenericError(ref s) => s,
+            WalletStorageError::UninitializedStorageError => "Postgresql wallet was not yet initialized"
+
         }
     }
 }
@@ -250,7 +255,9 @@ impl fmt::Display for WalletStorageError {
             WalletStorageError::IOError(ref s) => write!(f, "IO error occurred during storage operation: {}", s),
             WalletStorageError::PluggedStorageError(err_code) => write!(f, "Plugged storage error: {}", err_code as i32),
             WalletStorageError::CommonError(ref e) => write!(f, "Common error: {}", e.description()),
-            WalletStorageError::QueryError(ref e) => write!(f, "Query error: {}", e.description())
+            WalletStorageError::QueryError(ref e) => write!(f, "Query error: {}", e.description()),
+            WalletStorageError::GenericError(ref s) =>  write!(f, "Generic postgresql error: {}", s),
+            WalletStorageError::UninitializedStorageError => write!(f, "Postgresql wallet was not yet initialized"),
         }
     }
 }

--- a/experimental/plugins/postgres_storage/src/lib.rs
+++ b/experimental/plugins/postgres_storage/src/lib.rs
@@ -1053,6 +1053,7 @@ mod tests {
     use std::{slice, ptr};
     use wql::storage::ENCRYPTED_KEY_LEN;
     use rand::{thread_rng, Rng};
+    use postgres_storage::reset_wallet_strategy;
 
     #[test]
     fn postgres_wallet_crud_works() {
@@ -1730,6 +1731,7 @@ mod tests {
     }
 
     fn _cleanup() {
+        reset_wallet_strategy();
         let ten_millis = std::time::Duration::from_millis(1);
         let now = time::now();
         thread::sleep(ten_millis);

--- a/experimental/plugins/postgres_storage/src/lib.rs
+++ b/experimental/plugins/postgres_storage/src/lib.rs
@@ -223,7 +223,6 @@ impl PostgresWallet {
                 return ErrorCode::WalletNotFoundError;
             }
         };
-
         // get a handle (to use to identify wallet for subsequent calls)
         let xhandle = SequenceUtils::get_next_id();
 
@@ -1765,6 +1764,9 @@ mod tests {
                 if scheme == "MultiWalletSingleTable" {
                     return _wallet_config_multi();
                 }
+                if scheme == "MultiWalletSingleTableSharedPool" {
+                    return _wallet_config_multi_with_shared_pool();
+                }
             },
             Err(_) => ()
         };
@@ -1779,6 +1781,15 @@ mod tests {
         let config = Some(json!({
             "url": "localhost:5432".to_owned(),
             "wallet_scheme": "MultiWalletSingleTable".to_owned()
+        }).to_string());
+        config.map(CString::new)
+            .map_or(Ok(None), |r| r.map(Some)).unwrap()
+    }
+
+    fn _wallet_config_multi_with_shared_pool() -> Option<CString> {
+        let config = Some(json!({
+            "url": "localhost:5432".to_owned(),
+            "wallet_scheme": "MultiWalletSingleTableSharedPool".to_owned()
         }).to_string());
         config.map(CString::new)
             .map_or(Ok(None), |r| r.map(Some)).unwrap()

--- a/vcx/dummy-cloud-agent/config/pgsql-config.json
+++ b/vcx/dummy-cloud-agent/config/pgsql-config.json
@@ -13,7 +13,7 @@
     "addresses": [
       "127.0.0.1:8080"
     ],
-    "workers": 1
+    "workers": 2
   },
   "server_admin": {
     "enabled": false,
@@ -24,10 +24,10 @@
   "wallet_storage": {
     "config": {
       "url": "localhost:5432",
-      "max_connections" : 100,
-      "min_idle_time" : 1,
-      "connection_timeout" : 5,
-      "wallet_scheme": "MultiWalletSingleTable"
+      "max_connections" : 90,
+      "min_idle_count" : 5,
+      "connection_timeout" : 30,
+      "wallet_scheme": "MultiWalletSingleTableSharedPool"
     },
     "credentials": {
       "account": "postgres",

--- a/vcx/dummy-cloud-agent/config/pgsql-config.json
+++ b/vcx/dummy-cloud-agent/config/pgsql-config.json
@@ -25,7 +25,6 @@
     "config": {
       "url": "localhost:5432",
       "max_connections" : 90,
-      "min_idle_count" : 5,
       "connection_timeout" : 30,
       "wallet_scheme": "MultiWalletSingleTableSharedPool"
     },
@@ -35,9 +34,7 @@
       "admin_account": "postgres",
       "admin_password": "mysecretpassword"
     },
-    "type": "postgres_storage",
-    "plugin_init_function": null,
-    "plugin_library_path": null
+    "type": "postgres_storage"
   },
   "indy_runtime": {
     "crypto_thread_pool_size": 4


### PR DESCRIPTION
- Strategy `MultiWalletSingleTable` is creating many connection pools, one connection pool per wallet
- This adds `MultiWalletSingleTableSharedPool` strategy which shares postgre connections across wallets
- This also happens to remove several `unsafe` sections in the plugin