### PR TITLE
Update Rusqlite to version 0.25.3

### DIFF
--- a/libindy/Cargo.lock
+++ b/libindy/Cargo.lock
@@ -55,6 +55,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,7 +787,18 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -786,6 +808,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
 dependencies = [
  "polyval",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -841,7 +881,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indy"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "failure",
  "futures",
@@ -875,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "indy-sys"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "libc",
  "pkg-config",
@@ -964,7 +1004,7 @@ checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 
 [[package]]
 name = "libindy"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "android_logger",
  "backtrace",
@@ -1039,20 +1079,14 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.16.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "log"
@@ -1083,15 +1117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0136257df209261daa18d6c16394757c63e032e27aafd8b07788b051082bef"
 dependencies = [
  "log",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -1222,6 +1247,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -1369,7 +1400,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -1417,7 +1448,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
 ]
 
 [[package]]
@@ -1548,7 +1579,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -1603,17 +1634,17 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.20.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"
+checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
+ "hashlink",
  "libsqlite3-sys",
- "lru-cache",
  "memchr",
- "time",
+ "smallvec",
 ]
 
 [[package]]
@@ -1788,6 +1819,12 @@ dependencies = [
  "keccak",
  "opaque-debug 0.3.0",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "sodiumoxide"
@@ -2062,6 +2099,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/libindy/indy-api-types/Cargo.toml
+++ b/libindy/indy-api-types/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2.66"
 log = "0.4.8"
 openssl = {version = "0.10", optional = true}
 rust-base58 = {version = "0.0.4", optional = true}
-rusqlite = {version = "0.20", optional = true}  # Make sure rusqlite for android is also bumped with this. Rusqlite for android is at the bottom of this document.
+rusqlite = {version = "0.25.3", optional = true}  # Make sure rusqlite for android is also bumped with this. Rusqlite for android is at the bottom of this document.
 serde = "1.0.99"
 serde_json = "1.0.40"
 serde_derive = "1.0.99"
@@ -28,4 +28,4 @@ optional = true
 features = ["logger"]
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-rusqlite = { version = "0.20", features=["bundled"], optional = true }
+rusqlite = { version = "0.25.3", features=["bundled"], optional = true }

--- a/libindy/indy-api-types/src/errors.rs
+++ b/libindy/indy-api-types/src/errors.rs
@@ -269,7 +269,7 @@ impl From<rusqlite::Error> for IndyError {
             rusqlite::Error::SqliteFailure(
                 rusqlite::ffi::Error { code: rusqlite::ffi::ErrorCode::ConstraintViolation, .. }, _) =>
                 err.to_indy(IndyErrorKind::WalletItemAlreadyExists, "Wallet item already exists"),
-            rusqlite::Error::SqliteFailure(rusqlite::ffi::Error { code: rusqlite::ffi::ErrorCode::SystemIOFailure, .. }, _) =>
+            rusqlite::Error::SqliteFailure(rusqlite::ffi::Error { code: rusqlite::ffi::ErrorCode::SystemIoFailure, .. }, _) =>
                 err.to_indy(IndyErrorKind::IOError, "IO error during access sqlite database"),
             _ => err.to_indy(IndyErrorKind::InvalidState, "Unexpected sqlite error"),
         }

--- a/libindy/indy-wallet/Cargo.toml
+++ b/libindy/indy-wallet/Cargo.toml
@@ -14,7 +14,7 @@ libc = "*"
 log = "0.4.8"
 owning_ref = "0.4"
 rmp-serde = "0.13.7"
-rusqlite = "0.20" # Make sure rusqlite for android is also bumped with this. Rusqlite for android is at the bottom of this document.
+rusqlite = "0.25.3" # Make sure rusqlite for android is also bumped with this. Rusqlite for android is at the bottom of this document.
 rust-base58 = "0.0.4"
 serde = "1.0.99"
 serde_json = "1.0.40"
@@ -26,4 +26,4 @@ rand = "0.7.0"
 lazy_static = "1.3"
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-rusqlite = { version = "0.20", features=["bundled"] }
+rusqlite = { version = "0.25.3", features=["bundled"] }

--- a/libindy/indy-wallet/src/storage/default/mod.rs
+++ b/libindy/indy-wallet/src/storage/default/mod.rs
@@ -495,7 +495,7 @@ impl WalletStorage for SQLiteStorage {
     fn get_storage_metadata(&self) -> IndyResult<Vec<u8>> {
         self.conn.query_row(
             "SELECT value FROM metadata",
-            rusqlite::NO_PARAMS,
+            [],
             |row| { row.get(0) },
         ).map_err(IndyError::from)
     }
@@ -534,7 +534,7 @@ impl WalletStorage for SQLiteStorage {
 
             let res: Option<usize> = Option::from(self.conn.query_row(
                 &query_string,
-                &query_arguments,
+                &*query_arguments,
                 |row| {
                     let x: i64 = row.get(0)?;
                     Ok(x as usize)
@@ -727,14 +727,14 @@ impl WalletStorageType for SQLiteStorageType {
         // set journal mode to WAL, because it provides better performance.
         let journal_mode: String = conn.query_row(
             "PRAGMA journal_mode = WAL",
-            rusqlite::NO_PARAMS,
+            [],
             |row| { row.get(0) },
         )?;
 
         // if journal mode is set to WAL, set synchronous to FULL for safety reasons.
         // (synchronous = NORMAL with journal_mode = WAL does not guaranties durability).
         if journal_mode.to_lowercase() == "wal" {
-            conn.execute("PRAGMA synchronous = FULL", rusqlite::NO_PARAMS)?;
+            conn.execute("PRAGMA synchronous = FULL", [])?;
         }
 
         Ok(Box::new(SQLiteStorage { conn: Rc::new(conn) }))

--- a/libindy/indy-wallet/src/storage/default/transaction.rs
+++ b/libindy/indy-wallet/src/storage/default/transaction.rs
@@ -14,6 +14,7 @@ impl<'conn> Transaction<'conn> {
             TransactionBehavior::Deferred => "BEGIN DEFERRED",
             TransactionBehavior::Immediate => "BEGIN IMMEDIATE",
             TransactionBehavior::Exclusive => "BEGIN EXCLUSIVE",
+            _ => ""
         };
         conn.execute_batch(query)
             .map(move |_| {
@@ -75,8 +76,8 @@ impl<'conn> Transaction<'conn> {
             DropBehavior::Commit => self.commit_(),
             DropBehavior::Rollback => self.rollback_(),
             DropBehavior::Ignore => Ok(()),
-            DropBehavior::Panic => {
-                panic!("drop behaviour is set to panic".to_string());
+            _ => {
+                panic!("internal error: unsupported drop behaviour");
             }
         }
     }


### PR DESCRIPTION
The current version of `rusqlite` (0.20.0) is transitively dependent on `linked-hash-map v0.5.3`, which contains a bug ([fixed](https://github.com/contain-rs/linked-hash-map/pull/106) in version `0.5.4`). This bug causes runtime panics due to uninitialized reference on wallet access since rust `1.48.0`. See [here](https://github.com/mehcode/config-rs/issues/158), [here](https://github.com/hyperledger/aries-vcx/pull/126), and [here](https://github.com/hyperledger/indy-sdk/pull/2311).

This PR updates version of rusqlite which fixes the bug (replicating the changes in #2311 with green DCO), as the latest version of rusqlite removes dependency on `linked-hash-map`.

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>