### PR TITLE
Fix intermittent pgsql wallet unittest issues

### DIFF
--- a/experimental/plugins/postgres_storage/src/lib.rs
+++ b/experimental/plugins/postgres_storage/src/lib.rs
@@ -1100,7 +1100,7 @@ mod tests {
         assert_eq!(err, ErrorCode::Success);
 
         // update metadata to some new metadata
-        let metadata2 = _metadata2();
+        let metadata2 = _metadata2_cstring();
         let err = PostgresWallet::set_storage_metadata(handle, metadata2.as_ptr());
         assert_eq!(err, ErrorCode::Success);
 
@@ -1811,7 +1811,7 @@ mod tests {
         CString::new(foo).unwrap()
     }
 
-    fn _metadata2() -> Vec<i8> {
+    fn _metadata2() -> Vec<u8> {
         return vec![
             2, 3, 4, 5, 6, 7, 8, 9,
             2, 3, 4, 5, 6, 7, 8, 9,
@@ -1822,6 +1822,11 @@ mod tests {
             2, 3, 4, 5, 6, 7, 8, 9,
             2, 3, 4, 5, 6, 7, 8, 9
         ];
+    }
+
+    fn _metadata2_cstring() -> CString {
+        let foo = _metadata2();
+        CString::new(foo).unwrap()
     }
 
     fn _type(i: u8) -> CString {

--- a/experimental/plugins/postgres_storage/src/lib.rs
+++ b/experimental/plugins/postgres_storage/src/lib.rs
@@ -1731,7 +1731,7 @@ mod tests {
 
     fn _cleanup() {
         let ten_millis = std::time::Duration::from_millis(1);
-        let now = time::now();
+        let _now = time::now();
         thread::sleep(ten_millis);
 
         let id = _wallet_id();

--- a/experimental/plugins/postgres_storage/src/postgres_storage.rs
+++ b/experimental/plugins/postgres_storage/src/postgres_storage.rs
@@ -2279,14 +2279,14 @@ mod tests {
         "walle1"
     }
 
-    fn _storage() -> Box<WalletStorage> {
+    fn _storage() -> Box<dyn WalletStorage> {
         let storage_type = PostgresStorageType::new();
         storage_type.create_storage(_wallet_id(), Some(&_wallet_config()[..]), Some(&_wallet_credentials()[..]), &_metadata()).unwrap();
         let res = storage_type.open_storage(_wallet_id(), Some(&_wallet_config()[..]), Some(&_wallet_credentials()[..])).unwrap();
         res
     }
 
-    fn _storage_db_pool() -> Box<WalletStorage> {
+    fn _storage_db_pool() -> Box<dyn WalletStorage> {
         let storage_type = PostgresStorageType::new();
         storage_type.create_storage(_wallet_id(), Some(&_wallet_config_db_pool()[..]), Some(&_wallet_credentials()[..]), &_metadata()).unwrap();
         let res = storage_type.open_storage(_wallet_id(), Some(&_wallet_config_db_pool()[..]), Some(&_wallet_credentials()[..])).unwrap();


### PR DESCRIPTION
Tests in pgsql are still failing randomly when running
```
 RUST_BACKTRACE=full WALLET_SCHEME=MultiWalletSingleTable cargo test  -- --nocapture --test-threads=1
```
this PR fixes the issues. This PR is addition to previously merged https://github.com/hyperledger/indy-sdk/pull/2033/files

In addition fixed some warnings 