### PR TITLE
java wrapper should ignore MacOS X dynamic library pattern.

### DIFF
--- a/wrappers/java/lib/.gitignore
+++ b/wrappers/java/lib/.gitignore
@@ -1,2 +1,2 @@
 libindy.so
-
+libindy.dylib


### PR DESCRIPTION
MacOS X dynamic library name is different with Linux.