### PR TITLE
updated getting-started.dockerfile to use 'notebook' instead of 'ipyt…

### DIFF
--- a/docs/getting-started/getting-started.dockerfile
+++ b/docs/getting-started/getting-started.dockerfile
@@ -16,8 +16,8 @@ WORKDIR /home/indy
 
 RUN pip3 install -U \
 	pip \
-	ipython-notebook \
-      ipython==7.9 \
+	notebook \
+        ipython==7.9 \
 	setuptools \
 	jupyter \
 	python3-indy==1.11.0


### PR DESCRIPTION
…hon-notebook'

there doesn't seem to be any current version of 'ipython-notebook' as opposed to just 'notebook'