### PR TITLE
Update postgres index in multi-wallet to use md5

### DIFF
--- a/experimental/plugins/postgres_storage/src/postgres_storage.rs
+++ b/experimental/plugins/postgres_storage/src/postgres_storage.rs
@@ -196,7 +196,7 @@ const _CREATE_SCHEMA_MULTI: [&str; 14] = [
             ON UPDATE CASCADE
     )",
     "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_name ON tags_encrypted(wallet_id, name)",
-    "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_value ON tags_encrypted(wallet_id, value)",
+    "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_value ON tags_encrypted(wallet_id, md5(value))",
     "CREATE INDEX IF NOT EXISTS ix_tags_encrypted_wallet_id_item_id ON tags_encrypted(wallet_id, item_id)",
     "CREATE TABLE IF NOT EXISTS tags_plaintext(
         wallet_id VARCHAR(64) NOT NULL,


### PR DESCRIPTION
https://github.com/hyperledger/indy-sdk/pull/2232 supported saving big files in postgres.
However, it did not apply to `MultiWalletSingleTable` and `MultiWalletSingleTableSharedPool` modes.

This PR solves the above issue.
@ianco 

Signed-off-by: Ethan Sung <baegjae@gmail.com>