### PR TITLE
Fix OPENSSL_DIR at mac build

### DIFF
--- a/libindy/mac.build.sh
+++ b/libindy/mac.build.sh
@@ -41,7 +41,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     export CARGO_INCREMENTAL=1
     export RUST_LOG=indy=trace
     export RUST_TEST_THREADS=1
-    export OPENSSL_DIR=/usr/local/opt/`ls /usr/local/opt/ | grep openssl | sort | tail -1`
+    export OPENSSL_DIR=/usr/local/opt/openssl@1.1
     cargo build
     export LIBRARY_PATH=$(pwd)/target/debug
     cd ../cli


### PR DESCRIPTION
This PR resolves https://github.com/hyperledger/indy-sdk/issues/2427

I think the path of static version of openssl@1.1 is reasonable because it install static version of openssl@1.1.

Signed-off-by: Ethan Sung <baegjae@gmail.com>