### PR TITLE
Use correct path for OpenSSL in local Mac build script

### DIFF
--- a/libindy/mac.build.sh
+++ b/libindy/mac.build.sh
@@ -41,10 +41,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     export CARGO_INCREMENTAL=1
     export RUST_LOG=indy=trace
     export RUST_TEST_THREADS=1
-    for version in `ls -t /usr/local/Cellar/openssl/`; do
-        export OPENSSL_DIR=/usr/local/Cellar/openssl/$version
-        break
-    done
+    export OPENSSL_DIR=/usr/local/opt/`ls /usr/local/opt/ | grep openssl | sort | tail -1`
     cargo build
     export LIBRARY_PATH=$(pwd)/target/debug
     cd ../cli


### PR DESCRIPTION
Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>

Update build script for Mac to use correct open ssl path. By default, MacOS comes with preinstalled open ssl at the location `/usr/local/Cellar`, but the brew package previously in this script installs updated open ssl at different location. This causes libindy not to load correctly.