### PR TITLE
Remove the blocking input in the CD pipeline.

### DIFF
--- a/Jenkinsfile.cd
+++ b/Jenkinsfile.cd
@@ -866,7 +866,11 @@ def rustWrapperPublishing(testEnv, isRelease) {
 
     echo 'Publish Indy to Cargo'
 
-    def indy_sys_approved = input("Approve if indy-sys is available on crates.io") //TODO replace with auto-check and repeat logic
+    // Refs:
+    //  - https://github.com/hyperledger/indy-sdk/issues/2309
+    //  - https://github.com/hyperledger/indy-sdk/issues/2395
+    //  - Removing without adding retry logic to see if this is still an issue and if so how much of an issue.
+    // def indy_sys_approved = input("Approve if indy-sys is available on crates.io") //TODO replace with auto-check and repeat logic
 
     dir('wrappers/rust') {
         if (testReleaseVersion) {


### PR DESCRIPTION
- Remove the blocking input before the Cargo publish step.
- This is causing too many build resources issues to leave in place.
- Removing without adding the check and retry logic to see if and how much of an issue this still is.
- Related issue references:
  - https://github.com/hyperledger/indy-sdk/issues/2309
  - https://github.com/hyperledger/indy-sdk/issues/2395

Signed-off-by: Wade Barnes <wade@neoterictech.ca>