### PR TITLE
fix(node): reworked binding.gyp

### DIFF
--- a/wrappers/nodejs/binding.gyp
+++ b/wrappers/nodejs/binding.gyp
@@ -2,36 +2,35 @@
   "targets": [
     {
       "target_name": "indynodejs",
-      "include_dirs": [
-        "<!(node -e \"require('nan')\")",
-        "<(module_root_dir)/include",
-        "<(module_root_dir)/../../libindy/include"
-      ],
-      "sources": [
-        "src/indy.cc"
-      ],
-      "link_settings": {
-        "conditions": [
-          [ 'OS=="win"',
-            {
-              'library_dirs': [
-                "<(module_root_dir)",
-                "<!(node -e \"console.log(process.env.LD_LIBRARY_PATH || '')\")"
-              ],
-              'libraries': [
-                "indy.dll.lib"
-              ]
-            },
-            {
-              'libraries': [
-                "-L<(module_root_dir)",
-                "<!(node -e \"console.log((process.env.LD_LIBRARY_PATH || '').split(':').map(a => '-L' + a.trim()).filter(a => a != '-L').join(' '))\")",
-                "-lindy"
-              ],
-            },
-          ]
+      "include_dirs": ["<!(node -e \"require('nan')\")", "<(module_root_dir)/include"],
+      "sources": ["src/indy.cc"],
+      "conditions": [
+        [
+          "OS=='mac'",
+          {
+            "library_dirs": ["/usr/local/lib/", "/opt/homebrew/lib/"],
+            "link_settings": {
+              "libraries": ["libindy.dylib"]
+            }
+          }
         ],
-      }
+        [
+          "OS=='win'",
+          {
+            "library_dirs": ["<(module_root_dir)"],
+            "libraries": ["indy.dll.lib"]
+          }
+        ],
+        [
+          "OS=='linux'",
+          {
+            "library_dirs": ["/usr/local/lib/", "/usr/lib/"],
+            "link_settings": {
+              "libraries": ["libindy.so"]
+            }
+          }
+        ]
+      ]
     }
   ]
 }

--- a/wrappers/nodejs/binding.gyp
+++ b/wrappers/nodejs/binding.gyp
@@ -1,3 +1,9 @@
+# Location
+# macOS Intel: /usr/local/lib/libindy.dylib
+# macOS Apple: /opt/homebrew/lib/libindy.dylib
+# Linux      : /usr/lib/libindy.dylib OR /usr/local/lib/libindy.dylib
+# Windows    : anywhere & set LD_LIBRARY_PATH in your environment variables to the /lib folder
+
 {
   "targets": [
     {
@@ -17,19 +23,13 @@
         [
           "OS=='win'",
           {
-            "library_dirs": ["<(module_root_dir)"],
+            "library_dirs": [
+              "<(module_root_dir)",
+              "<!(node -e \"console.log(process.env.LD_LIBRARY_PATH || '')\")"
+            ],
             "libraries": ["indy.dll.lib"]
           }
         ],
-        [
-          "OS=='linux'",
-          {
-            "library_dirs": ["/usr/local/lib/", "/usr/lib/"],
-            "link_settings": {
-              "libraries": ["libindy.so"]
-            }
-          }
-        ]
       ]
     }
   ]

--- a/wrappers/nodejs/package.json
+++ b/wrappers/nodejs/package.json
@@ -23,7 +23,7 @@
     "include"
   ],
   "scripts": {
-    "prepare": "cp -r ../../libindy/include .",
+    "preinstall": "cp -r ../../libindy/include .",
     "test": "standard && ava --fail-fast",
     "rebuild": "node-gyp rebuild"
   },


### PR DESCRIPTION
The binding.gyp for the nodejs wrapper was incorrect and I have no clue how it even worked.

I am currently working on Apple Silicon trying to fix the support for the indy-sdk in node.

I could not test this yet on ~~Windows~~ or ~~Linux~~ so I will mark this as a draft for now.

Signed-off-by: Berend Sliedrecht <berend@animo.id>

Edit: Linux has been tested on Arch and is working. 
Edit2: Windows has been tested and it works via the `LD_LIBRARY_PATH`.