### PR TITLE
Fix rust warnings in vcx agency

### DIFF
--- a/vcx/dummy-cloud-agent/src/actors/admin.rs
+++ b/vcx/dummy-cloud-agent/src/actors/admin.rs
@@ -27,7 +27,7 @@ impl Admin {
     }
 
     pub fn handle_admin_message(&self, admin_msg: &AdminQuery)
-                                -> Box<Future<Item=ResAdminQuery, Error=Error>> {
+                                -> Box<dyn Future<Item=ResAdminQuery, Error=Error>> {
         match admin_msg {
             AdminQuery::GetDetailForwardAgents => {
                 if let Some(addr) = self.forward_agent.as_ref() {
@@ -95,7 +95,7 @@ impl Actor for Admin {
 }
 
 impl Handler<HandleAdminMessage> for Admin {
-    type Result = Box<Future<Item=ResAdminQuery, Error=Error>>;
+    type Result = Box<dyn Future<Item=ResAdminQuery, Error=Error>>;
 
     fn handle(&mut self, msg: HandleAdminMessage, _cnxt: &mut Self::Context) -> Self::Result {
         trace!("Admin Handler<HandleAdminMessage>::handle");

--- a/vcx/dummy-cloud-agent/src/actors/agent_connection.rs
+++ b/vcx/dummy-cloud-agent/src/actors/agent_connection.rs
@@ -1247,7 +1247,6 @@ impl AgentConnection {
 
         let remote_connection_detail = self.state.remote_connection_detail.as_ref()
             .ok_or(err_msg("Missed Remote Connection Details."))?;
-
         let remote_forward_agent_detail = &remote_connection_detail.forward_agent_detail;
         let remote_agent_pairwise_detail = &remote_connection_detail.agent_key_dlg_proof;
 
@@ -1270,7 +1269,6 @@ impl AgentConnection {
         match ProtocolType::get() {
             ProtocolTypes::V1 => {
                 let msg = ftry!(rmp_serde::to_vec_named(&msg));
-                ;
 
                 let payload_msg = PayloadV1 {
                     type_: PayloadTypes::build_v1(PayloadKinds::from(type_), "json"),
@@ -1285,7 +1283,6 @@ impl AgentConnection {
             }
             ProtocolTypes::V2 => {
                 let msg = ftry!(serde_json::to_string(&msg));
-                ;
 
                 let payload_msg = PayloadV2 {
                     type_: PayloadTypes::build_v2(PayloadKinds::from(type_)),

--- a/vcx/dummy-cloud-agent/src/app.rs
+++ b/vcx/dummy-cloud-agent/src/app.rs
@@ -42,7 +42,7 @@ pub fn start_app_server(server_config: ServerConfig, app_config: AppConfig, forw
 }
 
 
-fn _get_endpoint_details(state: Data<AppData>) -> Box<Future<Item=HttpResponse, Error=Error>> {
+fn _get_endpoint_details(state: Data<AppData>) -> Box<dyn Future<Item=HttpResponse, Error=Error>> {
     let f = state.forward_agent
         .send(GetEndpoint {})
         .from_err()
@@ -53,7 +53,7 @@ fn _get_endpoint_details(state: Data<AppData>) -> Box<Future<Item=HttpResponse, 
     Box::new(f)
 }
 
-fn _forward_message(state: Data<AppData>, stream: web::Payload) -> Box<Future<Item=HttpResponse, Error=Error>> {
+fn _forward_message(state: Data<AppData>, stream: web::Payload) -> Box<dyn Future<Item=HttpResponse, Error=Error>> {
     let f = stream.map_err(Error::from)
         .fold(web::BytesMut::new(), move |mut body, chunk| {
             body.extend_from_slice(&chunk);

--- a/vcx/dummy-cloud-agent/src/app_admin.rs
+++ b/vcx/dummy-cloud-agent/src/app_admin.rs
@@ -48,7 +48,7 @@ pub fn start_app_admin_server(server_admin_config: &ServerAdminConfig, admin_age
     info!("Admin Server started at addresses: {:?}.", server_admin_config.addresses);
 }
 
-fn _send_admin_message(state: Data<AdminAppData>, admin_msg: HandleAdminMessage) -> Box<Future<Item=HttpResponse, Error=Error>> {
+fn _send_admin_message(state: Data<AdminAppData>, admin_msg: HandleAdminMessage) -> Box<dyn Future<Item=HttpResponse, Error=Error>> {
     let f = state.admin_agent
                     .send(admin_msg)
                     .from_err()
@@ -59,22 +59,22 @@ fn _send_admin_message(state: Data<AdminAppData>, admin_msg: HandleAdminMessage)
     Box::new(f)
 }
 
-fn _get_agent_connection_details(state: Data<AdminAppData>, info: web::Path<AgentParams>) -> Box<Future<Item=HttpResponse, Error=Error>> {
+fn _get_agent_connection_details(state: Data<AdminAppData>, info: web::Path<AgentParams>) -> Box<dyn Future<Item=HttpResponse, Error=Error>> {
     let msg = HandleAdminMessage(AdminQuery::GetDetailAgentConnection(GetDetailAgentConnParams { agent_pairwise_did: info.did.clone() }));
     _send_admin_message(state, msg)
 }
 
-fn _get_agent_details(state: Data<AdminAppData>, info: web::Path<AgentParams>) -> Box<Future<Item=HttpResponse, Error=Error>> {
+fn _get_agent_details(state: Data<AdminAppData>, info: web::Path<AgentParams>) -> Box<dyn Future<Item=HttpResponse, Error=Error>> {
     let msg = HandleAdminMessage(AdminQuery::GetDetailAgent(GetDetailAgentParams { agent_did: info.did.clone() }));
     _send_admin_message(state, msg)
 }
 
-fn _get_actor_overview(state: Data<AdminAppData>) -> Box<Future<Item=HttpResponse, Error=Error>> {
+fn _get_actor_overview(state: Data<AdminAppData>) -> Box<dyn Future<Item=HttpResponse, Error=Error>> {
     let msg = HandleAdminMessage(AdminQuery::GetActorOverview);
     _send_admin_message(state, msg)
 }
 
-fn _get_forward_agent_details(state: Data<AdminAppData>) -> Box<Future<Item=HttpResponse, Error=Error>> {
+fn _get_forward_agent_details(state: Data<AdminAppData>) -> Box<dyn Future<Item=HttpResponse, Error=Error>> {
     let msg = HandleAdminMessage(AdminQuery::GetDetailForwardAgents);
     _send_admin_message(state, msg)
 }

--- a/vcx/dummy-cloud-agent/src/indy/crypto.rs
+++ b/vcx/dummy-cloud-agent/src/indy/crypto.rs
@@ -5,27 +5,27 @@ use utils::futures::*;
 pub fn auth_crypt(wallet_handle: i32,
                   sender_vk: &str,
                   recipient_vk: &str,
-                  message: &[u8]) -> Box<Future<Item=Vec<u8>, Error=IndyError>> {
+                  message: &[u8]) -> Box<dyn Future<Item=Vec<u8>, Error=IndyError>> {
     crypto::auth_crypt(wallet_handle, sender_vk, recipient_vk, message)
         .into_box()
 }
 
 pub fn auth_decrypt(wallet_handle: i32,
                     recipient_vk: &str,
-                    encrypted_message: &[u8]) -> Box<Future<Item=(String, Vec<u8>), Error=IndyError>> {
+                    encrypted_message: &[u8]) -> Box<dyn Future<Item=(String, Vec<u8>), Error=IndyError>> {
     crypto::auth_decrypt(wallet_handle, recipient_vk, encrypted_message)
         .into_box()
 }
 
 pub fn anon_crypt(recipient_vk: &str,
-                  message: &[u8]) -> Box<Future<Item=Vec<u8>, Error=IndyError>> {
+                  message: &[u8]) -> Box<dyn Future<Item=Vec<u8>, Error=IndyError>> {
     crypto::anon_crypt(recipient_vk, message)
         .into_box()
 }
 
 pub fn anon_decrypt(wallet_handle: i32,
                     recipient_vk: &str,
-                    encrypted_message: &[u8]) -> Box<Future<Item=Vec<u8>, Error=IndyError>> {
+                    encrypted_message: &[u8]) -> Box<dyn Future<Item=Vec<u8>, Error=IndyError>> {
     crypto::anon_decrypt(wallet_handle, recipient_vk, encrypted_message)
         .into_box()
 }
@@ -33,24 +33,24 @@ pub fn anon_decrypt(wallet_handle: i32,
 #[cfg(test)]
 pub fn sign(wallet_handle: i32,
             signer_vk: &str,
-            message: &[u8]) -> Box<Future<Item=Vec<u8>, Error=IndyError>> {
+            message: &[u8]) -> Box<dyn Future<Item=Vec<u8>, Error=IndyError>> {
     crypto::sign(wallet_handle, signer_vk, message)
         .into_box()
 }
 
 pub fn verify(signer_vk: &str,
               message: &[u8],
-              signature: &[u8]) -> Box<Future<Item=bool, Error=IndyError>> {
+              signature: &[u8]) -> Box<dyn Future<Item=bool, Error=IndyError>> {
     crypto::verify(signer_vk, message, signature)
         .into_box()
 }
 
-pub fn pack_message(wallet_handle: i32, sender_vk: Option<&str>, receiver_keys: &str, msg: &[u8]) -> Box<Future<Item=Vec<u8>, Error=IndyError>> {
+pub fn pack_message(wallet_handle: i32, sender_vk: Option<&str>, receiver_keys: &str, msg: &[u8]) -> Box<dyn Future<Item=Vec<u8>, Error=IndyError>> {
     crypto::pack_message(wallet_handle, msg, receiver_keys, sender_vk)
         .into_box()
 }
 
-pub fn unpack_message(wallet_handle: i32, msg: &[u8]) -> Box<Future<Item=Vec<u8>, Error=IndyError>> {
+pub fn unpack_message(wallet_handle: i32, msg: &[u8]) -> Box<dyn Future<Item=Vec<u8>, Error=IndyError>> {
     crypto::unpack_message(wallet_handle, msg)
         .into_box()
 }

--- a/vcx/dummy-cloud-agent/src/indy/did.rs
+++ b/vcx/dummy-cloud-agent/src/indy/did.rs
@@ -2,27 +2,27 @@ use futures::*;
 use utils::futures::*;
 use indyrs::{did, IndyError};
 
-pub fn create_and_store_my_did(wallet_handle: i32, did_info: &str) -> Box<Future<Item=(String, String), Error=IndyError>> {
+pub fn create_and_store_my_did(wallet_handle: i32, did_info: &str) -> Box<dyn Future<Item=(String, String), Error=IndyError>> {
     did::create_and_store_my_did(wallet_handle, did_info)
         .into_box()
 }
 
-pub fn key_for_local_did(wallet_handle: i32, did: &str) -> Box<Future<Item=String, Error=IndyError>> {
+pub fn key_for_local_did(wallet_handle: i32, did: &str) -> Box<dyn Future<Item=String, Error=IndyError>> {
     did::key_for_local_did(wallet_handle, did)
         .into_box()
 }
 
-pub fn store_their_did(wallet_handle: i32, did_info: &str) -> Box<Future<Item=(), Error=IndyError>> {
+pub fn store_their_did(wallet_handle: i32, did_info: &str) -> Box<dyn Future<Item=(), Error=IndyError>> {
     did::store_their_did(wallet_handle, did_info)
         .into_box()
 }
 
-pub fn set_did_metadata(wallet_handle: i32, did: &str, metadata: &str) -> Box<Future<Item=(), Error=IndyError>> {
+pub fn set_did_metadata(wallet_handle: i32, did: &str, metadata: &str) -> Box<dyn Future<Item=(), Error=IndyError>> {
     did::set_did_metadata(wallet_handle, did, metadata)
         .into_box()
 }
 
-pub fn get_did_metadata(wallet_handle: i32, did: &str) -> Box<Future<Item=String, Error=IndyError>> {
+pub fn get_did_metadata(wallet_handle: i32, did: &str) -> Box<dyn Future<Item=String, Error=IndyError>> {
     did::get_did_metadata(wallet_handle, did)
         .into_box()
 }

--- a/vcx/dummy-cloud-agent/src/indy/pairwise.rs
+++ b/vcx/dummy-cloud-agent/src/indy/pairwise.rs
@@ -16,27 +16,27 @@ pub struct PairwiseInfo {
 }
 
 
-pub fn is_pairwise_exists(wallet_handle: i32, their_did: &str) -> Box<Future<Item=bool, Error=IndyError>> {
+pub fn is_pairwise_exists(wallet_handle: i32, their_did: &str) -> Box<dyn Future<Item=bool, Error=IndyError>> {
     pairwise::is_pairwise_exists(wallet_handle, their_did)
         .into_box()
 }
 
-pub fn create_pairwise(wallet_handle: i32, their_did: &str, my_did: &str, metadata: Option<&str>) -> Box<Future<Item=(), Error=IndyError>> {
+pub fn create_pairwise(wallet_handle: i32, their_did: &str, my_did: &str, metadata: Option<&str>) -> Box<dyn Future<Item=(), Error=IndyError>> {
     pairwise::create_pairwise(wallet_handle, their_did, my_did, metadata)
         .into_box()
 }
 
-pub fn get_pairwise(wallet_handle: i32, their_did: &str) -> Box<Future<Item=String, Error=IndyError>> {
+pub fn get_pairwise(wallet_handle: i32, their_did: &str) -> Box<dyn Future<Item=String, Error=IndyError>> {
     pairwise::get_pairwise(wallet_handle, their_did)
         .into_box()
 }
 
-pub fn list_pairwise(wallet_handle: i32) -> Box<Future<Item=String, Error=IndyError>> {
+pub fn list_pairwise(wallet_handle: i32) -> Box<dyn Future<Item=String, Error=IndyError>> {
     pairwise::list_pairwise(wallet_handle)
         .into_box()
 }
 
-pub fn set_pairwise_metadata(wallet_handle: i32, their_did: &str, metadata: &str) -> Box<Future<Item=(), Error=IndyError>> {
+pub fn set_pairwise_metadata(wallet_handle: i32, their_did: &str, metadata: &str) -> Box<dyn Future<Item=(), Error=IndyError>> {
     pairwise::set_pairwise_metadata(wallet_handle, their_did, Some(metadata))
         .into_box()
 }

--- a/vcx/dummy-cloud-agent/src/indy/wallet.rs
+++ b/vcx/dummy-cloud-agent/src/indy/wallet.rs
@@ -2,18 +2,18 @@ use futures::*;
 use utils::futures::*;
 use indyrs::{wallet, IndyError};
 
-pub fn create_wallet(config: &str, credentials: &str) -> Box<Future<Item=(), Error=IndyError>> {
+pub fn create_wallet(config: &str, credentials: &str) -> Box<dyn Future<Item=(), Error=IndyError>> {
     wallet::create_wallet(config, credentials)
         .into_box()
 }
 
-pub fn open_wallet(config: &str, credentials: &str) -> Box<Future<Item=i32, Error=IndyError>> {
+pub fn open_wallet(config: &str, credentials: &str) -> Box<dyn Future<Item=i32, Error=IndyError>> {
     wallet::open_wallet(config, credentials)
         .into_box()
 }
 
 #[allow(unused)] // TODO: Use!
-pub fn close_wallet(wallet_handle: i32) -> Box<Future<Item=(), Error=IndyError>> {
+pub fn close_wallet(wallet_handle: i32) -> Box<dyn Future<Item=(), Error=IndyError>> {
     wallet::close_wallet(wallet_handle)
         .into_box()
 }

--- a/vcx/dummy-cloud-agent/src/utils/futures.rs
+++ b/vcx/dummy-cloud-agent/src/utils/futures.rs
@@ -63,7 +63,7 @@ macro_rules! err_act {
     }};
 }
 
-pub type BoxedFuture<I, E> = Box<Future<Item = I, Error = E>>;
+pub type BoxedFuture<I, E> = Box<dyn Future<Item = I, Error = E>>;
 
 pub trait FutureExt: Future + Sized {
     /// Box this future. Similar to `boxed` combinator, but does not require
@@ -72,12 +72,12 @@ pub trait FutureExt: Future + Sized {
 }
 
 impl<F: Future + 'static> FutureExt for F {
-    fn into_box(self) -> Box<Future<Item = Self::Item, Error = Self::Error>> {
+    fn into_box(self) -> Box<dyn Future<Item = Self::Item, Error = Self::Error>> {
         Box::new(self)
     }
 }
 
-pub type BoxedActorFuture<A, I, E> = Box<ActorFuture<Actor = A, Item = I, Error = E>>;
+pub type BoxedActorFuture<A, I, E> = Box<dyn ActorFuture<Actor = A, Item = I, Error = E>>;
 
 pub trait ActorFutureExt: ActorFuture + Sized {
     /// Box this future. Similar to `boxed` combinator, but does not require
@@ -86,7 +86,7 @@ pub trait ActorFutureExt: ActorFuture + Sized {
 }
 
 impl<F: ActorFuture + 'static> ActorFutureExt for F {
-    fn into_box(self) -> Box<ActorFuture<Actor = Self::Actor, Item = Self::Item, Error = Self::Error>> {
+    fn into_box(self) -> Box<dyn ActorFuture<Actor = Self::Actor, Item = Self::Item, Error = Self::Error>> {
         Box::new(self)
     }
 }


### PR DESCRIPTION
- Added `dyn` when using trait objects - omitting `dyn` is deprecated
- Removed extra semicolons