### PR TITLE
[#2445] Fix build of postgres storage plugin on ARM

### DIFF
--- a/experimental/plugins/postgres_storage/src/lib.rs
+++ b/experimental/plugins/postgres_storage/src/lib.rs
@@ -385,7 +385,7 @@ impl PostgresWallet {
 
         let record = handles.get(&record_handle).unwrap();
 
-        unsafe { *id_ptr = record.id.as_ptr() as *const i8; }
+        unsafe { *id_ptr = record.id.as_ptr() as *const c_char; }
 
         ErrorCode::Success
     }
@@ -408,7 +408,7 @@ impl PostgresWallet {
 
         let record = handles.get(&record_handle).unwrap();
 
-        unsafe { *type_ptr = record.type_.as_ptr() as *const i8; }
+        unsafe { *type_ptr = record.type_.as_ptr() as *const c_char; }
 
         ErrorCode::Success
     }
@@ -456,7 +456,7 @@ impl PostgresWallet {
 
         let record = handles.get(&record_handle).unwrap();
 
-        unsafe { *tags_json_ptr = record.tags.as_ptr() as *const i8; }
+        unsafe { *tags_json_ptr = record.tags.as_ptr() as *const c_char; }
 
         ErrorCode::Success
     }


### PR DESCRIPTION
Fixes issue #2445 
Building the postgres storage plugin fails on ARM (tested with v7 and v8) due to a typecast error. Adjusting the type fixed the problem.