### PR TITLE
VCX Aries: Fixed double escaping and sending of generic msgs.

### DIFF
--- a/vcx/libvcx/src/api/connection.rs
+++ b/vcx/libvcx/src/api/connection.rs
@@ -803,13 +803,13 @@ pub extern fn vcx_connection_send_message(command_handle: CommandHandle,
                                           msg: *const c_char,
                                           send_msg_options: *const c_char,
                                           cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, msg_id: *const c_char)>) -> u32 {
-    info!("vcx_message_send >>>");
+    info!("vcx_connection_send_message >>>");
 
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
     check_useful_c_str!(msg, VcxErrorKind::InvalidOption);
     check_useful_c_str!(send_msg_options, VcxErrorKind::InvalidOption);
 
-    trace!("vcx_message_send(command_handle: {}, connection_handle: {}, msg: {}, send_msg_options: {})",
+    trace!("vcx_connection_send_message(command_handle: {}, connection_handle: {}, msg: {}, send_msg_options: {})",
            command_handle, connection_handle, msg, send_msg_options);
 
     spawn(move || {

--- a/vcx/libvcx/src/v3/handlers/connection/connection.rs
+++ b/vcx/libvcx/src/v3/handlers/connection/connection.rs
@@ -183,16 +183,8 @@ impl Connection {
         AgentInfo::send_message_anonymously(message, did_doc)
     }
 
-    pub fn send_generic_message(&self, message: &str, _message_options: &str) -> VcxResult<String> {
-        trace!("Connection::send_generic_message >>> message: {:?}", message);
-
-        let message = match ::serde_json::from_str::<A2AMessage>(message) {
-            Ok(A2AMessage::Generic(message)) => {
-                BasicMessage::create()
-                    .set_content(message.to_string())
-                    .set_time()
-                    .to_a2a_message()
-            }
+    fn parse_generic_message(message: &str, _message_options: &str) -> A2AMessage {
+        match ::serde_json::from_str::<A2AMessage>(message) {
             Ok(a2a_message) => a2a_message,
             Err(_) => {
                 BasicMessage::create()
@@ -200,8 +192,13 @@ impl Connection {
                     .set_time()
                     .to_a2a_message()
             }
-        };
+        }
+    }
 
+    pub fn send_generic_message(&self, message: &str, _message_options: &str) -> VcxResult<String> {
+        trace!("Connection::send_generic_message >>> message: {:?}", message);
+
+        let message = Connection::parse_generic_message(message, _message_options);
         self.send_message(&message).map(|_| String::new())
     }
 
@@ -284,4 +281,40 @@ struct SideConnectionInfo {
     service_endpoint: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     protocols: Option<Vec<ProtocolDescriptor>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use v3::messages::a2a::A2AMessage;
+    use v3::handlers::connection::connection::Connection;
+
+    #[test]
+    fn test_parse_generic_message_plain_string_should_be_parsed_as_basic_msg() -> Result<(), String> {
+        let message = "Some plain text message";
+        let result = Connection::parse_generic_message(message, "");
+        match result {
+            A2AMessage::BasicMessage(basic_msg) => {
+                assert_eq!(basic_msg.content, message);
+                Ok(())
+            }
+            other => Err(format!("Result is not BasicMessage, but: {:?}", other))
+        }
+    }
+
+    #[test]
+    fn test_parse_generic_message_json_msg_should_be_parsed_as_generic() -> Result<(), String> {
+        let message = json!({
+            "@id": "some id",
+            "@type": "some type",
+            "content": "some content"
+        }).to_string();
+        let result = Connection::parse_generic_message(&message, "");
+        match result {
+            A2AMessage::Generic(value) => {
+                assert_eq!(value.to_string(), message);
+                Ok(())
+            }
+            other => Err(format!("Result is not Generic, but: {:?}", other))
+        }
+    }
 }

--- a/vcx/libvcx/src/v3/messages/a2a/mod.rs
+++ b/vcx/libvcx/src/v3/messages/a2a/mod.rs
@@ -72,7 +72,7 @@ pub enum A2AMessage {
     BasicMessage(BasicMessage),
 
     /// Any Raw Message
-    Generic(String),
+    Generic(Value),
 }
 
 impl<'de> Deserialize<'de> for A2AMessage {
@@ -81,7 +81,7 @@ impl<'de> Deserialize<'de> for A2AMessage {
 
         let message_type: MessageType = match serde_json::from_value(value["@type"].clone()) {
             Ok(message_type) => message_type,
-            Err(_) => return Ok(A2AMessage::Generic(value.to_string()))
+            Err(_) => return Ok(A2AMessage::Generic(value))
         };
 
         match (message_type.family, message_type.type_.as_str()) {
@@ -192,7 +192,7 @@ impl<'de> Deserialize<'de> for A2AMessage {
             }
             (_, other_type) => {
                 warn!("Unexpected @type field structure: {}", other_type);
-                Ok(A2AMessage::Generic(value.to_string()))
+                Ok(A2AMessage::Generic(value))
             }
         }
     }
@@ -229,7 +229,7 @@ impl Serialize for A2AMessage {
             A2AMessage::Query(msg) => set_a2a_message_type(msg, MessageFamilies::DiscoveryFeatures, A2AMessage::QUERY),
             A2AMessage::Disclose(msg) => set_a2a_message_type(msg, MessageFamilies::DiscoveryFeatures, A2AMessage::DISCLOSE),
             A2AMessage::BasicMessage(msg) => set_a2a_message_type(msg, MessageFamilies::Basicmessage, A2AMessage::BASIC_MESSAGE),
-            A2AMessage::Generic(msg) => ::serde_json::to_value(msg),
+            A2AMessage::Generic(msg) => Ok(msg.clone())
         }.map_err(ser::Error::custom)?;
 
         value.serialize(serializer)


### PR DESCRIPTION
Fixed sending generic msgs as BasicMsg (these are still sent if content is plain text).

Signed-off-by: Darko Kulic <darko.kulic@evernym.com>