### PR TITLE
VCX iOS wrapper updates

### DIFF
--- a/vcx/wrappers/ios/vcx/ConnectMeVcx.h
+++ b/vcx/wrappers/ios/vcx/ConnectMeVcx.h
@@ -182,6 +182,9 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
             recordId:(NSString *)recordId
            completion:(void (^)(NSError *error))completion;
 
+- (void) proofGetRequests:(NSInteger)connectionHandle
+              completion:(void (^)(NSError *error, NSString *requests))completion;
+
 - (void) proofRetrieveCredentials:(vcx_proof_handle_t)proofHandle
                    withCompletion:(void (^)(NSError *error, NSString *matchingCredentials))completion;
 

--- a/vcx/wrappers/ios/vcx/ConnectMeVcx.h
+++ b/vcx/wrappers/ios/vcx/ConnectMeVcx.h
@@ -89,11 +89,19 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
            connectionType:(NSString *)connectionType
                completion:(void (^)(NSError *error, NSString *inviteDetails))completion;
 
+- (void)connectionGetState:(NSInteger)connectionHandle
+                completion:(void (^)(NSError *error, NSInteger state))completion;
+
+- (void)connectionUpdateState:(NSInteger) connectionHandle
+                   completion:(void (^)(NSError *error, NSInteger state))completion;
+
 - (void)connectionSerialize:(NSInteger)connectionHandle
                  completion:(void (^)(NSError *error, NSString *serializedConnection))completion;
 
 - (void)connectionDeserialize:(NSString *)serializedConnection
                    completion:(void (^)(NSError *error, NSInteger connectionHandle))completion;
+
+- (int)connectionRelease:(NSInteger) connectionHandle;
 
 - (void)deleteConnection:(VcxHandle)connectionHandle
           withCompletion:(void (^)(NSError *error))completion;
@@ -147,6 +155,8 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
 - (void)credentialDeserialize:(NSString *)serializedCredential
                    completion:(void (^)(NSError *error, NSInteger credentialHandle))completion;
 
+- (int)credentialRelease:(NSInteger) credentialHandle;
+
 - (void)exportWallet:(NSString *)exportPath
          encryptWith:(NSString *)encryptionKey
           completion:(void (^)(NSError *error, NSInteger exportHandle))completion;
@@ -189,6 +199,12 @@ withSelectedCredentials:(NSString *)selectedCredentials
 withConnectionHandle:(vcx_connection_handle_t)connection_handle
     withCompletion:(void (^)(NSError *error))completion;
 
+- (void)proofGetState:(NSInteger)proofHandle
+           completion:(void (^)(NSError *error, NSInteger state))completion;
+
+- (void)proofUpdateState:(NSInteger) proofHandle
+              completion:(void (^)(NSError *error, NSInteger state))completion;
+
 - (void) proofReject: (vcx_proof_handle_t)proof_handle
       withConnectionHandle:(vcx_connection_handle_t)connection_handle
       withCompletion: (void (^)(NSError *error))completion;
@@ -215,6 +231,8 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
 
 - (void) proofDeserialize:(NSString *) serializedProof
            withCompletion:(void (^)(NSError *error, vcx_proof_handle_t proofHandle)) completion;
+
+- (int)proofRelease:(NSInteger) proofHandle;
 
 - (int)vcxShutdown:(BOOL *)deleteWallet;
 

--- a/vcx/wrappers/ios/vcx/ConnectMeVcx.m
+++ b/vcx/wrappers/ios/vcx/ConnectMeVcx.m
@@ -386,6 +386,36 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
+- (void)connectionGetState:(NSInteger)connectionHandle
+                completion:(void (^)(NSError *error, NSInteger state))completion {
+    vcx_error_t ret;
+    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    ret = vcx_connection_get_state(handle, connectionHandle, VcxWrapperCommonNumberCallback);
+    
+    if( ret != 0 )
+    {
+        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion([NSError errorFromVcxError: ret], 0);
+        });
+    }
+}
+
+- (void)connectionUpdateState:(NSInteger) connectionHandle
+                   completion:(void (^)(NSError *error, NSInteger state))completion {
+    vcx_error_t ret;
+    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    ret = vcx_connection_update_state(handle, connectionHandle, VcxWrapperCommonNumberCallback);
+    if( ret != 0 )
+    {
+        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion([NSError errorFromVcxError: ret], 0);
+        });
+    }
+}
+
 - (void)connectionSerialize:(NSInteger)connectionHandle
                   completion:(void (^)(NSError *error, NSString *serializedConnection))completion{
     vcx_error_t ret;
@@ -418,6 +448,10 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
            completion([NSError errorFromVcxError: ret],0);
        });
    }
+}
+
+- (int)connectionRelease:(NSInteger) connectionHandle {
+    return vcx_connection_release(connectionHandle);
 }
 
 - (void)deleteConnection:(VcxHandle)connectionHandle
