### PR TITLE
Add update webhookurl API to VCX Java wrapper

### DIFF
--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -26,6 +26,7 @@ public abstract class LibVcx {
         public String vcx_version();
         public int vcx_shutdown(boolean delete);
         public int vcx_reset();
+        public int vcx_update_webhook_url(int command_handle, String notification_webhook_url, Callback cb);
 
     /**
      * Helper API for testing purposes.

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/vcx/VcxApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/vcx/VcxApi.java
@@ -100,4 +100,29 @@ public class VcxApi extends VcxJava.API {
 
     }
 
+    private static Callback vcxUpdateWebhookUrlCB = new Callback() {
+        @SuppressWarnings({"unused", "unchecked"})
+        public void callback(int commandHandle, int err) {
+            logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "]");
+            CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);
+            if (!checkCallback(future, err)) return;
+            future.complete(err);
+        }
+    };
+
+    public static CompletableFuture<Integer> vcxUpdateWebhookUrl(String notificationWebhookUrl) throws VcxException {
+        ParamGuard.notNullOrWhiteSpace(notificationWebhookUrl, "notificationWebhookUrl");
+        logger.debug("vcxUpdateWebhookUrl() called with: notificationWebhookUrl = [" + notificationWebhookUrl + "]");
+        CompletableFuture<Integer> future = new CompletableFuture<Integer>();
+        int commandHandle = addFuture(future);
+
+        int result = LibVcx.api.vcx_update_webhook_url(
+                commandHandle,
+                notificationWebhookUrl,
+                vcxUpdateWebhookUrlCB);
+        checkResult(result);
+
+        return future;
+    }
+
 }


### PR DESCRIPTION
- vcxUpdateWebhookUrl (Java wrapper) -> vcx_update_webhook_url (Rust LibVCX)
- Although this PR does not have build dependencies, it has been tested in https://github.com/hyperledger/indy-sdk/pull/2112.

Signed-off-by: Ethan Sung <baegjae@gmail.com>