### PR TITLE
Add a podspec for objective-c indy wrapper in non-binary distribution

### DIFF
--- a/Specs/Indy/1.15.0/Indy.podspec
+++ b/Specs/Indy/1.15.0/Indy.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |spec|
+  spec.name     = 'Indy'
+  spec.version  = '1.15.0'
+  spec.license  =  'Apache License 2.0'
+  spec.homepage = 'https://github.com/hyperledger/indy-sdk'
+  spec.authors  = {'Hyperledger Indy Contributors' => 'hyperledger-indy@lists.hyperledger.org'}
+  spec.summary  = 'libindy objective-C wrapper'
+  spec.source   = {:git => 'https://github.com/hyperledger/indy-sdk.git', :tag => 'v1.15.0'}
+  spec.source_files = 'wrappers/ios/libindy-pod/Indy/**/*'
+  spec.exclude_files = [
+    'wrappers/ios/libindy-pod/Indy/Info.plist',
+    'wrappers/ios/libindy-pod/Indy/Wrapper/BlobStorage.*'
+  ]
+  spec.public_header_files = [
+    'wrappers/ios/libindy-pod/Indy/Indy.h',
+    'wrappers/ios/libindy-pod/Indy/Wrapper/*.h',
+    'wrappers/ios/libindy-pod/Indy/Utils/IndyLogger.h'
+  ]
+  spec.libraries = 'sqlite3'
+  spec.platform = :ios, '10.0'
+  spec.static_framework = true
+  spec.dependency   'libsodium'
+  spec.dependency   'libzmq', '4.2.3'
+  spec.dependency   'OpenSSL-XM'
+  spec.dependency   'libindy', '1.15.0'
+end

--- a/wrappers/ios/README.md
+++ b/wrappers/ios/README.md
@@ -2,6 +2,7 @@
 A wrapper is a private pod, so private podspec must be set. Put at the top of the Podfile: 
     
     source 'https://github.com/hyperledger/indy-sdk.git'
+    source 'https://github.com/CocoaPods/Specs.git'
     
 Cocoapod will search for spec files in the root Specs folder.
            
@@ -17,14 +18,22 @@ Cocoapod will search for spec files in the root Specs folder.
        
     These archives are located at `https://repo.sovrin.org/ios/libindy/{release-channel}/libindy-core/`.
     
-* There is manually built and published archive containing libindy objective C wrapper.
-   This archive is located at `https://repo.sovrin.org/ios/libindy/{release-channel}/indy-objc/`.
+* There are manually built and published archives containing libindy objective C wrapper until v1.8.2.
+   These archives are located at `https://repo.sovrin.org/ios/libindy/{release-channel}/indy-objc/`.
 
     Add pod to target:
         
-        pod 'libindy-objc'    
+        pod 'libindy-objc', '1.8.2'
   
 {release channel} must be replaced with master, rc or stable to define corresponded release channel.
+
+# Non-binary objective C wrapper podspec
+
+There are podspec files consisting of libindy objective C wrapper source files from v1.15.0.
+
+Add pod to target:
+
+    pod 'Indy', '1.15.0'
 
 # How to manually build
 
@@ -98,6 +107,8 @@ Run Archive process for `Indy` target. Custom post-action shell script `universa
 
 # Wrapper usage 
 
+## Objective-C
+
 Import header starting from 0.1.3:
 
 ```
@@ -110,6 +121,25 @@ For 0.1.1 and 0.1.2 versions:
 ```
 
 All wrapper types and classes have prefix `Indy`.
+
+## Swift
+
+```Swift
+import Indy
+
+// Creating a wallet
+let walletConfig = ["id": "demoWallet"].toString()
+let walletCredentials = ["key": "1234"].toString()
+let wallet = IndyWallet.sharedInstance()!
+wallet.createWallet(withConfig: walletConfig, credentials: walletCredentials) { err in
+   if let error = err as NSError? {
+       if (error.code != IndyErrorCode.WalletAlreadyExistsError.rawValue) {
+           print("Wallet creation failed: \(error.userInfo["message"] ?? "Unknown error")")
+           return
+       }
+   }
+}
+```
 
 ## Troubleshooting
 * Enable Logging - Use `setLogger` to pass a callback that will be used by Libindy to log a record.


### PR DESCRIPTION
Signed-off-by: conanoc <conanoc@gmail.com>

Previous podspec libindy-objc.podspec has several issues:
- It is based on pre-built binary and the binaries are not provided since v1.8.2
- Old binaries do not support newer versions of swift
- Binary frameworks cannot support multiple versions of swift

Source based podspec would be more convenient because we do not have to prepare binaries and there is no version dependency for swift.
Some notes about this commit:
- The podspec filename have to be the same as the name of the framework. So, I could not keep the previous name libindy-objc.podspec.
- The lastest version of libindy is v1.16.0, but one source file of the wrapper(wrappers/ios/libindy-pod/Indy/Wrapper/IndyErrors.h) had a [bug](https://github.com/hyperledger/indy-sdk/commit/9cd1d56b6209a7152f3cd983a0d6077430f09deb#diff-a29363c28be6b462a2bb8b4797fc665cbf01c89b7ad7e58dedaaa18e4f365a36)(comma missing) and was fixed later. So, tag v1.16.0 cannot be used for ios wrapper.
- Used OpenSSL-XM(1.0.210.1) pod instead of OpenSSL(1.0.210) pod because OpenSSL is not compatible with the latest version of cocoapods. OpenSSL podspec would be better copied to indy-sdk repo with fixes done in OpenSSL-XM.
