### PR TITLE
Fix indy_prover_delete_credential JNA callback

### DIFF
--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
@@ -321,7 +321,7 @@ public class Anoncreds extends IndyJava.API {
 	 *
 	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
 	 */
-	public static CompletableFuture<String>issuerRotateCredentialDefStart(
+	public static CompletableFuture<String> issuerRotateCredentialDefStart(
 			Wallet wallet,
 			String credDefId,
 			String configJson) throws IndyException {
@@ -358,7 +358,7 @@ public class Anoncreds extends IndyJava.API {
 	 *
 	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
 	 */
-	public static CompletableFuture<Void>issuerRotateCredentialDefApply(
+	public static CompletableFuture<Void> issuerRotateCredentialDefApply(
 			Wallet wallet,
 			String credDefId) throws IndyException {
 
@@ -1003,7 +1003,7 @@ public class Anoncreds extends IndyJava.API {
 				commandHandle,
 				walletHandle,
 				credId,
-				stringCb);
+				voidCb);
 
 		checkResult(future, result);
 


### PR DESCRIPTION
Fixing issue where `indy_prover_delete_credential` in Java was expecting to get back string in callback method does not return one. 

This was causing crashes on Android 23 devices and below
```
/apex/com.android.runtime/lib64/bionic/libc.so (strlen+16) (BuildId: 99d256d401014e290f38edaacced78da)
/data/app/net.globalid.aries.test-WNnANtndag0UbHLXUDTDjg==/lib/arm64/libjnidispatch.so (Java_com_sun_jna_Native_getStringBytes+32)
/apex/com.android.runtime/lib64/libart.so (art_quick_generic_jni_trampoline+144) (BuildId: 696d39ffaba44c5a3159a32a6f139534)
/memfd:/jit-cache (deleted) (com.sun.jna.Native.getString+76)
...
```