### PR TITLE
Update postgres index to use md5

### DIFF
--- a/experimental/plugins/postgres_storage/src/postgres_storage.rs
+++ b/experimental/plugins/postgres_storage/src/postgres_storage.rs
@@ -146,7 +146,7 @@ const _CREATE_SCHEMA: [&str; 12] = [
             ON UPDATE CASCADE
     )",
     "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_name ON tags_encrypted(name)",
-    "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_value ON tags_encrypted(md5(value))",
+    "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_value ON tags_encrypted(sha256(value))",
     "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_item_id ON tags_encrypted(item_id)",
     "CREATE TABLE IF NOT EXISTS tags_plaintext(
         name BYTEA NOT NULL,

--- a/experimental/plugins/postgres_storage/src/postgres_storage.rs
+++ b/experimental/plugins/postgres_storage/src/postgres_storage.rs
@@ -146,7 +146,7 @@ const _CREATE_SCHEMA: [&str; 12] = [
             ON UPDATE CASCADE
     )",
     "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_name ON tags_encrypted(name)",
-    "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_value ON tags_encrypted(value)",
+    "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_value ON tags_encrypted(md5(value))",
     "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_item_id ON tags_encrypted(item_id)",
     "CREATE TABLE IF NOT EXISTS tags_plaintext(
         name BYTEA NOT NULL,


### PR DESCRIPTION
Updates ix_tags_encrypted_value to use md5 so it can support larger values (eg images)
FYI @ianco 
Signed-off-by: Jacob Saur <jsaur@kiva.org>