@@ -704,6 +738,10 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
+- (int)credentialRelease:(NSInteger) credentialHandle {
+    return vcx_credential_release(credentialHandle);
+}
+
 - (void)exportWallet:(NSString *)exportPath
             encryptWith:(NSString *)encryptionKey
            completion:(void (^)(NSError *error, NSInteger exportHandle))completion {
@@ -905,6 +943,36 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     }
 }
 
+- (void)proofGetState:(NSInteger)proofHandle
+                completion:(void (^)(NSError *error, NSInteger state))completion {
+    vcx_error_t ret;
+    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    ret = vcx_disclosed_proof_get_state(handle, proofHandle, VcxWrapperCommonNumberCallback);
+    
+    if( ret != 0 )
+    {
+        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion([NSError errorFromVcxError: ret], 0);
+        });
+    }
+}
+
+- (void)proofUpdateState:(NSInteger) proofHandle
+                   completion:(void (^)(NSError *error, NSInteger state))completion {
+    vcx_error_t ret;
+    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    ret = vcx_disclosed_proof_update_state(handle, proofHandle, VcxWrapperCommonNumberCallback);
+    if( ret != 0 )
+    {
+        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion([NSError errorFromVcxError: ret], 0);
+        });
+    }
+}
+
 - (void) proofReject: (vcx_proof_handle_t)proof_handle withConnectionHandle:(vcx_connection_handle_t)connection_handle
       withCompletion: (void (^)(NSError *error))completion {
     vcx_error_t ret;
@@ -1045,6 +1113,9 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     }
 }
 
+- (int)proofRelease:(NSInteger) proofHandle {
+    return vcx_disclosed_proof_release(proofHandle);
+}
 
 - (void)createPaymentAddress:(NSString *)seed
               withCompletion:(void (^)(NSError *error, NSString *address))completion {

--- a/vcx/wrappers/ios/vcx/ConnectMeVcx.m
+++ b/vcx/wrappers/ios/vcx/ConnectMeVcx.m
@@ -866,6 +866,23 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
+- (void)proofGetRequests:(NSInteger)connectionHandle
+                   completion:(void (^)(NSError *error, NSString *requests))completion{
+   vcx_error_t ret;
+   vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+
+    ret = vcx_disclosed_proof_get_requests(handle,connectionHandle, VcxWrapperCommonStringCallback);
+
+   if( ret != 0 )
+   {
+       [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+       dispatch_async(dispatch_get_main_queue(), ^{
+           completion([NSError errorFromVcxError: ret],nil);
+       });
+   }
+}
+
 - (void) proofCreateWithMsgId:(NSString *)sourceId
          withConnectionHandle:(vcx_connection_handle_t)connectionHandle
                     withMsgId:(NSString *)msgId

--- a/vcx/wrappers/ios/vcx/include/libvcx.h
+++ b/vcx/wrappers/ios/vcx/include/libvcx.h
@@ -294,7 +294,7 @@ vcx_error_t vcx_connection_get_redirect_details(vcx_command_handle_t command_han
 vcx_error_t vcx_disclosed_proof_update_state(vcx_command_handle_t command_handle, vcx_proof_handle_t proof_handle, void (*cb)(vcx_command_handle_t xcommand_handle, vcx_error_t err, vcx_state_t state));
 
 /** Check for any proof requests from the connection. */
-vcx_error_t vcx_disclosed_proof_get_requests(vcx_command_handle_t command_handle, vcx_connection_handle_t connection_handle, void (*cb)(vcx_command_handle_t xcommand_handle, vcx_error_t err, const char *offers));
+vcx_error_t vcx_disclosed_proof_get_requests(vcx_command_handle_t command_handle, vcx_connection_handle_t connection_handle, void (*cb)(vcx_command_handle_t xcommand_handle, vcx_error_t err, const char *requests));
 
 /** Retrieves the state of the disclosed_proof. */
 vcx_error_t vcx_disclosed_proof_get_state(vcx_command_handle_t command_handle, vcx_proof_handle_t proof_handle, void (*cb)(vcx_command_handle_t xcommand_handle, vcx_error_t err, vcx_state_t state));


### PR DESCRIPTION
Added APIs
* connectionGetState, connectionUpdateState, connectionRelease
* credentialRelease
* proofGetRequests, proofGetState, proofUpdateState, proofRelease

Fixed 
* Fixed the parameter name of vcx_disclosed_proof_get_requests method (offers --> requests)

There are several data types for handles (connectionHandle, credentialHandle, proofHandle), and they are used Interchangeably. For example, for the connectionHandle, three data types (VcxHandle, NSInteger, vcx_connection_handle_t) are used in the code... I believe that there should be a consistent way of implementing it. In this PR, I only use NSInteger for all handles. 