### PR TITLE
Add batch revocation

### DIFF
--- a/vcx/libvcx/src/credential_def.rs
+++ b/vcx/libvcx/src/credential_def.rs
@@ -243,6 +243,15 @@ pub fn create_and_publish_credentialdef(source_id: String,
     Ok(handle)
 }
 
+pub fn publish_revocations(handle: u32) -> VcxResult<()> {
+    if let Some(rev_reg_id) = get_rev_reg_id(handle)? {
+        anoncreds::publish_local_revocations(rev_reg_id.as_str())?;
+        Ok(())
+    } else {
+        Err(VcxError::from(VcxErrorKind::InvalidCredDefHandle))
+    }
+}
+
 pub fn is_valid_handle(handle: u32) -> bool {
     CREDENTIALDEF_MAP.has_handle(handle)
 }

--- a/vcx/libvcx/src/error/mod.rs
+++ b/vcx/libvcx/src/error/mod.rs
@@ -74,6 +74,8 @@ pub enum VcxErrorKind {
     CredDefAlreadyCreated,
     #[fail(display = "Invalid Credential Definition handle")]
     InvalidCredDefHandle,
+    #[fail(display = "No revocation delta found in storage for this revocation registry. Were any credentials locally revoked?")]
+    RevDeltaNotFound,
 
     // Revocation
     #[fail(display = "Failed to create Revocation Registration Definition")]
@@ -381,6 +383,7 @@ impl From<VcxErrorKind> for u32 {
             VcxErrorKind::Common(num) => num,
             VcxErrorKind::LibndyError(num) => num,
             VcxErrorKind::NoAgentInformation => error::NO_AGENT_INFO.code_num,
+            VcxErrorKind::RevDeltaNotFound => error::REV_DELTA_NOT_FOUND.code_num,
         }
     }
 }

