### PR TITLE
Update the version of Rust

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -595,7 +595,7 @@ def iosTesting() {
                 //FIXME We downgrade rust for iOS build as 1.46.0 forces building cdylib crate that causes linking errors.
                 //FIXME See https://github.com/rust-lang/rust/issues/79373 for details.
                 //FIXME It is fixed in nightly already and we will switch to 1.49 after it is released.
-                sh "rustup default 1.45.0"
+                sh "rustup default 1.58.0"
 
                 setupRustIOS()
                 setupBrewPackages()
@@ -1456,7 +1456,7 @@ def shell(command) {
 }
 
 def setupRust() {
-    shell("rustup default 1.46.0")
+    shell("rustup default 1.58.0")
 }
 
 def androidPublishing() {

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -264,7 +264,7 @@ def iosTesting() {
                 //FIXME We downgrade rust for iOS build as 1.46.0 forces building cdylib crate that causes linking errors.
                 //FIXME See https://github.com/rust-lang/rust/issues/79373 for details.
                 //FIXME It is fixed in nightly already and we will switch to 1.49 after it is released.
-                sh "rustup default 1.45.0"
+                sh "rustup default 1.58.0"
                 
                 setupRustIOS()
                 setupBrewPackages()
@@ -666,7 +666,7 @@ def shell(command) {
 }
 
 def setupRust() {
-    shell("rustup default 1.46.0")
+    shell("rustup default 1.58.0")
 }
 
 def setupBrewPackages() {

--- a/ci/ga-ios-build.sh
+++ b/ci/ga-ios-build.sh
@@ -17,7 +17,7 @@ if [ -z "${LIBINDY_POD_VERSION}" ]; then
 fi
 
 if [ -z "${RUST_VER}" ]; then
-    export RUST_VER=1.45.2
+    export RUST_VER=1.58.0
     echo "ERROR: RUST_VER environment variable not specified, using $RUST_VER"
 fi
 

--- a/cli/src/command_executor.rs
+++ b/cli/src/command_executor.rs
@@ -51,6 +51,8 @@ impl ParamMetadata {
     }
 }
 
+// Turn off "error: field is never read: `dynamic_completion_type`" warning
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct CommandMetadata {
     name: &'static str,

--- a/cli/src/utils/mod.rs
+++ b/cli/src/utils/mod.rs
@@ -59,6 +59,6 @@ macro_rules! unwrap_or_return {
         match $result {
             Some(res) => res,
             None => return $err
-        };
+        }
     }
 }

--- a/libindy/ci/alpine.dockerfile
+++ b/libindy/ci/alpine.dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 ARG UID=1000
 ARG GID=1000
-ARG RUST_VER="1.45.2"
+ARG RUST_VER="1.58.0"
 ARG INDYSDK_PATH=/home/indy/indy-sdk
 
 ENV RUST_LOG=warning

--- a/libindy/ci/centos.dockerfile
+++ b/libindy/ci/centos.dockerfile
@@ -39,7 +39,7 @@ RUN wget https://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-mav
 RUN sed -i s/\$releasever/6/g /etc/yum.repos.d/epel-apache-maven.repo
 RUN yum install -y apache-maven
 
-ENV RUST_ARCHIVE=rust-1.46.0-x86_64-unknown-linux-gnu.tar.gz
+ENV RUST_ARCHIVE=rust-1.58.0-x86_64-unknown-linux-gnu.tar.gz
 ENV RUST_DOWNLOAD_URL=https://static.rust-lang.org/dist/$RUST_ARCHIVE
 
 RUN mkdir -p /rust

--- a/libindy/ci/ubuntu.dockerfile
+++ b/libindy/ci/ubuntu.dockerfile
@@ -31,8 +31,8 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 
 RUN pip3 install -U \
-	pip \
-	setuptools \
+	'pip<21.0' \
+	'setuptools<=50.3.2' \
 	virtualenv \
 	twine==1.15.0 \
 	plumbum==1.6.7 six==1.12.0 \
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN useradd -ms /bin/bash -u $uid indy
 USER indy
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.46.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.58.0
 ENV PATH /home/indy/.cargo/bin:$PATH
 
 RUN cargo install cargo-deb

--- a/libindy/ci/ubuntu18.dockerfile
+++ b/libindy/ci/ubuntu18.dockerfile
@@ -45,7 +45,7 @@ RUN apt-get install -y wget
 RUN useradd -ms /bin/bash -u $uid indy
 USER indy
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.46.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.58.0
 ENV PATH /home/indy/.cargo/bin:$PATH
 
 RUN cargo install cargo-deb

--- a/libindy/ci/wrappers/wrapper-base.dockerfile
+++ b/libindy/ci/wrappers/wrapper-base.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ARG RUST_VER=1.46.0
+ARG RUST_VER=1.58.0
 
 RUN apt-get update && \
     apt-get install -y \

--- a/libindy/indy-api-types/src/errors.rs
+++ b/libindy/indy-api-types/src/errors.rs
@@ -137,7 +137,7 @@ impl fmt::Display for IndyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut first = true;
 
-        for cause in Fail::iter_chain(self.inner.as_ref()) {
+        for cause in <dyn Fail>::iter_chain(self.inner.as_ref()) {
             if first {
                 first = false;
                 writeln!(f, "Error: {}", cause)?;
@@ -225,7 +225,7 @@ impl From<log::SetLoggerError> for IndyError {
 #[cfg(feature = "casting_errors")]
 impl From<UrsaCryptoError> for IndyError {
     fn from(err: UrsaCryptoError) -> Self {
-        let message = format!("UrsaCryptoError: {}", Fail::iter_causes(&err).map(|e| e.to_string()).collect::<String>());
+        let message = format!("UrsaCryptoError: {}", <dyn Fail>::iter_causes(&err).map(|e| e.to_string()).collect::<String>());
 
         match err.kind() {
             UrsaCryptoErrorKind::InvalidState => IndyError::from_msg(IndyErrorKind::InvalidState, message),

--- a/libindy/src/commands/non_secrets.rs
+++ b/libindy/src/commands/non_secrets.rs
@@ -312,8 +312,8 @@ impl NonSecretsCommandExecutor {
     }
 }
 
-#[serde(rename_all = "camelCase")]
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SearchRecords {
     pub total_count: Option<usize>,
     pub records: Option<Vec<WalletRecord>>

--- a/libindy/src/domain/cache.rs
+++ b/libindy/src/domain/cache.rs
@@ -1,11 +1,11 @@
-#[serde(rename_all = "camelCase")]
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PurgeOptions {
     pub max_age: Option<i32>,
 }
 
-#[serde(rename_all = "camelCase")]
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct GetCacheOptions {
     pub no_cache: Option<bool>,     // Skip usage of cache,
     pub no_update: Option<bool>,    // Use only cached data, do not try to update.

--- a/libindy/src/domain/ledger/response.rs
+++ b/libindy/src/domain/ledger/response.rs
@@ -60,8 +60,8 @@ pub struct TxnMetadata {
     pub creation_time: u64,
 }
 
-#[serde(tag = "op")]
 #[derive(Deserialize, Debug)]
+#[serde(tag = "op")]
 pub enum Message<T> {
     #[serde(rename = "REQNACK")]
     ReqNACK(Response),

--- a/libindy/src/services/pool/types.rs
+++ b/libindy/src/services/pool/types.rs
@@ -354,8 +354,8 @@ pub struct SimpleRequest {
     pub req_id: u64,
 }
 
-#[serde(tag = "op")]
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "op")]
 pub enum Message {
     #[serde(rename = "CONSISTENCY_PROOF")]
     ConsistencyProof(ConsistencyProof),

--- a/libindy/src/utils/result.rs
+++ b/libindy/src/utils/result.rs
@@ -61,7 +61,7 @@ macro_rules! unwrap_opt_or_return {
         match $opt {
             Some(val) => val,
             None => return $err
-        };
+        }
     }
 }
 
@@ -70,6 +70,6 @@ macro_rules! unwrap_or_return {
         match $result {
             Ok(res) => res,
             Err(_) => return $err
-        };
+        }
     }
 }

--- a/libindy/tests/utils/types.rs
+++ b/libindy/tests/utils/types.rs
@@ -77,8 +77,8 @@ pub struct WalletRecord {
     pub tags: Option<HashMap<String, String>>
 }
 
-#[serde(rename_all = "camelCase")]
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SearchRecords {
     pub total_count: Option<i32>,
     pub records: Option<Vec<WalletRecord>>

--- a/libnullpay/src/libindy/ledger.rs
+++ b/libnullpay/src/libindy/ledger.rs
@@ -28,7 +28,6 @@ pub fn build_get_txn_request(
 
 
 extern {
-    #[no_mangle]
     pub fn indy_build_get_txn_request(command_handle: i32,
                                       submitter_did: *const c_char,
                                       ledger_type: *const c_char,

--- a/libnullpay/src/libindy/logger.rs
+++ b/libnullpay/src/libindy/logger.rs
@@ -35,6 +35,5 @@ pub fn get_logger() -> Result<(*const c_void, Option<EnabledCB>, Option<LogCB>, 
 }
 
 extern {
-    #[no_mangle]
     pub fn indy_get_logger(context: *mut *const c_void, enabled_cb_p: *mut Option<EnabledCB>, log_cb_p: *mut Option<LogCB>, flush_cb_p: *mut Option<FlushCB>) -> ErrorCode;
 }

--- a/libnullpay/src/libindy/payments.rs
+++ b/libnullpay/src/libindy/payments.rs
@@ -161,7 +161,6 @@ pub fn list_payment_addresses(wallet_handle: i32,
 }
 
 extern {
-    #[no_mangle]
     pub fn indy_register_payment_method(
         command_handle: i32,
         payment_method: *const c_char,
@@ -182,7 +181,6 @@ extern {
         verify_with_address: Option<VerifyWithAddressCB>,
         cb: Option<extern fn(command_handle_: i32, err: ErrorCode)>) -> ErrorCode;
 
-    #[no_mangle]
     fn indy_list_payment_addresses(command_handle: i32,
                                    wallet_handle: i32,
                                    cb: Option<extern fn(command_handle_: i32,

--- a/vcx/ci/test.dockerfile
+++ b/vcx/ci/test.dockerfile
@@ -47,7 +47,7 @@ RUN curl -fsOSL $LIBINDY_DOWNLOAD_URL \
     && apt-get -f install
 
 # Install Rust
-ENV RUST_ARCHIVE=rust-1.20.0-x86_64-unknown-linux-gnu.tar.gz
+ENV RUST_ARCHIVE=rust-1.58.0-x86_64-unknown-linux-gnu.tar.gz
 ENV RUST_DOWNLOAD_URL=https://static.rust-lang.org/dist/$RUST_ARCHIVE
 
 RUN mkdir -p /rust

--- a/vcx/ci/ubuntu.dockerfile
+++ b/vcx/ci/ubuntu.dockerfile
@@ -60,7 +60,7 @@ ARG uid=1000
 RUN useradd -ms /bin/bash -u $uid vcx
 USER vcx
 
-ARG RUST_VER="1.46.0"
+ARG RUST_VER="1.58.0"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
 ENV PATH /home/vcx/.cargo/bin:$PATH
 

--- a/vcx/dummy-cloud-agent/src/domain/a2a.rs
+++ b/vcx/dummy-cloud-agent/src/domain/a2a.rs
@@ -208,8 +208,8 @@ pub struct SendMessages {
     pub uids: Vec<String>,
 }
 
-#[serde(untagged)]
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum MessageDetail {
     ConnectionRequestRedirect(ConnectionRequestRedirectMessageDetail),
     ConnectionRequestAnswer(ConnectionRequestAnswerMessageDetail),

--- a/vcx/libvcx/build_scripts/ios/mac/mac.01.libindy.setup.sh
+++ b/vcx/libvcx/build_scripts/ios/mac/mac.01.libindy.setup.sh
@@ -44,7 +44,7 @@ fi
 
 if [[ $RUSTUP_VERSION =~ ^'rustup ' ]]; then
     rustup update
-    rustup default 1.46.0
+    rustup default 1.58.0
     rustup component add rls-preview rust-analysis rust-src
     echo "Using rustc version $(rustc --version)"
     rustup target add aarch64-apple-ios x86_64-apple-ios

--- a/vcx/libvcx/src/error/mod.rs
+++ b/vcx/libvcx/src/error/mod.rs
@@ -234,7 +234,7 @@ impl fmt::Display for VcxError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut first = true;
 
-        for cause in Fail::iter_chain(&self.inner) {
+        for cause in dyn Fail::iter_chain(&self.inner) {
             if first {
                 first = false;
                 writeln!(f, "Error: {}", cause)?;
@@ -426,7 +426,7 @@ pub fn set_current_error(err: &VcxError) {
         let error_json = json!({
             "error": err.kind().to_string(),
             "message": err.to_string(),
-            "cause": Fail::find_root_cause(err).to_string(),
+            "cause": dyn Fail::find_root_cause(err).to_string(),
             "backtrace": err.backtrace().map(|bt| bt.to_string())
         }).to_string();
         error.replace(Some(CStringUtils::string_to_cstring(error_json)));

--- a/vcx/libvcx/src/messages/mod.rs
+++ b/vcx/libvcx/src/messages/mod.rs
@@ -551,8 +551,8 @@ pub struct MessageSent {
     pub uids: Vec<String>,
 }
 
-#[serde(untagged)]
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum MessageDetail {
     ConnectionRequestAnswer(AcceptInviteMessageDetails),
     ConnectionRequestRedirect(RedirectConnectionMessageDetails),

--- a/vcx/libvcx/src/utils/libindy/ledger.rs
+++ b/vcx/libvcx/src/utils/libindy/ledger.rs
@@ -485,8 +485,8 @@ pub struct Request {
     pub endorser: Option<String>
 }
 
-#[serde(tag = "op")]
 #[derive(Deserialize, Debug)]
+#[serde(tag = "op")]
 pub enum Response {
     #[serde(rename = "REQNACK")]
     ReqNACK(Reject),

--- a/wrappers/rust/indy-sys/build.rs
+++ b/wrappers/rust/indy-sys/build.rs
@@ -48,7 +48,7 @@ fn find_dir(dir_name: Option<String>, use_static: bool) {
 fn find_pkg(use_static: bool) {
     match pkg_config::Config::new().statik(use_static).probe("libindy") {
         Ok(_) => println!("cargo:warning=Libindy found in pkgcfg tree."),
-        Err(e) => panic!(format!("Error: {:?}", e)),
+        Err(e) => panic!("Error: {:?}", e),
     }
 }
 
@@ -56,6 +56,6 @@ fn find_pkg(use_static: bool) {
 fn find_pkg(_use_static: bool) {
     match vcpkg::Config::new().emit_includes(true).lib_name("libindy").probe("indy") {
         Ok(_) => println!("cargo:warning=Libindy found in vcpkg tree."),
-        Err(e) => panic!(format!("Error: {:?}", e)),
+        Err(e) => panic!("Error: {:?}", e),
     }
 }

--- a/wrappers/rust/indy-sys/src/anoncreds.rs
+++ b/wrappers/rust/indy-sys/src/anoncreds.rs
@@ -5,7 +5,6 @@ use {CString, Error};
 
 extern {
 
-    #[no_mangle]
     pub fn indy_issuer_create_schema(command_handle: CommandHandle,
                                      issuer_did: CString,
                                      name: CString,
@@ -13,7 +12,6 @@ extern {
                                      attrs: CString,
                                      cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_issuer_create_and_store_credential_def(command_handle: CommandHandle,
                                                        wallet_handle: WalletHandle,
                                                        issuer_did: CString,
@@ -23,20 +21,17 @@ extern {
                                                        config_json: CString,
                                                        cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_issuer_rotate_credential_def_start(command_handle: CommandHandle,
                                                    wallet_handle: WalletHandle,
                                                    cred_def_id: CString,
                                                    config_json: CString,
                                                    cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_issuer_rotate_credential_def_apply(command_handle: CommandHandle,
                                                    wallet_handle: WalletHandle,
                                                    cred_def_id: CString,
                                                    cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_issuer_create_and_store_revoc_reg(command_handle: CommandHandle,
                                                   wallet_handle: WalletHandle,
                                                   issuer_did: CString,
@@ -47,13 +42,11 @@ extern {
                                                   tails_writer_handle: TailWriterHandle,
                                                   cb: Option<ResponseStringStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_issuer_create_credential_offer(command_handle: CommandHandle,
                                                wallet_handle: WalletHandle,
                                                cred_def_id: CString,
                                                cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_issuer_create_credential(command_handle: CommandHandle,
                                          wallet_handle: WalletHandle,
                                          cred_offer_json: CString,
@@ -63,7 +56,6 @@ extern {
                                          blob_storage_reader_handle: BlobStorageReaderHandle,
                                          cb: Option<ResponseStringStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_issuer_revoke_credential(command_handle: CommandHandle,
                                          wallet_handle: WalletHandle,
                                          blob_storage_reader_cfg_handle: BlobStorageReaderCfgHandle,
@@ -71,19 +63,16 @@ extern {
                                          cred_revoc_id: CString,
                                          cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_issuer_merge_revocation_registry_deltas(command_handle: CommandHandle,
                                                         rev_reg_delta_json: CString,
                                                         other_rev_reg_delta_json: CString,
                                                         cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_create_master_secret(command_handle: CommandHandle,
                                             wallet_handle: WalletHandle,
                                             master_secret_id: CString,
                                             cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_create_credential_req(command_handle: CommandHandle,
                                              wallet_handle: WalletHandle,
                                              prover_did: CString,
@@ -92,7 +81,6 @@ extern {
                                              master_secret_id: CString,
                                              cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_set_credential_attr_tag_policy(command_handle: CommandHandle,
                                                       wallet_handle: WalletHandle,
                                                       cred_def_id: CString,
@@ -100,13 +88,11 @@ extern {
                                                       retroactive: bool,
                                                       cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_get_credential_attr_tag_policy(command_handle: CommandHandle,
                                                       wallet_handle: WalletHandle,
                                                       cred_def_id: CString,
                                                       cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_store_credential(command_handle: CommandHandle,
                                         wallet_handle: WalletHandle,
                                         cred_id: CString,
@@ -116,67 +102,56 @@ extern {
                                         rev_reg_def_json: CString,
                                         cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_get_credential(command_handle: CommandHandle,
                                       wallet_handle: WalletHandle,
                                       cred_id: CString,
                                       cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_delete_credential(command_handle: CommandHandle,
                                          wallet_handle: WalletHandle,
                                          cred_id: CString,
                                          cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_get_credentials(command_handle: CommandHandle,
                                        wallet_handle: WalletHandle,
                                        filter_json: CString,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_search_credentials(command_handle: CommandHandle,
                                           wallet_handle: WalletHandle,
                                           query_json: CString,
                                           cb: Option<ResponseI32UsizeCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_fetch_credentials(command_handle: CommandHandle,
                                          search_handle: SearchHandle,
                                          count: usize,
                                          cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_close_credentials_search(command_handle: CommandHandle,
                                                 search_handle: SearchHandle,
                                                 cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_get_credentials_for_proof_req(command_handle: CommandHandle,
                                                      wallet_handle: WalletHandle,
                                                      proof_request_json: CString,
                                                      cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_search_credentials_for_proof_req(command_handle: CommandHandle,
                                                         wallet_handle: WalletHandle,
                                                         proof_request_json: CString,
                                                         extra_query_json: CString,
                                                         cb: Option<ResponseI32CB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_fetch_credentials_for_proof_req(command_handle: CommandHandle,
                                                        search_handle: SearchHandle,
                                                        item_referent: CString,
                                                        count: usize,
                                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_close_credentials_search_for_proof_req(command_handle: CommandHandle,
                                                               search_handle: SearchHandle,
                                                               cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prover_create_proof(command_handle: CommandHandle,
                                     wallet_handle: WalletHandle,
                                     proof_req_json: CString,
@@ -187,7 +162,6 @@ extern {
                                     rev_states_json: CString,
                                     cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_verifier_verify_proof(command_handle: CommandHandle,
                                       proof_request_json: CString,
                                       proof_json: CString,
@@ -197,7 +171,6 @@ extern {
                                       rev_regs_json: CString,
                                       cb: Option<ResponseBoolCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_create_revocation_state(command_handle: CommandHandle,
                                         blob_storage_reader_handle: BlobStorageReaderHandle,
                                         rev_reg_def_json: CString,
@@ -206,7 +179,6 @@ extern {
                                         cred_rev_id: CString,
                                         cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_update_revocation_state(command_handle: CommandHandle,
                                         blob_storage_reader_handle: BlobStorageReaderHandle,
                                         rev_state_json: CString,
@@ -216,10 +188,8 @@ extern {
                                         cred_rev_id: CString,
                                         cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_generate_nonce(command_handle: CommandHandle,
                                cb: Option<ResponseStringCB>) -> Error;
-    #[no_mangle]
     pub fn indy_to_unqualified(command_handle: CommandHandle,
                                entity: CString,
                                cb: Option<ResponseStringCB>) -> Error;

--- a/wrappers/rust/indy-sys/src/blob_storage.rs
+++ b/wrappers/rust/indy-sys/src/blob_storage.rs
@@ -4,13 +4,11 @@ use {CString, Error, CommandHandle};
 
 extern {
 
-    #[no_mangle]
     pub fn indy_open_blob_storage_reader(command_handle: CommandHandle,
                                          type_: CString,
                                          config_json: CString,
                                          cb: Option<ResponseI32CB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_open_blob_storage_writer(command_handle: CommandHandle,
                                          type_: CString,
                                          config_json: CString,

--- a/wrappers/rust/indy-sys/src/cache.rs
+++ b/wrappers/rust/indy-sys/src/cache.rs
@@ -4,7 +4,6 @@ use {CString, Error, CommandHandle, WalletHandle, PoolHandle};
 
 extern {
 
-    #[no_mangle]
     pub fn indy_get_schema(command_handle: CommandHandle,
                            pool_handle: PoolHandle,
                            wallet_handle: WalletHandle,
@@ -13,7 +12,6 @@ extern {
                            options_json: CString,
                            cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_cred_def(command_handle: CommandHandle,
                              pool_handle: PoolHandle,
                              wallet_handle: WalletHandle,
@@ -22,13 +20,11 @@ extern {
                              options_json: CString,
                              cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_purge_schema_cache(command_handle: CommandHandle,
                                    wallet_handle: WalletHandle,
                                    options_json: CString,
                                    cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_purge_cred_def_cache(command_handle: CommandHandle,
                                      wallet_handle: WalletHandle,
                                      options_json: CString,

--- a/wrappers/rust/indy-sys/src/crypto.rs
+++ b/wrappers/rust/indy-sys/src/crypto.rs
@@ -4,26 +4,22 @@ use {BString, CString, Error, CommandHandle, WalletHandle};
 
 extern {
 
-    #[no_mangle]
     pub fn indy_create_key(command_handle: CommandHandle,
                            wallet_handle: WalletHandle,
                            key_json: CString,
                            cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_set_key_metadata(command_handle: CommandHandle,
                                  wallet_handle: WalletHandle,
                                  verkey: CString,
                                  metadata: CString,
                                  cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_key_metadata(command_handle: CommandHandle,
                                  wallet_handle: WalletHandle,
                                  verkey: CString,
                                  cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_crypto_sign(command_handle: CommandHandle,
                             wallet_handle: WalletHandle,
                             signer_vk: CString,
@@ -31,7 +27,6 @@ extern {
                             message_len: u32,
                             cb: Option<ResponseSliceCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_crypto_verify(command_handle: CommandHandle,
                               signer_vk: CString,
                               message_raw: BString,
@@ -40,7 +35,6 @@ extern {
                               signature_len: u32,
                               cb: Option<ResponseBoolCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_crypto_auth_crypt(command_handle: CommandHandle,
                                   wallet_handle: WalletHandle,
                                   sender_vk: CString,
@@ -49,7 +43,6 @@ extern {
                                   msg_len: u32,
                                   cb: Option<ResponseSliceCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_crypto_auth_decrypt(command_handle: CommandHandle,
                                     wallet_handle: WalletHandle,
                                     recipient_vk: CString,
@@ -57,14 +50,12 @@ extern {
                                     encrypted_len: u32,
                                     cb: Option<ResponseStringSliceCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_crypto_anon_crypt(command_handle: CommandHandle,
                                   recipient_vk: CString,
                                   msg_data: BString,
                                   msg_len: u32,
                                   cb: Option<ResponseSliceCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_crypto_anon_decrypt(command_handle: CommandHandle,
                                     wallet_handle: WalletHandle,
                                     recipient_vk: CString,
@@ -72,7 +63,6 @@ extern {
                                     encrypted_len: u32,
                                     cb: Option<ResponseSliceCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_pack_message(command_handle: CommandHandle,
                              wallet_handle: WalletHandle,
                              message: BString,
@@ -81,7 +71,6 @@ extern {
                              sender: CString,
                              cb: Option<ResponseSliceCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_unpack_message(command_handle: CommandHandle,
                                wallet_handle: WalletHandle,
                                jwe_msg: BString,

--- a/wrappers/rust/indy-sys/src/did.rs
+++ b/wrappers/rust/indy-sys/src/did.rs
@@ -3,45 +3,38 @@ use super::*;
 use {CString, Error, CommandHandle, WalletHandle, PoolHandle};
 
 extern {
-    #[no_mangle]
     pub fn indy_create_and_store_my_did(command_handle: CommandHandle,
                                         wallet_handle: WalletHandle,
                                         did_info: CString,
                                         cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_replace_keys_start(command_handle: CommandHandle,
                                    wallet_handle: WalletHandle,
                                    did: CString,
                                    key_info: CString,
                                    cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_replace_keys_apply(command_handle: CommandHandle,
                                    wallet_handle: WalletHandle,
                                    did: CString,
                                    cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_store_their_did(command_handle: CommandHandle,
                                 wallet_handle: WalletHandle,
                                 identity_json: CString,
                                 cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_key_for_did(command_handle: CommandHandle,
                             pool_handle: PoolHandle,
                             wallet_handle: WalletHandle,
                             did: CString,
                             cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_key_for_local_did(command_handle: CommandHandle,
                                   wallet_handle: WalletHandle,
                                   did: CString,
                                   cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_set_endpoint_for_did(command_handle: CommandHandle,
                                      wallet_handle: WalletHandle,
                                      did: CString,
@@ -49,44 +42,37 @@ extern {
                                      transport_key: CString,
                                      cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_endpoint_for_did(command_handle: CommandHandle,
                                      wallet_handle: WalletHandle,
                                      pool_handle: PoolHandle,
                                      did: CString,
                                      cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_set_did_metadata(command_handle: CommandHandle,
                                  wallet_handle: WalletHandle,
                                  did: CString,
                                  metadata: CString,
                                  cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_did_metadata(command_handle: CommandHandle,
                                  wallet_handle: WalletHandle,
                                  did: CString,
                                  cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_my_did_with_meta(command_handle: CommandHandle,
                                      wallet_handle: WalletHandle,
                                      my_did: CString,
                                      cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_list_my_dids_with_meta(command_handle: CommandHandle,
                                        wallet_handle: WalletHandle,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_abbreviate_verkey(command_handle: CommandHandle,
                                   did: CString,
                                   full_verkey: CString,
                                   cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_qualify_did(command_handle: CommandHandle,
                             wallet_handle: WalletHandle,
                             method: CString,

--- a/wrappers/rust/indy-sys/src/ledger.rs
+++ b/wrappers/rust/indy-sys/src/ledger.rs
@@ -3,7 +3,6 @@ use super::*;
 use {CString, Error, CommandHandle, WalletHandle, PoolHandle};
 
 extern {
-    #[no_mangle]
     pub fn indy_sign_and_submit_request(command_handle: CommandHandle,
                                         pool_handle: PoolHandle,
                                         wallet_handle: WalletHandle,
@@ -11,13 +10,11 @@ extern {
                                         request_json: CString,
                                         cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_submit_request(command_handle: CommandHandle,
                                pool_handle: PoolHandle,
                                request_json: CString,
                                cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_submit_action(command_handle: CommandHandle,
                               pool_handle: PoolHandle,
                               request_json: CString,
@@ -25,27 +22,23 @@ extern {
                               timeout: Timeout,
                               cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_sign_request(command_handle: CommandHandle,
                              wallet_handle: WalletHandle,
                              submitter_did: CString,
                              request_json: CString,
                              cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_multi_sign_request(command_handle: CommandHandle,
                                    wallet_handle: WalletHandle,
                                    submitter_did: CString,
                                    request_json: CString,
                                    cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_ddo_request(command_handle: CommandHandle,
                                       submitter_did: CString,
                                       target_did: CString,
                                       cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_nym_request(command_handle: CommandHandle,
                                   submitter_did: CString,
                                   target_did: CString,
@@ -54,18 +47,15 @@ extern {
                                   role: CString,
                                   cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_nym_request(command_handle: CommandHandle,
                                       submitter_did: CString,
                                       target_did: CString,
                                       cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_get_nym_response(command_handle: CommandHandle,
                                        get_nym_response: CString,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_attrib_request(command_handle: CommandHandle,
                                      submitter_did: CString,
                                      target_did: CString,
@@ -74,7 +64,6 @@ extern {
                                      enc: CString,
                                      cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_attrib_request(command_handle: CommandHandle,
                                          submitter_did: CString,
                                          target_did: CString,
@@ -83,74 +72,62 @@ extern {
                                          enc: CString,
                                          cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_schema_request(command_handle: CommandHandle,
                                      submitter_did: CString,
                                      data: CString,
                                      cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_schema_request(command_handle: CommandHandle,
                                          submitter_did: CString,
                                          id: CString,
                                          cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_get_schema_response(command_handle: CommandHandle,
                                           get_schema_response: CString,
                                           cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_cred_def_request(command_handle: CommandHandle,
                                        submitter_did: CString,
                                        data: CString,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_cred_def_request(command_handle: CommandHandle,
                                            submitter_did: CString,
                                            id: CString,
                                            cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_get_cred_def_response(command_handle: CommandHandle,
                                             get_cred_def_response: CString,
                                             cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_node_request(command_handle: CommandHandle,
                                    submitter_did: CString,
                                    target_did: CString,
                                    data: CString,
                                    cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_validator_info_request(command_handle: CommandHandle,
                                                  submitter_did: CString,
                                                  cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_txn_request(command_handle: CommandHandle,
                                       submitter_did: CString,
                                       ledger_type: CString,
                                       seq_no: i32,
                                       cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_pool_config_request(command_handle: CommandHandle,
                                           submitter_did: CString,
                                           writes: bool,
                                           force: bool,
                                           cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_pool_restart_request(command_handle: CommandHandle,
                                            submitter_did: CString,
                                            action: CString,
                                            datetime: CString,
                                            cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_pool_upgrade_request(command_handle: CommandHandle,
                                            submitter_did: CString,
                                            name: CString,
@@ -165,24 +142,20 @@ extern {
                                            package: CString,
                                            cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_revoc_reg_def_request(command_handle: CommandHandle,
                                             submitter_did: CString,
                                             data: CString,
                                             cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_revoc_reg_def_request(command_handle: CommandHandle,
                                                 submitter_did: CString,
                                                 id: CString,
                                                 cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_get_revoc_reg_def_response(command_handle: CommandHandle,
                                                  get_revoc_reg_def_response: CString,
                                                  cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_revoc_reg_entry_request(command_handle: CommandHandle,
                                               submitter_did: CString,
                                               revoc_reg_def_id: CString,
@@ -190,19 +163,16 @@ extern {
                                               value: CString,
                                               cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_revoc_reg_request(command_handle: CommandHandle,
                                             submitter_did: CString,
                                             revoc_reg_def_id: CString,
                                             timestamp: i64,
                                             cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_get_revoc_reg_response(command_handle: CommandHandle,
                                              get_revoc_reg_response: CString,
                                              cb: Option<ResponseStringStringU64CB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_revoc_reg_delta_request(command_handle: CommandHandle,
                                                   submitter_did: CString,
                                                   revoc_reg_def_id: CString,
@@ -210,24 +180,20 @@ extern {
                                                   to: i64,
                                                   cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_get_revoc_reg_delta_response(command_handle: CommandHandle,
                                                    get_revoc_reg_delta_response: CString,
                                                    cb: Option<ResponseStringStringU64CB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_register_transaction_parser_for_sp(command_handle: CommandHandle,
                                                    txn_type: CString,
                                                    parser: Option<CustomTransactionParser>,
                                                    free: Option<CustomFree>,
                                                    cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_response_metadata(command_handle: CommandHandle,
                                       response: CString,
                                       cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_auth_rule_request(command_handle: CommandHandle,
                                         submitter_did: CString,
                                         txn_type: CString,
@@ -238,13 +204,11 @@ extern {
                                         constraint: CString,
                                         cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_auth_rules_request(command_handle: CommandHandle,
                                          submitter_did: CString,
                                          data: CString,
                                          cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_auth_rule_request(command_handle: CommandHandle,
                                             submitter_did: CString,
                                             txn_type: CString,
@@ -254,7 +218,6 @@ extern {
                                             new_value: CString,
                                             cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_txn_author_agreement_request(command_handle: CommandHandle,
                                                    submitter_did: CString,
                                                    text: CString,
@@ -263,19 +226,16 @@ extern {
                                                    retirement_ts: i64,
                                                    cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_disable_all_txn_author_agreements_request(command_handle: CommandHandle,
                                                                 submitter_did: CString,
                                                                 cb: Option<ResponseStringCB>) -> Error;
 
 
-    #[no_mangle]
     pub fn indy_build_get_txn_author_agreement_request(command_handle: CommandHandle,
                                                        submitter_did: CString,
                                                        data: CString,
                                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_acceptance_mechanisms_request(command_handle: CommandHandle,
                                                     submitter_did: CString,
                                                     aml: CString,
@@ -283,14 +243,12 @@ extern {
                                                     aml_context: CString,
                                                     cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_acceptance_mechanisms_request(command_handle: CommandHandle,
                                                         submitter_did: CString,
                                                         timestamp: i64,
                                                         version: CString,
                                                         cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_append_txn_author_agreement_acceptance_to_request(command_handle: CommandHandle,
                                                                   request_json: CString,
                                                                   text: CString,
@@ -300,19 +258,16 @@ extern {
                                                                   time_of_acceptance: u64,
                                                                   cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_append_request_endorser(command_handle: CommandHandle,
                                         request_json: CString,
                                         endorser_did: CString,
                                         cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_ledgers_freeze_request(command_handle: CommandHandle,
                                        submitter_did: CString,
                                        ledgers_ids: CString,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_frozen_ledgers_request(command_handle: CommandHandle,
                                         submitter_did: CString,
                                         cb: Option<ResponseStringCB>) -> Error;

--- a/wrappers/rust/indy-sys/src/lib.rs
+++ b/wrappers/rust/indy-sys/src/lib.rs
@@ -64,9 +64,7 @@ pub type ResponseStringStringU64CB = extern fn(xcommand_handle: CommandHandle, e
 pub type ResponseStringI64CB = extern fn(xcommand_handle: CommandHandle, err: Error, arg1: CString, arg3: i64);
 
 extern {
-    #[no_mangle]
     pub fn indy_set_runtime_config(config: CString) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_current_error(error_json_p: *mut CString);
 }

--- a/wrappers/rust/indy-sys/src/logger.rs
+++ b/wrappers/rust/indy-sys/src/logger.rs
@@ -2,26 +2,21 @@ use {CString, CVoid, Error};
 
 extern {
 
-    #[no_mangle]
     pub fn indy_set_logger(context: *const CVoid,
                            enabled: Option<EnabledCB>,
                            log: Option<LogCB>,
                            flush: Option<FlushCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_set_logger_with_max_lvl(context: *const CVoid,
                                         enabled: Option<EnabledCB>,
                                         log: Option<LogCB>,
                                         flush: Option<FlushCB>,
                                         max_lvl: u32)-> Error;
 
-    #[no_mangle]
     pub fn indy_set_log_max_lvl(max_lvl: u32) -> Error;
 
-    #[no_mangle]
     pub fn indy_set_default_logger(pattern: CString) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_logger(context_p: *mut CVoid,
                            enabled_cb_p: *mut Option<EnabledCB>,
                            log_cb_p: *mut Option<LogCB>,

--- a/wrappers/rust/indy-sys/src/metrics.rs
+++ b/wrappers/rust/indy-sys/src/metrics.rs
@@ -3,7 +3,6 @@ use super::*;
 use {Error, CommandHandle};
 
 extern {
-    #[no_mangle]
     pub fn indy_collect_metrics(command_handle: CommandHandle,
                                 cb: Option<ResponseStringCB>) -> Error;
 }

--- a/wrappers/rust/indy-sys/src/non_secrets.rs
+++ b/wrappers/rust/indy-sys/src/non_secrets.rs
@@ -4,7 +4,6 @@ use {CString, Error, CommandHandle, WalletHandle};
 
 extern {
 
-    #[no_mangle]
     pub fn indy_add_wallet_record(command_handle: CommandHandle,
                                   wallet_handle: WalletHandle,
                                   type_: CString,
@@ -13,7 +12,6 @@ extern {
                                   tags_json: CString,
                                   cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_update_wallet_record_value(command_handle: CommandHandle,
                                            wallet_handle: WalletHandle,
                                            type_: CString,
@@ -21,7 +19,6 @@ extern {
                                            value: CString,
                                            cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_update_wallet_record_tags(command_handle: CommandHandle,
                                           wallet_handle: WalletHandle,
                                           type_: CString,
@@ -29,7 +26,6 @@ extern {
                                           tags_json: CString,
                                           cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_add_wallet_record_tags(command_handle: CommandHandle,
                                        wallet_handle: WalletHandle,
                                        type_: CString,
@@ -37,7 +33,6 @@ extern {
                                        tags_json: CString,
                                        cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_delete_wallet_record_tags(command_handle: CommandHandle,
                                           wallet_handle: WalletHandle,
                                           type_: CString,
@@ -45,14 +40,12 @@ extern {
                                           tag_names_json: CString,
                                           cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_delete_wallet_record(command_handle: CommandHandle,
                                      wallet_handle: WalletHandle,
                                      type_: CString,
                                      id: CString,
                                      cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_wallet_record(command_handle: CommandHandle,
                                   wallet_handle: WalletHandle,
                                   type_: CString,
@@ -60,7 +53,6 @@ extern {
                                   options_json: CString,
                                   cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_open_wallet_search(command_handle: CommandHandle,
                                    wallet_handle: WalletHandle,
                                    type_: CString,
@@ -68,14 +60,12 @@ extern {
                                    options_json: CString,
                                    cb: Option<ResponseI32CB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_fetch_wallet_search_next_records(command_handle: CommandHandle,
                                                  wallet_handle: WalletHandle,
                                                  wallet_search_handle: SearchHandle,
                                                  count: usize,
                                                  cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_close_wallet_search(command_handle: CommandHandle,
                                     wallet_search_handle: SearchHandle,
                                     cb: Option<ResponseEmptyCB>) -> Error;

--- a/wrappers/rust/indy-sys/src/pairwise.rs
+++ b/wrappers/rust/indy-sys/src/pairwise.rs
@@ -4,13 +4,11 @@ use {CString, Error, CommandHandle, WalletHandle};
 
 extern {
 
-    #[no_mangle]
     pub fn indy_is_pairwise_exists(command_handle: CommandHandle,
                                    wallet_handle: WalletHandle,
                                    their_did: CString,
                                    cb: Option<ResponseBoolCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_create_pairwise(command_handle: CommandHandle,
                                 wallet_handle: WalletHandle,
                                 their_did: CString,
@@ -18,18 +16,15 @@ extern {
                                 metadata: CString,
                                 cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_list_pairwise(command_handle: CommandHandle,
                               wallet_handle: WalletHandle,
                               cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_pairwise(command_handle: CommandHandle,
                              wallet_handle: WalletHandle,
                              their_did: CString,
                              cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_set_pairwise_metadata(command_handle: CommandHandle,
                                       wallet_handle: WalletHandle,
                                       their_did: CString,

--- a/wrappers/rust/indy-sys/src/payments.rs
+++ b/wrappers/rust/indy-sys/src/payments.rs
@@ -3,7 +3,6 @@ use super::*;
 use {CString, Error, CommandHandle, WalletHandle};
 
 extern {
-    #[no_mangle]
     pub fn indy_register_payment_method(command_handle: CommandHandle,
                                         payment_method: CString,
                                         create_payment_address: Option<CreatePaymentAddressCB>,
@@ -23,19 +22,16 @@ extern {
                                         verify_with_address: Option<VerifyWithAddressCB>,
                                         cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_create_payment_address(command_handle: CommandHandle,
                                        wallet_handle: WalletHandle,
                                        payment_method: CString,
                                        config: CString,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_list_payment_addresses(command_handle: CommandHandle,
                                        wallet_handle: WalletHandle,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_add_request_fees(command_handle: CommandHandle,
                                  wallet_handle: WalletHandle,
                                  submitter_did: CString,
@@ -45,13 +41,11 @@ extern {
                                  extra: CString,
                                  cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_response_with_fees(command_handle: CommandHandle,
                                          payment_method: CString,
                                          resp_json: CString,
                                          cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_payment_sources_with_from_request(command_handle: CommandHandle,
                                                             wallet_handle: WalletHandle,
                                                             submitter_did: CString,
@@ -59,26 +53,22 @@ extern {
                                                             from: i64,
                                                             cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_get_payment_sources_with_from_response(command_handle: CommandHandle,
                                                    payment_method: CString,
                                                    resp_json: CString,
                                                    cb: Option<ResponseStringI64CB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_payment_sources_request(command_handle: CommandHandle,
                                                   wallet_handle: WalletHandle,
                                                   submitter_did: CString,
                                                   payment_address: CString,
                                                   cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_get_payment_sources_response(command_handle: CommandHandle,
                                                    payment_method: CString,
                                                    resp_json: CString,
                                                    cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_payment_req(command_handle: CommandHandle,
                                   wallet_handle: WalletHandle,
                                   submitter_did: CString,
@@ -87,13 +77,11 @@ extern {
                                   extra: CString,
                                   cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_payment_response(command_handle: CommandHandle,
                                        payment_method: CString,
                                        resp_json: CString,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_prepare_payment_extra_with_acceptance_data(command_handle: CommandHandle,
                                                            extra_json: CString,
                                                            text: CString,
@@ -103,7 +91,6 @@ extern {
                                                            time_of_acceptance: u64,
                                                            cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_mint_req(command_handle: CommandHandle,
                                wallet_handle: WalletHandle,
                                submitter_did: CString,
@@ -111,7 +98,6 @@ extern {
                                extra: CString,
                                cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_set_txn_fees_req(command_handle: CommandHandle,
                                        wallet_handle: WalletHandle,
                                        submitter_did: CString,
@@ -119,33 +105,28 @@ extern {
                                        fees_json: CString,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_get_txn_fees_req(command_handle: CommandHandle,
                                        wallet_handle: WalletHandle,
                                        submitter_did: CString,
                                        payment_method: CString,
                                        cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_get_txn_fees_response(command_handle: CommandHandle,
                                             payment_method: CString,
                                             resp_json: CString,
                                             cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_build_verify_payment_req(command_handle: CommandHandle,
                                          wallet_handle: WalletHandle,
                                          submitter_did: CString,
                                          receipt: CString,
                                          cb: Option<ResponseStringStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_parse_verify_payment_response(command_handle: CommandHandle,
                                               payment_method: CString,
                                               resp_json: CString,
                                               cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_get_request_info(command_handle: CommandHandle,
                                  get_auth_rule_resp_json: CString,
                                  requester_info_json: CString,
@@ -157,7 +138,6 @@ extern {
                                   message_raw: BString,
                                   message_len: u32,
                                   cb: Option<ResponseSliceCB>) -> Error;
-    #[no_mangle]
     pub fn indy_verify_with_address(command_handle: CommandHandle,
                                     address: CString,
                                     message_raw: BString,

--- a/wrappers/rust/indy-sys/src/pool.rs
+++ b/wrappers/rust/indy-sys/src/pool.rs
@@ -4,38 +4,31 @@ use {CString, Error, CommandHandle, PoolHandle};
 
 extern {
 
-    #[no_mangle]
     pub fn indy_create_pool_ledger_config(command_handle: CommandHandle,
                                           config_name: CString,
                                           config: CString,
                                           cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_open_pool_ledger(command_handle: CommandHandle,
                                  config_name: CString,
                                  config: CString,
                                  cb: Option<ResponseI32CB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_refresh_pool_ledger(command_handle: CommandHandle,
                                     handle: PoolHandle,
                                     cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_list_pools(command_handle: CommandHandle,
                            cb: Option<ResponseStringCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_close_pool_ledger(command_handle: CommandHandle,
                                   handle: PoolHandle,
                                   cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_delete_pool_ledger_config(command_handle: CommandHandle,
                                           config_name: CString,
                                           cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_set_protocol_version(command_handle: CommandHandle,
                                      protocol_version: usize,
                                      cb: Option<ResponseEmptyCB>) -> Error;

--- a/wrappers/rust/indy-sys/src/wallet.rs
+++ b/wrappers/rust/indy-sys/src/wallet.rs
@@ -4,7 +4,6 @@ use {BString, CString, Error, CommandHandle, StorageHandle};
 
 extern {
 
-    #[no_mangle]
     pub fn indy_register_wallet_storage(command_handle: CommandHandle,
                                         type_: CString,
                                         create: Option<WalletCreate>,
@@ -33,43 +32,36 @@ extern {
                                         free_search: Option<WalletFreeSearch>,
                                         cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_create_wallet(command_handle: CommandHandle,
                               config: CString,
                               credentials: CString,
                               cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_open_wallet(command_handle: CommandHandle,
                             config: CString,
                             credentials: CString,
                             cb: Option<ResponseWalletHandleCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_export_wallet(command_handle: CommandHandle,
                               wallet_handle: WalletHandle,
                               export_config: CString,
                               cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_import_wallet(command_handle: CommandHandle,
                               config: CString,
                               credentials: CString,
                               import_config: CString,
                               cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_close_wallet(command_handle: CommandHandle,
                              wallet_handle: WalletHandle,
                              cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_delete_wallet(command_handle: CommandHandle,
                               config: CString,
                               credentials: CString,
                               cb: Option<ResponseEmptyCB>) -> Error;
 
-    #[no_mangle]
     pub fn indy_generate_wallet_key(command_handle: CommandHandle,
                                     config: CString,
                                     cb: Option<ResponseStringCB>) -> Error;


### PR DESCRIPTION
- Upgrade to Rust `1.58.0`
- Update code to align with the newer coding conventions.
  - Clean up linting and compiler warnings.
- Pin `pip<21.0` and `setuptools<=50.3.2` in `libindy/ci/ubuntu.dockerfile` to resolve build/test issues on ubuntu 16.04.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>

This PR addresses the cargo resolver issues causing the the Jenkins builds to fail by updating the Rust/Cargo versions used for the builds.