### PR TITLE
Java wrapper: Setting revoc dir in tests

### DIFF
--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/interaction/AnoncredsVerifyProofAfterCredentialRevokeTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/interaction/AnoncredsVerifyProofAfterCredentialRevokeTest.java
@@ -12,6 +12,7 @@ import org.hyperledger.indy.sdk.did.DidResults;
 import org.hyperledger.indy.sdk.ledger.Ledger;
 import org.hyperledger.indy.sdk.ledger.LedgerResults;
 import org.hyperledger.indy.sdk.ledger.LedgerResults.ParseResponseResult;
+import org.hyperledger.indy.sdk.utils.EnvironmentUtils;
 import org.hyperledger.indy.sdk.utils.PoolUtils;
 import org.hyperledger.indy.sdk.wallet.Wallet;
 import org.json.JSONArray;
@@ -29,7 +30,7 @@ import static org.junit.Assert.assertFalse;
 public class AnoncredsVerifyProofAfterCredentialRevokeTest extends IndyIntegrationTestWithPoolAndSingleWallet {
 	// This test is a copy of a project attached to IS-1368. We omitted pool and wallet preparation.
 
-	private static String indyClientPath;
+	private static final String indyClientPath = EnvironmentUtils.getTmpPath();
 
 	@Test
 	public void testAnoncredsVerifyProofAfterCredentialRevoke() throws Exception {


### PR DESCRIPTION
The declared field was never initialized. From that, the path was always `null/revoc_dir/` which works for most environments as it will just create a folder with name null. But one some environment this becomes an issue. For example, Android would take the current directory in `/` and would then try to create directory `/null`. Application space of course does not have permission to write to `/` so this would fail with IO Error.