### PR TITLE
LibVCX fixes in Java wrapper

### DIFF
--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -25,7 +25,6 @@ public abstract class LibVcx {
         public String vcx_error_c_message(int error_code);
         public String vcx_version();
         public int vcx_shutdown(boolean delete);
-        public int vcx_reset();
 
     /**
      * Helper API for testing purposes.
@@ -372,11 +371,6 @@ public abstract class LibVcx {
      *
      * Used for sending a disclosed_proof to an identity owner.
      */
-
-        /**
-         * Creates a disclosed_proof object.  Populates a handle to the new disclosed_proof.
-         */
-        public int vcx_disclosed_proof_create_with_request(int command_handle, String source_id, String requested_attrs, String requested_predicates, String name, Callback cb);
 
         /**
          * Create a proof object with proof request

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -25,6 +25,7 @@ public abstract class LibVcx {
         public String vcx_error_c_message(int error_code);
         public String vcx_version();
         public int vcx_shutdown(boolean delete);
+        public int vcx_update_institution_info(String name, String logo_url);
 
     /**
      * Helper API for testing purposes.

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -404,6 +404,12 @@ public abstract class LibVcx {
         public int vcx_disclosed_proof_update_state(int command_handle, int proof_handle, Callback cb);
 
         /**
+         * Populates status of the proof from the given message.
+         */
+        public int vcx_disclosed_proof_update_state_with_message(int command_handle, int proof_handle, String message, Callback cb);
+
+
+        /**
          * Check for any proof requests from the connection.
          */
         public int vcx_disclosed_proof_get_requests(int command_handle, int connection_handle, Callback cb);

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/connection/ConnectionApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/connection/ConnectionApi.java
@@ -505,7 +505,7 @@ public class ConnectionApi extends VcxJava.API {
 
         CompletableFuture<String> future = new CompletableFuture<String>();
         int commandHandle = addFuture(future);
-        int result = LibVcx.api.vcx_connection_get_pw_did(commandHandle, connectionHandle, vcxConnectionGetTheirPwDidCB);
+        int result = LibVcx.api.vcx_connection_get_their_pw_did(commandHandle, connectionHandle, vcxConnectionGetTheirPwDidCB);
         checkResult(result);
 
         return future;

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/proof/DisclosedProofApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/proof/DisclosedProofApi.java
@@ -69,6 +69,20 @@ public class DisclosedProofApi extends VcxJava.API {
         return future;
     }
 
+    public static CompletableFuture<Integer> proofUpdateStateWithMessage(
+            int proofHandle,
+            String message
+    ) throws VcxException {
+        logger.debug("proofUpdateStateWithMessage() called with: proofHandle = [" + proofHandle + "]");
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        int commandHandle = addFuture(future);
+
+        int result = LibVcx.api.vcx_disclosed_proof_update_state_with_message(commandHandle, proofHandle, message, vcxProofUpdateStateCB);
+        checkResult(result);
+
+        return future;
+    }
+
     private static Callback proofGetRequestsCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err, String proofRequests) {

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/proof/DisclosedProofApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/proof/DisclosedProofApi.java
@@ -17,35 +17,6 @@ public class DisclosedProofApi extends VcxJava.API {
     }
 
     private static final Logger logger = LoggerFactory.getLogger("DisclosedProofApi");
-    private static Callback vcxProofCreateCB = new Callback() {
-        @SuppressWarnings({"unused", "unchecked"})
-        public void callback(int commandHandle, int err, int proofHandle) {
-            logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "], proofHandle = [" + proofHandle + "]");
-            CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);
-            if (!checkCallback(future, err)) return;
-            future.complete(proofHandle);
-        }
-    };
-
-    public static CompletableFuture<CreateProofMsgIdResult> proofCreate(
-            String sourceId,
-            String requestedAttributes,
-            String requestedPredicates,
-            String name
-    ) throws VcxException {
-        ParamGuard.notNull(sourceId, "sourceId");
-        ParamGuard.notNull(requestedAttributes, "requestedAttributes");
-        ParamGuard.notNull(requestedPredicates, "requestedPredicates");
-        ParamGuard.notNull(name, "name");
-        logger.debug("proofCreate() called with: sourceId = [" + sourceId + "], requestedAttributes = [" + requestedAttributes + "], requestedPredicates = [" + requestedPredicates + "], name = [" + name + "]");
-        CompletableFuture<CreateProofMsgIdResult> future = new CompletableFuture<>();
-        int commandHandle = addFuture(future);
-
-        int result = LibVcx.api.vcx_disclosed_proof_create_with_request(commandHandle, sourceId, requestedAttributes, requestedPredicates, name, vcxProofCreateCB);
-        checkResult(result);
-
-        return future;
-    }
 
     private static Callback vcxProofCreateWithMsgIdCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/vcx/VcxApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/vcx/VcxApi.java
@@ -100,4 +100,17 @@ public class VcxApi extends VcxJava.API {
 
     }
 
+    public static int vcxUpdateInstitutionInfo(String name, String logoUrl) throws VcxException {
+        ParamGuard.notNullOrWhiteSpace(name, "name");
+        ParamGuard.notNullOrWhiteSpace(logoUrl, "logoUrl");
+        logger.debug("vcxUpdateInstitutionInfo() called with: name = [" + name + "], logoUrl = [" + logoUrl + "]");
+
+        int result = LibVcx.api.vcx_update_institution_info(
+                name,
+                logoUrl);
+        checkResult(result);
+
+        return result;
+    }
+
 }

--- a/vcx/wrappers/java/src/test/java/com/evernym/sdk/vcx/DisclosedProofApiTest.java
+++ b/vcx/wrappers/java/src/test/java/com/evernym/sdk/vcx/DisclosedProofApiTest.java
@@ -34,14 +34,6 @@ public class DisclosedProofApiTest {
    }
 
     @Test
-    @DisplayName("throw illegal argument exception if invalid arguments are provided")
-    void throwIllegalArgumentxException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            TestHelper.getResultFromFuture(DisclosedProofApi.proofCreate(sourceId, null, "{}", name));
-        });
-    }
-
-    @Test
     @DisplayName("serialize and deserialize proof")
     void serializeDisclosedProof() throws VcxException, ExecutionException, InterruptedException {
         int proofHandle = TestHelper.getResultFromFuture(DisclosedProofApi.proofCreateWithRequest(sourceId, proofRequest));


### PR DESCRIPTION
*Bug fix*
* The API connectionGetTheirPwDid returns pw_did not their_pw_did

*New APIs*
 * DisclosedProofApi.proofUpdateStateWithMessage
 * VcxApi.vcxUpdateInstitutionInfo

*Remove obsolete APIs*
* vcx_reset
* DisclosedProofApi.proofCreate