### PR TITLE
docs: Update getting started dockerfile

### DIFF
--- a/docs/getting-started/getting-started.dockerfile
+++ b/docs/getting-started/getting-started.dockerfile
@@ -1,33 +1,34 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 RUN useradd -ms /bin/bash indy
 
 # Install environment
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Moscow
 RUN apt-get update -y && apt-get install -y \
-	wget \
-	python3.5 \
-	python3-pip \
-	python-setuptools \
-	apt-transport-https \
-	ca-certificates \
-	software-properties-common
+    wget \
+    python3.5 \
+    python3-pip \
+    python-setuptools \
+    apt-transport-https \
+    ca-certificates \
+    software-properties-common
 
 WORKDIR /home/indy
 
-RUN pip3 install --upgrade pip
 RUN pip3 install -U \
-	pip \
-	ipython-notebook \
-      ipython==7.9 \
-	setuptools \
-	jupyter \
-	python3-indy==1.11.0
+    pip \
+    ipython==7.9 \
+    setuptools \
+    jupyter \
+    python3-indy==1.11.0
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
     && add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial stable" \
+    && add-apt-repository "deb http://security.ubuntu.com/ubuntu xenial-security main" \
     && apt-get update \
     && apt-get install -y \
-    libindy=1.11.0
+    libssl1.0.0 libindy=1.11.0
 
 USER indy
 

--- a/docs/getting-started/getting-started.dockerfile
+++ b/docs/getting-started/getting-started.dockerfile
@@ -6,26 +6,26 @@ RUN useradd -ms /bin/bash indy
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Moscow
 RUN apt-get update -y && apt-get install -y \
-    wget \
-    python3.5 \
-    python3-pip \
-    python-setuptools \
-    apt-transport-https \
-    ca-certificates \
-    software-properties-common
+	wget \
+	python3.5 \
+	python3-pip \
+	python-setuptools \
+	apt-transport-https \
+	ca-certificates \
+	software-properties-common
 
 WORKDIR /home/indy
 
 RUN pip3 install -U \
-    pip \
+	pip \
     ipython==7.9 \
-    setuptools \
-    jupyter \
-    python3-indy==1.11.0
+	setuptools \
+	jupyter \
+	python3-indy==1.11.0
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
     && add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial stable" \
-    && add-apt-repository "deb http://security.ubuntu.com/ubuntu xenial-security main" \
+	&& add-apt-repository "deb http://security.ubuntu.com/ubuntu xenial-security main" \
     && apt-get update \
     && apt-get install -y \
     libssl1.0.0 libindy=1.11.0


### PR DESCRIPTION
Ubuntu 16.04 still installs `Python:2.7` and `pip`. Thus, the `getting-started` docker image doesn't build as expected.
So, an update to `Ubuntu:20.04` is needed for the images to build successfully.