### PR TITLE
nodejs: fix order of arguments to buildGetAttribRequest

### DIFF
--- a/wrappers/nodejs/README.md
+++ b/wrappers/nodejs/README.md
@@ -1649,14 +1649,14 @@ Builds an ATTRIB request. Request to add attribute to a NYM record.
 
 Errors: `Common*`
 
-#### buildGetAttribRequest \( submitterDid, targetDid, hash, raw, enc \) -&gt; request
+#### buildGetAttribRequest \( submitterDid, targetDid, raw, hash, enc \) -&gt; request
 
 Builds a GET\_ATTRIB request. Request to get information about an Attribute for the specified DID.
 
 * `submitterDid`: String - \(Optional\) DID of the read request sender \(if not provided then default Libindy DID will be used\).
 * `targetDid`: String - Target DID as base58-encoded string for 16 or 32 bit DID value.
-* `hash`: String - \(Optional\) Requested attribute hash.
 * `raw`: String - \(Optional\) Requested attribute name.
+* `hash`: String - \(Optional\) Requested attribute hash.
 * `enc`: String - \(Optional\) Requested attribute encrypted value.
 * __->__ `request`: Json
 

--- a/wrappers/nodejs/src/index.js
+++ b/wrappers/nodejs/src/index.js
@@ -431,9 +431,9 @@ indy.buildAttribRequest = function buildAttribRequest (submitterDid, targetDid, 
   return cb.promise
 }
 
-indy.buildGetAttribRequest = function buildGetAttribRequest (submitterDid, targetDid, hash, raw, enc, cb) {
+indy.buildGetAttribRequest = function buildGetAttribRequest (submitterDid, targetDid, raw, hash, enc, cb) {
   cb = wrapIndyCallback(cb, fromJson)
-  capi.buildGetAttribRequest(submitterDid, targetDid, hash, raw, enc, cb)
+  capi.buildGetAttribRequest(submitterDid, targetDid, raw, hash, enc, cb)
   return cb.promise
 }
 

--- a/wrappers/nodejs/src/indy.cc
+++ b/wrappers/nodejs/src/indy.cc
@@ -1702,8 +1702,8 @@ NAN_METHOD(buildGetAttribRequest) {
   INDY_ASSERT_NARGS(buildGetAttribRequest, 6)
   INDY_ASSERT_STRING(buildGetAttribRequest, 0, submitterDid)
   INDY_ASSERT_STRING(buildGetAttribRequest, 1, targetDid)
-  INDY_ASSERT_STRING(buildGetAttribRequest, 2, hash)
-  INDY_ASSERT_STRING(buildGetAttribRequest, 3, raw)
+  INDY_ASSERT_STRING(buildGetAttribRequest, 2, raw)
+  INDY_ASSERT_STRING(buildGetAttribRequest, 3, hash)
   INDY_ASSERT_STRING(buildGetAttribRequest, 4, enc)
   INDY_ASSERT_FUNCTION(buildGetAttribRequest, 5)
   const char* arg0 = argToCString(info[0]);


### PR DESCRIPTION
Libindy's build_get_attrib_request API expects the arguments in a different order

Refer to: https://github.com/hyperledger/indy-sdk/blob/d8c68d7894be07ef50f5d1c4aa6326a201da030f/libindy/src/api/ledger.rs#L564