### PR TITLE
rename wallets because test failed

### DIFF
--- a/libindy/tests/anoncreds_demos.rs
+++ b/libindy/tests/anoncreds_demos.rs
@@ -500,10 +500,10 @@ mod demos {
         Setup::empty();
 
         //1. Issuer creates wallet, gets wallet handle
-        let (issuer_wallet_handle, issuer_wallet_config) = wallet::create_and_open_default_wallet("anoncreds_works_for_revocation_proof_issuance_by_demand").unwrap();
+        let (issuer_wallet_handle, issuer_wallet_config) = wallet::create_and_open_default_wallet("anoncreds_works_for_revocation_proof_issuance_by_demand_i").unwrap();
 
         //2. Prover creates wallet, gets wallet handle
-        let (prover_wallet_handle, prover_wallet_config) = wallet::create_and_open_default_wallet("anoncreds_works_for_revocation_proof_issuance_by_demand").unwrap();
+        let (prover_wallet_handle, prover_wallet_config) = wallet::create_and_open_default_wallet("anoncreds_works_for_revocation_proof_issuance_by_demand_p").unwrap();
 
         //3 Issuer creates Schema, Credential Definition and Revocation Registry
         let (schema_id, schema_json,


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

the test failed with `wallet with that name already exists` so this PR names issuer and prover wallet. 

I am kind of astonished why this ever worked. Maybe I am confuse. 
Anyway all tests succeed now