### PR TITLE
Dont fail with Error:success when sending Aries message from Nodejs LibVCX

### DIFF
--- a/vcx/wrappers/node/src/api/connection.ts
+++ b/vcx/wrappers/node/src/api/connection.ts
@@ -414,7 +414,8 @@ export class Connection extends VCXBaseWithState<IConnectionData> {
    * msg_id = await connection.send_message(
    *     {msg:"are you there?",type:"question","title":"Sending you a question"})
    * ```
-   * @returns {Promise<string}
+   * @returns {Promise<string>} Promise of String representing UID of created message in 1.0 VCX protocol. When using
+   * 2.0 / 3.0 / Aries protocol, return empty string.
    */
   public async sendMessage (msgData: IMessageData): Promise<string> {
     const sendMsgOptions = {
@@ -437,10 +438,6 @@ export class Connection extends VCXBaseWithState<IConnectionData> {
             (xHandle: number, err: number, details: string) => {
               if (err) {
                 reject(err)
-                return
-              }
-              if (!details) {
-                reject(`Connection ${this.sourceId} connect returned empty string`)
                 return
               }
               resolve(details)


### PR DESCRIPTION
`sendMessage` in NodeJS wrapper is calling rust here:
https://github.com/hyperledger/indy-sdk/blob/master/vcx/libvcx/src/api/connection.rs#L801
which propagates result of `send_generic_message `
defined here
https://github.com/hyperledger/indy-sdk/blob/master/vcx/libvcx/src/connection.rs#L842
so: 

1. For legacy this calls
https://github.com/hyperledger/indy-sdk/blob/master/vcx/libvcx/src/connection.rs#L398
returning UID according to what was returned from agency.

2. But for Aries is called
https://github.com/hyperledger/indy-sdk/blob/master/vcx/libvcx/src/v3/handlers/connection/connection.rs#L186
which always returns empty String. 

In NodeJS wrapper there was validation making sure that the string passed to callback is not empty. Hence this would always fail when using Aries with error `Error:SUCCESS`

