### PR TITLE
fix(objective c wrapper) NSError should be nil when there is no error

### DIFF
--- a/wrappers/ios/libindy-pod/Indy/Utils/Exstensions/NSError+IndyError.m
+++ b/wrappers/ios/libindy-pod/Indy/Utils/Exstensions/NSError+IndyError.m
@@ -12,11 +12,14 @@ static NSString *const IndyErrorDomain = @"IndyErrorDomain";
 
 + (NSError *)errorFromIndyError:(indy_error_t)error {
 
+    if (error == Success)
+        return nil;
+
     NSMutableDictionary *userInfo = [NSMutableDictionary new];
 
-    if (error != Success) {
-        const char * error_json_p;
-        indy_get_current_error(&error_json_p);
+    const char * error_json_p;
+    indy_get_current_error(&error_json_p);
+    if (error_json_p) {
         NSString *errorDetailsJson = [NSString stringWithUTF8String:error_json_p];
 
         NSDictionary *errorDetails = [NSDictionary fromString:errorDetailsJson];


### PR DESCRIPTION
Signed-off-by: conanoc <conanoc@gmail.com>

Returning NSError with error code **Success** makes trouble sometimes.
The following code snippet opens a wallet using async/await in swift5. It always throws error and does not return wallet handle because the error included in the completion handler is not nil.
```swift
    let wallet = IndyWallet.sharedInstance()!
    var walletHandle : IndyHandle?
    do {
        walletHandle = try await wallet.open(withConfig: walletConfig, credentials: walletCredentials)
    } catch {
        if let err = error as NSError? {
            print("Cannot open wallet: \(err.userInfo["message"] ?? "Unknown error")")
        }
        return
    }
```

So, NSError should be nil when the indy_error_code is Success.