### PR TITLE
Update rust toolchain from 1.39 to 1.40

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -1766,7 +1766,7 @@ def shell(command) {
 }
 
 def setupRust() {
-    shell("rustup default 1.39.0")
+    shell("rustup default 1.40.0")
 }
 
 def androidPublishing() {

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -866,7 +866,7 @@ def shell(command) {
 }
 
 def setupRust() {
-    shell("rustup default 1.39.0")
+    shell("rustup default 1.40.0")
 }
 
 def setupBrewPackages() {

--- a/libindy/ci/centos.dockerfile
+++ b/libindy/ci/centos.dockerfile
@@ -39,7 +39,7 @@ RUN wget https://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-mav
 RUN sed -i s/\$releasever/6/g /etc/yum.repos.d/epel-apache-maven.repo
 RUN yum install -y apache-maven
 
-ENV RUST_ARCHIVE=rust-1.39.0-x86_64-unknown-linux-gnu.tar.gz
+ENV RUST_ARCHIVE=rust-1.40.0-x86_64-unknown-linux-gnu.tar.gz
 ENV RUST_DOWNLOAD_URL=https://static.rust-lang.org/dist/$RUST_ARCHIVE
 
 RUN mkdir -p /rust

--- a/libindy/ci/ubuntu.dockerfile
+++ b/libindy/ci/ubuntu.dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN useradd -ms /bin/bash -u $uid indy
 USER indy
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.39.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.40.0
 ENV PATH /home/indy/.cargo/bin:$PATH
 
 RUN cargo install cargo-deb

--- a/libindy/ci/ubuntu18.dockerfile
+++ b/libindy/ci/ubuntu18.dockerfile
@@ -43,7 +43,7 @@ RUN apt-get install -y wget
 RUN useradd -ms /bin/bash -u $uid indy
 USER indy
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.39.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.40.0
 ENV PATH /home/indy/.cargo/bin:$PATH
 
 RUN cargo install cargo-deb

--- a/vcx/ci/ubuntu.dockerfile
+++ b/vcx/ci/ubuntu.dockerfile
@@ -60,7 +60,7 @@ ARG uid=1000
 RUN useradd -ms /bin/bash -u $uid vcx
 USER vcx
 
-ARG RUST_VER="1.39.0"
+ARG RUST_VER="1.40.0"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
 ENV PATH /home/vcx/.cargo/bin:$PATH
 

--- a/vcx/libvcx/build_scripts/ios/mac/mac.01.libindy.setup.sh
+++ b/vcx/libvcx/build_scripts/ios/mac/mac.01.libindy.setup.sh
@@ -44,7 +44,7 @@ fi
 
 if [[ $RUSTUP_VERSION =~ ^'rustup ' ]]; then
     rustup update
-    rustup default 1.39.0
+    rustup default 1.40.0
     rustup component add rls-preview rust-analysis rust-src
     echo "Using rustc version $(rustc --version)"
     rustup target add aarch64-apple-ios armv7-apple-ios armv7s-apple-ios x86_64-apple-ios i386-apple-ios


### PR DESCRIPTION
Due to unidentified reason, builds started fail with
```
   Compiling quote v0.6.13
   Compiling aho-corasick v0.7.12
error[E0658]: `cfg(doctest)` is experimental and subject to change
   --> /home/indy/.cargo/registry/src/github.com-1ecc6299db9ec823/aho-corasick-0.7.12/src/lib.rs:190:7
    |
190 | #[cfg(doctest)]
    |       ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62210
error[E0658]: `cfg(doctest)` is experimental and subject to change
   --> /home/indy/.cargo/registry/src/github.com-1ecc6299db9ec823/aho-corasick-0.7.12/src/lib.rs:194:7
    |
194 | #[cfg(doctest)]
    |       ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62210
```
As is noted https://stackoverflow.com/questions/62383641/errore0658-cfgdoctest-is-experimental-and-subject-to-change
`cfg(doctest)` used by `aho-corasick v0.7.12` 
```
├── ursa v0.3.2
│   ├── env_logger v0.7.1
│   │   ├── atty v0.2.14
│   │   │   └── libc v0.2.71 (*)
│   │   ├── humantime v1.3.0
│   │   │   └── quick-error v1.2.3
│   │   ├── log v0.4.8 (*)
│   │   ├── regex v1.3.9
│   │   │   ├── aho-corasick v0.7.12
│   │   │   │   └── memchr v2.3.3 (*)
│   │   │   ├── memchr v2.3.3 (*)
│   │   │   ├── regex-syntax v0.6.18
│   │   │   └── thread_local v1.0.1
│   │   │       └── lazy_static v1.4.0 (*)
│   │   └── termcolor v1.1.0
```
As noted in the SO link, `cfg(doctest) should be stable since 1.40,` so this fixes the issue, tested locally (and confirmed I get the same error with rust 1.39.0 as well)

But I wonder why it broke so suddenly, why didn't these errors appear previously - any idea?
