### PR TITLE
Fixes pip bootstrap error

### DIFF
--- a/libindy/ci/wrappers/python.dockerfile
+++ b/libindy/ci/wrappers/python.dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
       python3.5 \
       python-setuptools
 
-RUN curl -fsSL -o- https://bootstrap.pypa.io/pip/get-pip.py | python3.6
+RUN curl -fsSL -o- https://bootstrap.pypa.io/pip/3.6/get-pip.py  | python3.6
 
 RUN pip install -U \
 	setuptools \


### PR DESCRIPTION
The pipeline is failing in the build-image-python step.
Pip is complaining about the wrong url. 
```
 #6 [3/4] RUN curl -fsSL -o- https://bootstrap.pypa.io/pip/get-pip.py | python3.6
#6 sha256:ec08f7fc3ed30f11c7a36d067994d6e26242634d813008d8a05d9731c2997e56
#6 0.432 ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
#6 ERROR: executor failed running [/bin/sh -c curl -fsSL -o- https://bootstrap.pypa.io/pip/get-pip.py | python3.6]: exit code: 1
```
This PR should fix that.