### PR TITLE
Add revoke credential API to VCX Java wrapper

### DIFF
--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -299,6 +299,8 @@ public abstract class LibVcx {
         /** Sets the credential request in an accepted state. (not in MVP) */
         public int vcx_issuer_accept_credential(int credential_handle);
 
+        /** Revokes credential. */
+        public int vcx_issuer_revoke_credential(int command_handle, int credential_handle, Callback cb);
 
     /**
      * proof object

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/issuer/IssuerApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/issuer/IssuerApi.java
@@ -326,4 +326,29 @@ public class IssuerApi extends VcxJava.API {
 
         return future;
     }
+
+    private static Callback issuerRevokeCredentialCB = new Callback() {
+        @SuppressWarnings({"unused", "unchecked"})
+        public void callback(int commandHandle, int err) {
+            logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "]");
+            CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);
+            if (!checkCallback(future, err)) return;
+            future.complete(err);
+        }
+    };
+
+    public static CompletableFuture<Integer> issuerRevokeCredential(int credentialHandle) throws VcxException {
+        ParamGuard.notNull(credentialHandle, "credentialHandle");
+        logger.debug("issuerRevokeCredential() called with: credentialHandle = [" + credentialHandle + "]");
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        int issue = addFuture(future);
+
+        int result = LibVcx.api.vcx_issuer_revoke_credential(
+                issue,
+                credentialHandle,
+                issuerRevokeCredentialCB);
+
+        checkResult(result);
+        return future;
+    }
 }


### PR DESCRIPTION
- issuerRevokeCredential (Java wrapper) -> vcx_issuer_revoke_credential (Rust LibVCX)
- Although this PR does not have build dependencies, it has been tested in https://github.com/hyperledger/indy-sdk/pull/2148.

Signed-off-by: Ethan Sung <baegjae@gmail.com>