### PR TITLE
Fix taa py wrapper

### DIFF
--- a/vcx/wrappers/node/demo/faber.js
+++ b/vcx/wrappers/node/demo/faber.js
@@ -4,6 +4,7 @@ const { Proof } = require('../dist/src/api/proof')
 const { Connection } = require('../dist/src/api/connection')
 const { Schema } = require('./../dist/src/api/schema')
 const { StateType, ProofState } = require('../dist/src')
+const { setActiveTxnAuthorAgreementMeta, getLedgerAuthorAgreement } = require('./../dist/src/api/utils')
 const sleepPromise = require('sleep-promise')
 const demoCommon = require('./common')
 const { getRandomInt } = require('./common')
@@ -14,6 +15,8 @@ const { runScript } = require('./script-comon')
 
 const utime = Math.floor(new Date() / 1000)
 const optionalWebhook = 'http://localhost:7209/notifications/faber'
+
+const TAA_ACCEPT = process.env.TAA_ACCEPT === 'true' || false
 
 const provisionConfig = {
   agency_url: 'http://localhost:8080',
@@ -61,6 +64,13 @@ async function runFaber (options) {
 
   logger.info(`#2 Using following agent provision to initialize VCX ${JSON.stringify(agentProvision, null, 2)}`)
   await demoCommon.initVcxWithProvisionedAgentConfig(agentProvision)
+
+  if (TAA_ACCEPT) {
+    logger.info('#2.1 Accept transaction author agreement')
+    const taa = await getLedgerAuthorAgreement()
+    const taa_json = JSON.parse(taa)
+    await setActiveTxnAuthorAgreementMeta(taa_json.text, taa_json.version, null, Object.keys(taa_json.aml)[0], utime)
+  }
 
   const version = `${getRandomInt(1, 101)}.${getRandomInt(1, 101)}.${getRandomInt(1, 101)}`
   const schemaData = {

--- a/vcx/wrappers/python3/demo/faber.py
+++ b/vcx/wrappers/python3/demo/faber.py
@@ -60,9 +60,10 @@ async def main():
         print("#2.1 Accept transaction author agreement")
         txn_author_agreement = await vcx_get_ledger_author_agreement()
         txn_author_agreement_json = json.loads(txn_author_agreement)
+        first_acc_mech_type = list(txn_author_agreement_json['aml'].keys())[0]
         vcx_set_active_txn_author_agreement_meta(text=txn_author_agreement_json['text'], version=txn_author_agreement_json['version'],
                                                  hash=None,
-                                                 acc_mech_type="service_agreement", time_of_acceptance=int(time.time()))
+                                                 acc_mech_type=first_acc_mech_type, time_of_acceptance=int(time.time()))
 
     print("#3 Create a new schema on the ledger")
     version = format("%d.%d.%d" % (random.randint(1, 101), random.randint(1, 101), random.randint(1, 101)))

--- a/vcx/wrappers/python3/demo/faber.py
+++ b/vcx/wrappers/python3/demo/faber.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import random
+import os
+import time
 from ctypes import cdll
 from time import sleep
 
@@ -10,10 +12,11 @@ from vcx.api.credential_def import CredentialDef
 from vcx.api.issuer_credential import IssuerCredential
 from vcx.api.proof import Proof
 from vcx.api.schema import Schema
-from vcx.api.utils import vcx_agent_provision
+from vcx.api.utils import vcx_agent_provision, vcx_get_ledger_author_agreement, vcx_set_active_txn_author_agreement_meta
 from vcx.api.vcx_init import vcx_init_with_config
 from vcx.state import State, ProofState
 
+TAA_ACCEPT = bool(os.getenv("TAA_ACCEPT", "0") == "1")
 
 # logging.basicConfig(level=logging.DEBUG) uncomment to get logs
 
@@ -51,6 +54,15 @@ async def main():
 
     print("#2 Initialize libvcx with new configuration")
     await vcx_init_with_config(json.dumps(config))
+
+    if TAA_ACCEPT:
+        # To support ledger which transaction author agreement accept needed
+        print("#2.1 Accept transaction author agreement")
+        txn_author_agreement = await vcx_get_ledger_author_agreement()
+        txn_author_agreement_json = json.loads(txn_author_agreement)
+        vcx_set_active_txn_author_agreement_meta(text=txn_author_agreement_json['text'], version=txn_author_agreement_json['version'],
+                                                 hash=None,
+                                                 acc_mech_type="service_agreement", time_of_acceptance=int(time.time()))
 
     print("#3 Create a new schema on the ledger")
     version = format("%d.%d.%d" % (random.randint(1, 101), random.randint(1, 101), random.randint(1, 101)))

--- a/vcx/wrappers/python3/vcx/api/utils.py
+++ b/vcx/wrappers/python3/vcx/api/utils.py
@@ -210,9 +210,9 @@ def vcx_set_active_txn_author_agreement_meta(text: Optional[str],
 
     name = 'vcx_set_active_txn_author_agreement_meta'
 
-    c_text = c_char_p(json.dumps(text).encode('utf-8')) if text else None
-    c_version = c_char_p(json.dumps(version).encode('utf-8')) if version else None
-    c_hash = c_char_p(json.dumps(hash).encode('utf-8')) if hash else None
+    c_text = c_char_p(text.encode('utf-8')) if text else None
+    c_version = c_char_p(version.encode('utf-8')) if version else None
+    c_hash = c_char_p(hash.encode('utf-8')) if hash else None
     c_acc_mech_type = c_char_p(acc_mech_type.encode('utf-8'))
     c_time_of_acceptance = c_uint64(time_of_acceptance)
 


### PR DESCRIPTION
I tried to use vcx with the sovrin builder network and got an error while starting `faber.py` at step 3. Before fixes, it always returns.
```bash
#1 Provision an agent and wallet, get back configuration details
#2 Initialize libvcx with new configuration
#2.1 Accept transaction author agreement
#3 Create a new schema on the ledger
Traceback (most recent call last):
  File "faber.py", line 194, in <module>
    loop.run_until_complete(main())
  File "/home/user/.pyenv/versions/3.7.6/lib/python3.7/asyncio/base_events.py", line 583, in run_until_complete
    return future.result()
  File "faber.py", line 73, in main
    schema = await Schema.create(f'schema{str(random.randint(1, 101))}', 'degree schema asd', version, ['email', 'first_name', 'last_name'], 0)
  File "/home/user/Desktop/blockchain/indy-sdk/vcx/wrappers/python3/vcx/api/schema.py", line 106, in create
    schema = await Schema._create("vcx_schema_create", constructor_params, c_params)
  File "/home/user/Desktop/blockchain/indy-sdk/vcx/wrappers/python3/vcx/api/vcx_base.py", line 47, in _create
    cls.create.cb)
vcx.error.VcxError: (<ErrorCode.DuplicateSchema: 1088>, {'backtrace': '', 'cause': 'Reject { reason: "client request invalid: InvalidClientTaaAcceptanceError(\\\'Incorrect Txn Author Agreement(digest=273df4edd0756bc4354f587e2f73db01acee711f925fef69bc85f878c3b7dc15) in the request\\\',)" }', 'error': 'Duplicate Schema: Ledger Already Contains Schema For Given DID, Version, and Name Combination', 'message': 'Error: Duplicate Schema: Ledger Already Contains Schema For Given DID, Version, and Name Combination\n  Caused by: Reject { reason: "client request invalid: InvalidClientTaaAcceptanceError(\\\'Incorrect Txn Author Agreement(digest=273df4edd0756bc4354f587e2f73db01acee711f925fef69bc85f878c3b7dc15) in the request\\\',)" }\n'})
```

As tested on python cli
```bash
>>> test_str = "hashed_data"
>>> test_str
'hashed_data'
>>> import json
>>> json.dumps(test_str)
'"hashed_data"'
```

The string from json.dumps() result on `vcx_set_active_txn_author_agreement_meta` will have extra single quote that might have transaction author agreement always incorrect.

After removed json.dumps() from `vcx_set_active_txn_author_agreement_meta` all steps work

Sorry for close previous PR but, due to accidentally commit has been pushed that why I close it. It would be great if any contributor can remove the previous PR.

For the comments earlier are

-----
@mirgee 23 hours ago Contributor
What is the reason that json.dumps() was used previously? The typing clearly specifies str... Anyway, maybe we should raise a TypeError if text, version and hash are not either None or str.

-----
@Patrik-Stas 21 hours ago Contributor
Thanks for contribution @krgko ! +1

I don't know if it just me, but it seems like Sovrin BuilderNet is having some issues so it's difficult to verify the changes. I tried to basically port these changes to nodejs demo and run against Sovrin BuilderNet but getting probably unrelated issue:

```bash
TRACE|indy::services::payments      |           src/services/payments.rs:450 | _handle_constraint <<< result: Err(IndyError { inner:

The requester role "101" doesn't meet to constraint ""2"".

The transaction is not allowed to a requester })
```

@mirgee any luck testing this?