### PR TITLE
fix ordering of attributes being used before being introduced

### DIFF
--- a/libindy/src/commands/non_secrets.rs
+++ b/libindy/src/commands/non_secrets.rs
@@ -312,8 +312,8 @@ impl NonSecretsCommandExecutor {
     }
 }
 
-#[serde(rename_all = "camelCase")]
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SearchRecords {
     pub total_count: Option<usize>,
     pub records: Option<Vec<WalletRecord>>

--- a/libindy/src/domain/cache.rs
+++ b/libindy/src/domain/cache.rs
@@ -1,11 +1,11 @@
-#[serde(rename_all = "camelCase")]
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PurgeOptions {
     pub max_age: Option<i32>,
 }
 
-#[serde(rename_all = "camelCase")]
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct GetCacheOptions {
     pub no_cache: Option<bool>,     // Skip usage of cache,
     pub no_update: Option<bool>,    // Use only cached data, do not try to update.

--- a/libindy/src/domain/ledger/response.rs
+++ b/libindy/src/domain/ledger/response.rs
@@ -60,8 +60,8 @@ pub struct TxnMetadata {
     pub creation_time: u64,
 }
 
-#[serde(tag = "op")]
 #[derive(Deserialize, Debug)]
+#[serde(tag = "op")]
 pub enum Message<T> {
     #[serde(rename = "REQNACK")]
     ReqNACK(Response),

--- a/libindy/src/services/pool/types.rs
+++ b/libindy/src/services/pool/types.rs
@@ -354,8 +354,8 @@ pub struct SimpleRequest {
     pub req_id: u64,
 }
 
-#[serde(tag = "op")]
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "op")]
 pub enum Message {
     #[serde(rename = "CONSISTENCY_PROOF")]
     ConsistencyProof(ConsistencyProof),


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

The compiler was complaining about the following:

> warning: derive helper attribute is used before it is introduced
   --> src/services/pool/types.rs:357:3
    |
357 | #[serde(tag = "op")]
    |   ^^^^^
358 | #[derive(Serialize, Deserialize, Debug)]
    |          --------- the attribute is introduced here
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>


This PR reorders the two code lines so that the attribute is used after being introduced