--- a/vcx/libvcx/src/utils/error.rs
+++ b/vcx/libvcx/src/utils/error.rs
@@ -115,6 +115,7 @@ pub static ACTION_NOT_SUPPORTED: Error = Error { code_num: 1103, message: "Actio
 pub static INVALID_REDIRECT_DETAILS: Error = Error{code_num: 1104, message: "Invalid redirect details structure"};
 /* EC 1105 is reserved for proprietary forks of libVCX */
 pub static NO_AGENT_INFO: Error = Error{code_num: 1106, message: "Agent pairwise information not found"};
+pub static REV_DELTA_NOT_FOUND: Error = Error{code_num: 1107, message: "No revocation delta found in storage for this revocation registry. Were any credentials locally revoked?"};
 
 lazy_static! {
     static ref ERROR_C_MESSAGES: HashMap<u32, CString> = {

--- a/vcx/libvcx/src/utils/libindy/cache.rs
+++ b/vcx/libvcx/src/utils/libindy/cache.rs
@@ -1,9 +1,11 @@
 use serde_json;
 
-use utils::libindy::wallet::{add_record, get_record, update_record_value};
+use utils::libindy::wallet::{add_record, get_record, update_record_value, delete_record};
+use error::{VcxErrorKind, VcxError, VcxResult};
 
 static CACHE_TYPE: &str = "cache";
 static REV_REG_CACHE_PREFIX: &str = "rev_reg:";
+static REV_REG_DELTA_CACHE_PREFIX: &str = "rev_reg_delta:";
 
 ///
 /// Cache object for rev reg cache
@@ -20,6 +22,23 @@ pub struct RevRegCache {
 pub struct RevState {
     pub timestamp: u64,
     pub value: String,
+}
+///
+///
+/// Cache object for rev reg delta cache
+///
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+pub struct RevRegDeltaCache {
+    pub rev_reg_delta: Option<RevRegDeltaState>,
+}
+
+///
+/// Current issuers local rev reg delta.
+///
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct RevRegDeltaState {
+    pub value: String,
+    pub ver: String,
 }
 
 ///
@@ -76,6 +95,83 @@ pub fn set_rev_reg_cache(rev_reg_id: &str, cache: &RevRegCache) {
     }
 }
 
+///
+/// Returns the rev reg delta cache.
+///
+/// # Arguments
+/// `rev_reg_id`: revocation registry id
+///
+/// # Returns
+/// Revocation registry delta json as a string
+pub fn get_rev_reg_delta_cache(rev_reg_id: &str) -> Option<String> {
+    debug!("Getting rev_reg_delta_cache for rev_reg_id {}", rev_reg_id);
+
+    let wallet_id = format!("{}{}", REV_REG_DELTA_CACHE_PREFIX, rev_reg_id);
+    match get_record(CACHE_TYPE, &wallet_id, &json!({"retrieveType": false, "retrieveValue": true, "retrieveTags": false}).to_string()) {
+        Ok(json) => {
+            match serde_json::from_str(&json)
+                .and_then(|x: serde_json::Value| 
+                    serde_json::from_str(x.get("value").unwrap_or(&serde_json::Value::Null).as_str().unwrap_or(""))) {
+                Ok(cache) => cache,
+                Err(err) => {
+                    warn!("Unable to convert rev_reg_delta cache for rev_reg_id: {}, json: {}, error: {}", rev_reg_id, json, err);
+                    None
+                }
+            }
+        },
+        Err(err) => {
+            warn!("Unable to get rev_reg_delta cache for rev_reg_id: {}, error: {}", rev_reg_id, err);
+            None
+        }
+    }
+}
+
+///
+/// Saves rev reg delta cache.
+/// Errors are silently ignored.
+///
+/// # Arguments
+/// `rev_reg_id`: revocation registry id.
+/// `cache`: Cache object.
+///
+pub fn set_rev_reg_delta_cache(rev_reg_id: &str, cache: &str) -> VcxResult<()> {
+    debug!("Setting rev_reg_delta_cache for rev_reg_id {}, cache {}", rev_reg_id, cache);
+    match serde_json::to_string(cache) {
+        Ok(json) => {
+            let wallet_id = format!("{}{}", REV_REG_DELTA_CACHE_PREFIX, rev_reg_id);
+            match update_record_value(CACHE_TYPE, &wallet_id, &json)
+                .or(add_record(CACHE_TYPE, &wallet_id, &json, None)) {
+                    Ok(_) => Ok(()),
+                    Err(err) => Err(err)
+                }
+        },
+        Err(_) => {
+            Err(VcxError::from(VcxErrorKind::SerializationError))
+        }
+    }
+}
+
+///
+///
+/// Clears the cache
+/// Errors are silently ignored.
+///
+/// # Arguments
+/// `rev_reg_id`: revocation registry id.
+/// `cache`: Cache object.
+///
+pub fn clear_rev_reg_delta_cache(rev_reg_id: &str) -> VcxResult<String> {
+    debug!("Clearing rev_reg_delta_cache for rev_reg_id {}", rev_reg_id);
+    if let Some(last_delta) = get_rev_reg_delta_cache(rev_reg_id) {
+        debug!("Got last delta = {}", last_delta);
+        let wallet_id = format!("{}{}", REV_REG_DELTA_CACHE_PREFIX, rev_reg_id);
+        delete_record(CACHE_TYPE, &wallet_id)?;
+        debug!("Record with id {} deleted", wallet_id);
+        Ok(last_delta)
+    } else {
+        Err(VcxError::from(VcxErrorKind::IOError))
+    }
+}
 
 #[cfg(test)]
 pub mod tests {

--- a/vcx/wrappers/node/src/api/credential-def.ts
+++ b/vcx/wrappers/node/src/api/credential-def.ts
@@ -358,8 +358,8 @@ export class CredentialDef extends VCXBase<ICredentialDefData> {
         (resolve, reject, cb) => {
           const rc = rustAPI().vcx_credentialdef_get_state(0, this.handle, cb)
           if (rc) {
-              reject(rc)
-            }
+            reject(rc)
+          }
         },
         (resolve, reject) => ffi.Callback(
           'void',
@@ -376,6 +376,31 @@ export class CredentialDef extends VCXBase<ICredentialDefData> {
       throw new VCXInternalError(err)
     }
   }
+
+  public async publishRevocations (): Promise<void> {
+    try {
+      await createFFICallbackPromise<number>(
+        (resolve, reject, cb) => {
+          const rc = rustAPI().vcx_credentialdef_publish_revocations(0, this.handle, cb)
+          if (rc) {
+            reject(rc)
+          }
+        },
+        (resolve, reject) => ffi.Callback(
+          'void',
+          ['uint32', 'uint32', 'uint32'],
+          (handle: number, err: any, state: CredentialDefState) => {
+            if (err) {
+              reject(err)
+            }
+            resolve(state)
+          })
+      )
+    } catch (err) {
+      throw new VCXInternalError(err)
+    }
+  }
+
 
   get name () {
     return this._name

--- a/vcx/wrappers/node/src/api/issuer-credential.ts
+++ b/vcx/wrappers/node/src/api/issuer-credential.ts
@@ -432,6 +432,31 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData> {
     }
   }
 
+  public async revokeCredentialLocal (): Promise<void> {
+    try {
+      await createFFICallbackPromise<void>(
+        (resolve, reject, cb) => {
+          const rc = rustAPI().vcx_issuer_revoke_credential_local(0, this.handle, cb)
+          if (rc) {
+            reject(rc)
+          }
+        },
+        (resolve, reject) => ffi.Callback(
+          'void',
+          ['uint32', 'uint32'],
+          (xcommandHandle: number, err: number) => {
+            if (err) {
+              reject(err)
+              return
+            }
+            resolve()
+          })
+      )
+    } catch (err) {
+      throw new VCXInternalError(err)
+    }
+  }
+
   get credDefHandle () {
     return this._credDefHandle
   }

--- a/vcx/wrappers/node/src/rustlib.ts
+++ b/vcx/wrappers/node/src/rustlib.ts
@@ -136,6 +136,7 @@ export interface IFFIEntryPoint {
   vcx_issuer_create_credential: (commandId: number, sourceId: string, credDefHandle: number, issuerDid: string | null,
                                  attr: string, credentialName: string, price: string, cb: any) => number,
   vcx_issuer_revoke_credential: (commandId: number, handle: number, cb: any) => number,
+  vcx_issuer_revoke_credential_local: (commandId: number, handle: number, cb: any) => number,
   vcx_issuer_send_credential: (commandId: number, credentialHandle: number, connectionHandle: number, cb: any) =>
     number,
   vcx_issuer_get_credential_msg: (commandId: number, credentialHandle: number, myPwDid: string, cb: any) =>
@@ -222,6 +223,7 @@ export interface IFFIEntryPoint {
   vcx_credentialdef_get_payment_txn: (commandId: number, handle: number, cb: any) => number,
   vcx_credentialdef_update_state: (commandId: number, handle: number, cb: any) => number,
   vcx_credentialdef_get_state: (commandId: number, handle: number, cb: any) => number,
+  vcx_credentialdef_publish_revocations: (commandId: number, handle: number, cb: any) => number,
 
   // schema
   vcx_schema_get_attributes: (commandId: number, sourceId: string, schemaId: string, cb: any) => number,
@@ -335,6 +337,7 @@ export const FFIConfiguration: { [ Key in keyof IFFIEntryPoint ]: any } = {
   vcx_issuer_create_credential: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_SOURCE_ID,
     FFI_CREDENTIALDEF_HANDLE, FFI_STRING_DATA, FFI_STRING_DATA, FFI_STRING_DATA, FFI_STRING_DATA, FFI_CALLBACK_PTR]],
   vcx_issuer_revoke_credential: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CALLBACK_PTR]],
+  vcx_issuer_revoke_credential_local: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CALLBACK_PTR]],
   vcx_issuer_send_credential: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CONNECTION_HANDLE,
     FFI_CALLBACK_PTR]],
   vcx_issuer_get_credential_msg: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_STRING_DATA,
@@ -418,6 +421,7 @@ export const FFIConfiguration: { [ Key in keyof IFFIEntryPoint ]: any } = {
   vcx_credentialdef_get_payment_txn: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE,FFI_CALLBACK_PTR]],
   vcx_credentialdef_update_state: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE,FFI_CALLBACK_PTR]],
   vcx_credentialdef_get_state: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE,FFI_CALLBACK_PTR]],
+  vcx_credentialdef_publish_revocations: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE,FFI_CALLBACK_PTR]],
 
   // logger
   vcx_set_default_logger: [FFI_ERROR_CODE, [FFI_STRING]],


### PR DESCRIPTION
Adds API to revoke credentials locally (saving / merging revocation registry entry to the wallet) and publish revocation registry entry to the ledger (i.e. make all revocations revoked locally public). 

Tested for both V2 and V3 (V3 with #2148 and #2112 merged in). 

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>