### PR TITLE
VCX - Make a comment field as an optional

### DIFF
--- a/vcx/libvcx/src/v3/messages/issuance/credential.rs
+++ b/vcx/libvcx/src/v3/messages/issuance/credential.rs
@@ -12,7 +12,8 @@ use std::convert::TryInto;
 pub struct Credential {
     #[serde(rename = "@id")]
     pub id: MessageId,
-    pub comment: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
     #[serde(rename = "credentials~attach")]
     pub credentials_attach: Attachments,
     #[serde(rename = "~thread")]
@@ -28,7 +29,7 @@ impl Credential {
     }
 
     pub fn set_comment(mut self, comment: String) -> Self {
-        self.comment = comment;
+        self.comment = Some(comment);
         self
     }
 
@@ -98,7 +99,7 @@ pub mod tests {
 
         Credential {
             id: MessageId::id(),
-            comment: _comment(),
+            comment: Some(_comment()),
             thread: thread(),
             credentials_attach: attachment,
             please_ack: None,

--- a/vcx/libvcx/src/v3/messages/issuance/credential_offer.rs
+++ b/vcx/libvcx/src/v3/messages/issuance/credential_offer.rs
@@ -12,7 +12,8 @@ use std::convert::TryInto;
 pub struct CredentialOffer {
     #[serde(rename = "@id")]
     pub id: MessageId,
-    pub comment: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
     pub credential_preview: CredentialPreviewData,
     #[serde(rename = "offers~attach")]
     pub offers_attach: Attachments,
@@ -32,7 +33,7 @@ impl CredentialOffer {
     }
 
     pub fn set_comment(mut self, comment: String) -> Self {
-        self.comment = comment;
+        self.comment = Some(comment);
         self
     }
 
@@ -147,7 +148,7 @@ pub mod tests {
 
         CredentialOffer {
             id: MessageId::id(),
-            comment: _comment(),
+            comment: Some(_comment()),
             credential_preview: _preview_data(),
             offers_attach: attachment,
             thread: Some(_thread()),

--- a/vcx/libvcx/src/v3/messages/issuance/credential_proposal.rs
+++ b/vcx/libvcx/src/v3/messages/issuance/credential_proposal.rs
@@ -8,7 +8,8 @@ use messages::thread::Thread;
 pub struct CredentialProposal {
     #[serde(rename = "@id")]
     pub id: MessageId,
-    pub comment: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
     pub credential_proposal: CredentialPreviewData,
     pub schema_id: String,
     pub cred_def_id: String,
@@ -23,7 +24,7 @@ impl CredentialProposal {
     }
 
     pub fn set_comment(mut self, comment: String) -> Self {
-        self.comment = comment;
+        self.comment = Some(comment);
         self
     }
 
@@ -77,7 +78,7 @@ pub mod tests {
     pub fn _credential_proposal() -> CredentialProposal {
         CredentialProposal {
             id: MessageId::id(),
-            comment: _comment(),
+            comment: Some(_comment()),
             credential_proposal: _credential_preview_data(),
             schema_id: _schema_id(),
             thread: Some(thread()),


### PR DESCRIPTION
According to aries rfcs 
https://github.com/hyperledger/aries-rfcs/tree/master/features/0036-issue-credential
https://github.com/hyperledger/aries-rfcs/tree/master/features/0453-issue-credential-v2
the comment field is an optional field. 
However, libvcx expects this as a mandatary, so if the comment is empty it causes Json parsing error 
```
Caused by: Cannot deserialize A2A message: missing field 'comment'
```
This PR fixes this issue.