### PR TITLE
ipython-notebook to notebook as old version no longer supported

### DIFF
--- a/docs/getting-started/getting-started.dockerfile
+++ b/docs/getting-started/getting-started.dockerfile
@@ -16,8 +16,8 @@ WORKDIR /home/indy
 
 RUN pip3 install -U \
 	pip \
-	ipython-notebook \
-      ipython==7.9 \
+	notebook \
+      	ipython==7.9 \
 	setuptools \
 	jupyter \
 	python3-indy==1.11.0


### PR DESCRIPTION
Signed-off-by: colpclark <colin.clark@xaiow.com>

jupyter have changed the name of ipython-notebook to just notebook now so I updated the getting-started.dockerfile in the docs directory to reflect this