### PR TITLE
Fixes #2304 Java wrapper for `indy_list_pools` Indy SDK function

### DIFF
--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
@@ -31,6 +31,7 @@ public abstract class LibIndy {
 		public int indy_close_pool_ledger(int command_handle, int handle, Callback cb);
 		public int indy_delete_pool_ledger_config(int command_handle, String config_name, Callback cb);
 		public int indy_set_protocol_version(int command_handle, int protocol_version, Callback cb);
+		public int indy_list_pools(int command_handle, Callback cb);
 
 		// wallet.rs
 

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
@@ -73,6 +73,22 @@ public class Pool extends IndyJava.API implements AutoCloseable {
 			future.complete(result);
 		}
 	};
+
+	/**
+	 * Callback used when listPools completes.
+	 */
+	private static Callback listPoolsCb = new Callback() {
+
+		@SuppressWarnings({"unused", "unchecked"})
+		public void callback(int xcommand_handle, int err, String metadata) {
+
+			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(xcommand_handle);
+			if (! checkResult(future, err)) return;
+
+			String result = metadata;
+			future.complete(result);
+		}
+	};
 	
 	/*
 	 * STATIC METHODS
@@ -253,6 +269,26 @@ public class Pool extends IndyJava.API implements AutoCloseable {
 				commandHandle,
 				protocolVersion,
 				voidCb);
+
+		checkResult(future, result);
+
+		return future;
+	}
+
+	/**
+	 * Lists names of created pool ledgers
+	 *
+	 * @return A future that does not resolve a value.
+	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
+	 */
+	public static CompletableFuture<String> listPools() throws IndyException {
+
+		CompletableFuture<String> future = new CompletableFuture<String>();
+		int commandHandle = addFuture(future);
+
+		int result = LibIndy.api.indy_list_pools(
+				commandHandle,
+				listPoolsCb);
 
 		checkResult(future, result);
 

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/pool/Pool.java
@@ -278,7 +278,9 @@ public class Pool extends IndyJava.API implements AutoCloseable {
 	/**
 	 * Lists names of created pool ledgers
 	 *
-	 * @return A future that does not resolve a value.
+	 * @return A future resolving to a list of pools: [{
+	 *     "pool": string - Name of pool ledger stored in the wallet.
+	 *   }]
 	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
 	 */
 	public static CompletableFuture<String> listPools() throws IndyException {

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/pool/ListPoolsTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/pool/ListPoolsTest.java
@@ -14,13 +14,13 @@ import static org.junit.Assert.assertEquals;
 public class ListPoolsTest extends IndyIntegrationTest {
 
     @Test
-    public void testCreatePoolWorksForNullConfig() throws Exception {
-        File file = new File("testCreatePoolWorks.txn");
+    public void testListPoolsWorks() throws Exception {
+        File file = new File("testListPoolsWorks.txn");
         file.deleteOnExit();
         assertTrue(file.createNewFile());
         PoolUtils.writeTransactions(file);
 
-        String testPoolName = "testCreatePoolWorks";
+        String testPoolName = "testListPoolsWorks";
 
         Pool.createPoolLedgerConfig(testPoolName, null).get();
         String listPoolsJson = Pool.listPools().get();

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/pool/ListPoolsTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/pool/ListPoolsTest.java
@@ -1,0 +1,34 @@
+package org.hyperledger.indy.sdk.pool;
+
+import org.hyperledger.indy.sdk.IndyIntegrationTest;
+import org.hyperledger.indy.sdk.utils.PoolUtils;
+
+import org.junit.Test;
+import org.json.JSONArray;
+
+import java.io.File;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class ListPoolsTest extends IndyIntegrationTest {
+
+    @Test
+    public void testCreatePoolWorksForNullConfig() throws Exception {
+        File file = new File("testCreatePoolWorks.txn");
+        file.deleteOnExit();
+        assertTrue(file.createNewFile());
+        PoolUtils.writeTransactions(file);
+
+        String testPoolName = "testCreatePoolWorks";
+
+        Pool.createPoolLedgerConfig(testPoolName, null).get();
+        String listPoolsJson = Pool.listPools().get();
+
+        JSONArray listPools = new JSONArray(listPoolsJson);
+
+        assertEquals(1, listPools.length());
+        assertEquals(testPoolName, listPools.getJSONObject(0).getString("pool"));
+    }
+
+}


### PR DESCRIPTION
A wrapper function for the `indy_list_pools` Indy SDK function was missing in the Java SDK.