### PR TITLE
Fix build error. Use latest version of "quote" (yanked), "failure" crates

### DIFF
--- a/libindy/Cargo.toml
+++ b/libindy/Cargo.toml
@@ -29,7 +29,7 @@ fatal_warnings = []
 [dependencies]
 env_logger = "0.7"
 etcommon-rlp = "0.2.4"
-failure = "0.1.6"
+failure = "0.1.7"
 hex = "0.3.2"
 libc = "0.2.66"
 log = "0.4.8"
@@ -55,7 +55,7 @@ regex = "1.2.1"
 indy-api-types = { path = "./indy-api-types"}
 indy-utils = { path = "./indy-utils"}
 indy-wallet = { path = "./indy-wallet"}
-quote = "=1.0.2"
+quote = "=1.0.7"
 
 [dependencies.uuid]
 version = "0.7.4"


### PR DESCRIPTION
Fix build error. Use latest version of "quote" crate since "quote=1.0.2" is yanked and use latest version of "failure" crate to avoid compile error.
