### PR TITLE
Added jsonschema to getting-started.dockerfile

### DIFF
--- a/docs/getting-started/getting-started.dockerfile
+++ b/docs/getting-started/getting-started.dockerfile
@@ -20,7 +20,8 @@ RUN pip3 install -U \
 	pip \
 	setuptools \
 	jupyter \
-	python3-indy==1.11.0
+	python3-indy==1.11.0 \
+	jsonschema
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
     && add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial stable" \


### PR DESCRIPTION
Updated indy-sdk/docs/getting-started/getting-started.dockerfile
by adding jsonschema which is a dependency of jupyter.

**Error :**
![86485919_1054512398242872_4192776585075490816_n](https://user-images.githubusercontent.com/21141785/74402941-aff7fc80-4e4b-11ea-8703-804395cf111d.jpg)

**Fixed :**
![86345756_215279149605323_2301936714983145472_n](https://user-images.githubusercontent.com/21141785/74403091-1ed55580-4e4c-11ea-818c-cb19ce9d19ab.jpg)
