### PR TITLE
Revert "IS-1486: Switch libs to libssl 1.1 on Ubuntu 18.04"

### DIFF
--- a/libindy/ci/ubuntu18.dockerfile
+++ b/libindy/ci/ubuntu18.dockerfile
@@ -40,8 +40,6 @@ RUN apt-get install -y nodejs
 
 RUN apt-get install -y wget
 
-RUN apt remove -y libssl1.0.0
-
 RUN useradd -ms /bin/bash -u $uid indy
 USER indy
 


### PR DESCRIPTION
Reverts hyperledger/indy-sdk#2097

Signed-off-by: Sergey Minaev <sergey.minaev@dsr-corporation.com>