### PR TITLE
allow issuance of multiple cred at same revocation index

### DIFF
--- a/libindy/include/indy_anoncreds.h
+++ b/libindy/include/indy_anoncreds.h
@@ -80,6 +80,7 @@ extern "C" {
                                                       const char *  cred_req_json,
                                                       const char *  cred_values_json,
                                                       const char *  rev_reg_id,
+                                                      indy_handle_t rev_idx,
                                                       indy_handle_t blob_storage_reader_handle,
 
                                                       void           (*cb)(indy_handle_t command_handle_,

--- a/libindy/src/services/metrics/command_metrics.rs
+++ b/libindy/src/services/metrics/command_metrics.rs
@@ -61,7 +61,7 @@ impl From<&IssuerCommand> for CommandMetric {
             IssuerCommand::CreateCredentialOffer(_, _, _) => {
                 CommandMetric::IssuerCommandCreateCredentialOffer
             }
-            IssuerCommand::CreateCredential(_, _, _, _, _, _, _) => {
+            IssuerCommand::CreateCredential(_, _, _, _, _, _, _,_) => {
                 CommandMetric::IssuerCommandCreateCredential
             }
             IssuerCommand::RevokeCredential(_, _, _, _, _) => {

--- a/libindy/tests/anoncreds.rs
+++ b/libindy/tests/anoncreds.rs
@@ -4166,6 +4166,7 @@ mod medium_cases {
                                                           &credential_req,
                                                           &anoncreds::xyz_credential_values_json(),
                                                           None,
+                                                          None,
                                                           None);
             assert_code!(ErrorCode::CommonInvalidStructure, res);
 
@@ -4183,6 +4184,7 @@ mod medium_cases {
                                                           &credential_offer,
                                                           &credential_req,
                                                           &anoncreds::gvt_credential_values_json(),
+                                                          None,
                                                           None,
                                                           None);
             assert_code!(ErrorCode::WalletInvalidHandle, res);
@@ -4205,6 +4207,7 @@ mod medium_cases {
                                                           &credential_offer,
                                                           &credential_req,
                                                           &anoncreds::gvt_credential_values_json(),
+                                                          None,
                                                           None,
                                                           None);
             assert_code!(ErrorCode::CommonInvalidStructure, res);
@@ -4229,6 +4232,7 @@ mod medium_cases {
                                                           &credential_offer,
                                                           &credential_request,
                                                           &credential_values_json,
+                                                          None,
                                                           None,
                                                           None);
             assert_code!(ErrorCode::CommonInvalidStructure, res);
@@ -4259,6 +4263,7 @@ mod medium_cases {
                                                                               &credential_offer,
                                                                               &credential_req,
                                                                               &anoncreds::gvt_credential_values_json(),
+                                                                              None,
                                                                               None,
                                                                               None).unwrap();
 

--- a/libindy/tests/demo.rs
+++ b/libindy/tests/demo.rs
@@ -266,6 +266,7 @@ fn anoncreds_demo_works() {
                                                      CString::new(credential_req_json.as_str()).unwrap().as_ptr(),
                                                      CString::new(credential_json).unwrap().as_ptr(),
                                                      CString::new(rev_reg_id.as_str()).unwrap().as_ptr(),
+                                                     -1,
                                                      blob_storage_reader_handle,
                                                      issuer_create_credential_callback)
         };

--- a/libindy/tests/interaction.rs
+++ b/libindy/tests/interaction.rs
@@ -245,6 +245,7 @@ impl Issuer {
                                                                                                  &cred_req_json,
                                                                                                  cred_values_json,
                                                                                                  Some(&self.rev_reg_id),
+                                                                                                 None,
                                                                                                  Some(blob_storage_reader_handle)).unwrap();
 
 

--- a/libindy/tests/utils/anoncreds.rs
+++ b/libindy/tests/utils/anoncreds.rs
@@ -76,8 +76,8 @@ pub fn issuer_create_credential_offer(wallet_handle: WalletHandle, cred_def_id: 
 }
 
 pub fn issuer_create_credential(wallet_handle: WalletHandle, cred_offer_json: &str, cred_req_json: &str, cred_values_json: &str,
-                                rev_reg_id: Option<&str>, blob_storage_reader_handle: Option<i32>) -> Result<(String, Option<String>, Option<String>), IndyError> {
-    anoncreds::issuer_create_credential(wallet_handle, cred_offer_json, cred_req_json, cred_values_json, rev_reg_id, blob_storage_reader_handle.unwrap_or(-1)).wait() // TODO OPTIONAL blob_storage_reader_handle
+                                rev_reg_id: Option<&str>,rev_idx: Option<u32>, blob_storage_reader_handle: Option<i32>) -> Result<(String, Option<String>, Option<String>), IndyError> {
+    anoncreds::issuer_create_credential(wallet_handle, cred_offer_json, cred_req_json, cred_values_json, rev_reg_id,rev_idx ,blob_storage_reader_handle.unwrap_or(-1)).wait() // TODO OPTIONAL blob_storage_reader_handle
 }
 
 pub fn issuer_revoke_credential(wallet_handle: WalletHandle, blob_storage_reader_handle: i32, rev_reg_id: &str, cred_revoc_id: &str) -> Result<String, IndyError> {
@@ -1036,6 +1036,7 @@ pub fn init_common_wallet() -> (&'static str, &'static str, &'static str, &'stat
                                                                     &issuer1_gvt_credential_req,
                                                                     &gvt_credential_values_json(),
                                                                     None,
+                                                                    None,
                                                                     None).unwrap();
 
             //11. Prover stores Credential
@@ -1058,6 +1059,7 @@ pub fn init_common_wallet() -> (&'static str, &'static str, &'static str, &'stat
                                                                         &issuer1_gvt_sub_credential_offer,
                                                                         &issuer1_gvt_sub_credential_req,
                                                                         &gvt_sub_credential_values_json(),
+                                                                        None,
                                                                         None,
                                                                         None).unwrap();
 
@@ -1082,6 +1084,7 @@ pub fn init_common_wallet() -> (&'static str, &'static str, &'static str, &'stat
                                                                     &issuer1_xyz_credential_req,
                                                                     &xyz_credential_values_json(),
                                                                     None,
+                                                                    None,
                                                                     None).unwrap();
 
             //14. Prover stores Credential
@@ -1105,6 +1108,7 @@ pub fn init_common_wallet() -> (&'static str, &'static str, &'static str, &'stat
                                                                     &issuer2_gvt_credential_offer,
                                                                     &issuer2_gvt_credential_req,
                                                                     &gvt2_credential_values_json(),
+                                                                    None,
                                                                     None,
                                                                     None).unwrap();
 
@@ -1218,6 +1222,7 @@ pub fn multi_steps_create_credential(prover_master_secret_id: &str,
                                                      &cred_req,
                                                      &cred_values,
                                                      None,
+                                                     None,
                                                      None).unwrap();
 
     // Prover stores received Credential
@@ -1237,6 +1242,7 @@ pub fn multi_steps_create_revocation_credential(prover_master_secret_id: &str,
                                                 cred_def_id: &str,
                                                 cred_def_json: &str,
                                                 rev_reg_id: &str,
+                                                rev_idx: Option<u32>,
                                                 revoc_reg_def_json: &str,
                                                 blob_storage_reader_handle: i32)
                                                 -> (String, Option<String>) {
@@ -1256,6 +1262,7 @@ pub fn multi_steps_create_revocation_credential(prover_master_secret_id: &str,
                                                                                                    &prover1_cred_req_json,
                                                                                                    &cred_values,
                                                                                                    Some(rev_reg_id),
+                                                                                                   rev_idx,
                                                                                                    Some(blob_storage_reader_handle)).unwrap();
     let revoc_reg_delta1_json = revoc_reg_delta1_json;
     let prover1_cred_rev_id = prover1_cred_rev_id.unwrap();

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/LibIndy.java
@@ -130,7 +130,7 @@ public abstract class LibIndy {
 		public int indy_issuer_rotate_credential_def_apply(int command_handle, int wallet_handle, String cred_def_id, Callback cb);
 		public int indy_issuer_create_and_store_revoc_reg(int command_handle, int wallet_handle, String issuer_did, String revoc_def_type, String tag, String cred_def_id, String config_json, int blob_storage_writer_handle, Callback cb);
 		public int indy_issuer_create_credential_offer(int command_handle, int wallet_handle, String cred_def_id, Callback cb);
-		public int indy_issuer_create_credential(int command_handle, int wallet_handle, String cred_offer_json, String cred_req_json, String cred_values_json, String rev_reg_id, int blob_storage_reader_handle, Callback cb);
+		public int indy_issuer_create_credential(int command_handle, int wallet_handle, String cred_offer_json, String cred_req_json, String cred_values_json, String rev_reg_id, int revIdx, int blob_storage_reader_handle, Callback cb);
 		public int indy_issuer_revoke_credential(int command_handle, int wallet_handle, int blob_storage_reader_handle, String rev_reg_id, String cred_revoc_id, Callback cb);
 //		public int indy_issuer_recover_credential(int command_handle, int wallet_handle, int blob_storage_reader_handle, String rev_reg_id, String cred_revoc_id, Callback cb);
 		public int indy_issuer_merge_revocation_registry_deltas(int command_handle, String rev_reg_delta_json, String other_rev_reg_delta_json, Callback cb);

--- a/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
+++ b/wrappers/java/src/main/java/org/hyperledger/indy/sdk/anoncreds/Anoncreds.java
@@ -576,6 +576,7 @@ public class Anoncreds extends IndyJava.API {
 	 *                       It should not be parsed and are likely to change in future versions).
 	 *     }
 	 * credRevocId: local id for revocation info (Can be used for revocation of this cred)
+	 * revIdx: revocation tail index, allow issuance of multiple credentials to same revocation index.
 	 * revocRegDeltaJson: Revocation registry delta json with a newly issued credential
 	 * @throws IndyException Thrown if an error occurs when calling the underlying SDK.
 	 */
@@ -585,6 +586,7 @@ public class Anoncreds extends IndyJava.API {
 			String credReqJson,
 			String credValuesJson,
 			String revRegId,
+			int revIdx,
 			int blobStorageReaderHandle) throws IndyException {
 
 		ParamGuard.notNull(wallet, "wallet");
@@ -604,6 +606,7 @@ public class Anoncreds extends IndyJava.API {
 				credReqJson,
 				credValuesJson,
 				revRegId,
+				revIdx,
 				blobStorageReaderHandle,
 				issuerCreateCredentialCb);
 

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/AnoncredsIntegrationTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/AnoncredsIntegrationTest.java
@@ -133,7 +133,7 @@ public class AnoncredsIntegrationTest {
 		issuer1GvtCredReqMetadata = createCredReqResult.getCredentialRequestMetadataJson();
 
 		AnoncredsResults.IssuerCreateCredentialResult createCredResult =
-				Anoncreds.issuerCreateCredential(wallet, issuer1GvtCredOffer, issuer1GvtCredReq, gvtCredentialValuesJson, null, - 1).get();
+				Anoncreds.issuerCreateCredential(wallet, issuer1GvtCredOffer, issuer1GvtCredReq, gvtCredentialValuesJson, null,-1, - 1).get();
 		String issuer1GvtCredential = createCredResult.getCredentialJson();
 
 		Anoncreds.proverStoreCredential(wallet, credentialId1, issuer1GvtCredReqMetadata, issuer1GvtCredential, issuer1gvtCredDef, null).get();
@@ -142,7 +142,7 @@ public class AnoncredsIntegrationTest {
 		String issuer1XyzCredReq = createCredReqResult.getCredentialRequestJson();
 		String issuer1XyzCredReqMetadata = createCredReqResult.getCredentialRequestMetadataJson();
 
-		createCredResult = Anoncreds.issuerCreateCredential(wallet, issuer1XyzCredOffer, issuer1XyzCredReq, xyzCredentialValuesJson, null, - 1).get();
+		createCredResult = Anoncreds.issuerCreateCredential(wallet, issuer1XyzCredOffer, issuer1XyzCredReq, xyzCredentialValuesJson, null,-1, - 1).get();
 		String issuer1XyzCredential = createCredResult.getCredentialJson();
 
 		Anoncreds.proverStoreCredential(wallet, credentialId2, issuer1XyzCredReqMetadata, issuer1XyzCredential, issuer1xyzCredDef, null).get();
@@ -158,7 +158,7 @@ public class AnoncredsIntegrationTest {
 				"           \"age\":{\"raw\":\"28\",\"encoded\":\"28\"}\n" +
 				"   }";
 
-		createCredResult = Anoncreds.issuerCreateCredential(wallet, issuer2GvtCredOffer, issuer2GvtCredReq, gvt2CredValues, null, - 1).get();
+		createCredResult = Anoncreds.issuerCreateCredential(wallet, issuer2GvtCredOffer, issuer2GvtCredReq, gvt2CredValues, null,-1, - 1).get();
 		String issuer2GvtCredential = createCredResult.getCredentialJson();
 
 		String credentialId3 = "id3";

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/IssuerCreateCredentialTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/IssuerCreateCredentialTest.java
@@ -23,6 +23,6 @@ public class IssuerCreateCredentialTest extends AnoncredsIntegrationTest {
 				"        \"age\":\"28\"" +
 				"       }";
 
-		Anoncreds.issuerCreateCredential(wallet, issuer1GvtCredOffer, issuer1GvtCredReq, credValues, null, - 1).get();
+		Anoncreds.issuerCreateCredential(wallet, issuer1GvtCredOffer, issuer1GvtCredReq, credValues, null,-1, - 1).get();
 	}
 }

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/IssuerRevokeCredentialTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/anoncreds/IssuerRevokeCredentialTest.java
@@ -60,7 +60,7 @@ public class IssuerRevokeCredentialTest extends AnoncredsIntegrationTest {
 
 		//9. Issuer create Credential
 		AnoncredsResults.IssuerCreateCredentialResult createCredentialResult =
-				Anoncreds.issuerCreateCredential(wallet, credOfferJson, credentialReqJson, gvtCredentialValuesJson, revRegId, blobStorageReaderHandleCfg).get();
+				Anoncreds.issuerCreateCredential(wallet, credOfferJson, credentialReqJson, gvtCredentialValuesJson, revRegId,-1, blobStorageReaderHandleCfg).get();
 		String credJson = createCredentialResult.getCredentialJson();
 		String credRevocId = createCredentialResult.getRevocId();
 		String revRegDelta = createCredentialResult.getRevocRegDeltaJson();

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/demo/AnoncredsDemoTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/demo/AnoncredsDemoTest.java
@@ -107,7 +107,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		// Issuer create Credential
 		IssuerCreateCredentialResult createCredentialResult =
-				Anoncreds.issuerCreateCredential(issuerWallet, credOffer, credReq, gvtCredentialValues, null, - 1).get();
+				Anoncreds.issuerCreateCredential(issuerWallet, credOffer, credReq, gvtCredentialValues, null,-1 , - 1).get();
 		String credential = createCredentialResult.getCredentialJson();
 
 		// Prover store Credential
@@ -224,7 +224,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		// Issuer create Credential
 		IssuerCreateCredentialResult gvtCreateCredentialResult =
-				Anoncreds.issuerCreateCredential(issuerGvtWallet, gvtCredOffer, gvtCredReq, gvtCredentialValues, null, - 1).get();
+				Anoncreds.issuerCreateCredential(issuerGvtWallet, gvtCredOffer, gvtCredReq, gvtCredentialValues, null, -1, - 1).get();
 		String gvtCredential = gvtCreateCredentialResult.getCredentialJson();
 
 		// Prover store Credential
@@ -236,7 +236,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 		String xyzCredReqMetadata = createCredReqResult.getCredentialRequestMetadataJson();
 
 		// Issuer create Credential
-		IssuerCreateCredentialResult xyzCreateCredentialResult = Anoncreds.issuerCreateCredential(issuerXyzWallet, xyzCredOffer, xyzCredReq, xyzCredentialValues, null, - 1).get();
+		IssuerCreateCredentialResult xyzCreateCredentialResult = Anoncreds.issuerCreateCredential(issuerXyzWallet, xyzCredOffer, xyzCredReq, xyzCredentialValues, null, -1, - 1).get();
 		String xyzCredential = xyzCreateCredentialResult.getCredentialJson();
 
 		// Prover store Credential
@@ -350,7 +350,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		// Issuer create GVT Credential
 		IssuerCreateCredentialResult gvtCreateCredentialResult =
-				Anoncreds.issuerCreateCredential(issuerWallet, gvtCredOffer, gvtCredReq, gvtCredentialValues, null, - 1).get();
+				Anoncreds.issuerCreateCredential(issuerWallet, gvtCredOffer, gvtCredReq, gvtCredentialValues, null, -1, - 1).get();
 		String gvtCredential = gvtCreateCredentialResult.getCredentialJson();
 
 		// Prover store GVT Credential
@@ -363,7 +363,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		// Issuer create XYZ Credential
 		IssuerCreateCredentialResult xyzCreateCredentialResult =
-				Anoncreds.issuerCreateCredential(issuerWallet, xyzCredOffer, xyzCredReq, xyzCredentialValues, null, - 1).get();
+				Anoncreds.issuerCreateCredential(issuerWallet, xyzCredOffer, xyzCredReq, xyzCredentialValues, null, -1, - 1).get();
 		String xyzCredential = xyzCreateCredentialResult.getCredentialJson();
 
 		// Prover store XYZ Credential
@@ -475,7 +475,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		// Issuer create Credential
 		IssuerCreateCredentialResult createCredentialResult =
-				Anoncreds.issuerCreateCredential(issuerWallet, credOffer, credReq, gvtCredentialValues, revRegId, blobStorageReaderHandleCfg).get();
+				Anoncreds.issuerCreateCredential(issuerWallet, credOffer, credReq, gvtCredentialValues, revRegId, -1, blobStorageReaderHandleCfg).get();
 		String credential = createCredentialResult.getCredentialJson();
 		String revRegDelta = createCredentialResult.getRevocRegDeltaJson();
 		String credRevId = createCredentialResult.getRevocId();
@@ -563,7 +563,7 @@ public class AnoncredsDemoTest extends IndyIntegrationTest {
 
 		// Issuer create Credential
 		IssuerCreateCredentialResult createCredentialResult =
-				Anoncreds.issuerCreateCredential(issuerWallet, credOffer, credReq, gvtCredentialValues, null, - 1).get();
+				Anoncreds.issuerCreateCredential(issuerWallet, credOffer, credReq, gvtCredentialValues, null,-1 , - 1).get();
 		String credential = createCredentialResult.getCredentialJson();
 
 		// Prover store Credential

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/interaction/AnoncredsRevocationInteractionTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/interaction/AnoncredsRevocationInteractionTest.java
@@ -160,7 +160,7 @@ public class AnoncredsRevocationInteractionTest extends IndyIntegrationTestWithP
 		// Issuer creates Credential
 		AnoncredsResults.IssuerCreateCredentialResult credRegInfo =
 				Anoncreds.issuerCreateCredential(wallet, credOfferJson, credReqJson,
-						GVT_CRED_VALUES, revRegId,
+						GVT_CRED_VALUES, revRegId, -1,
 						blobStorageReaderHandle.getBlobStorageReaderHandle()).get();
 
 		String credJson = credRegInfo.getCredentialJson();
@@ -533,7 +533,7 @@ public class AnoncredsRevocationInteractionTest extends IndyIntegrationTestWithP
 
 		AnoncredsResults.IssuerCreateCredentialResult credRegInfo =
 				Anoncreds.issuerCreateCredential(wallet, credOfferJson, credReqJson,
-						GVT_CRED_VALUES, revRegId,
+						GVT_CRED_VALUES, revRegId, -1,
 						blobStorageReaderHandle.getBlobStorageReaderHandle()).get();
 
 		String credJson = credRegInfo.getCredentialJson();

--- a/wrappers/java/src/test/java/org/hyperledger/indy/sdk/interaction/AnoncredsVerifyProofAfterCredentialRevokeTest.java
+++ b/wrappers/java/src/test/java/org/hyperledger/indy/sdk/interaction/AnoncredsVerifyProofAfterCredentialRevokeTest.java
@@ -166,7 +166,7 @@ public class AnoncredsVerifyProofAfterCredentialRevokeTest extends IndyIntegrati
 
 
 		AnoncredsResults.IssuerCreateCredentialResult createCredResult = Anoncreds.issuerCreateCredential(wallet, credentialOffer,
-				proverCredReqResult.getCredentialRequestJson(), credentialDataForIndy.toString(), revRegDefId, blobReaderHandle).get();
+				proverCredReqResult.getCredentialRequestJson(), credentialDataForIndy.toString(), revRegDefId, -1, blobReaderHandle).get();
 
 		String issuedCredential = createCredResult.getCredentialJson();
 		String issuedCredentialDelta = createCredResult.getRevocRegDeltaJson();

--- a/wrappers/nodejs/src/index.js
+++ b/wrappers/nodejs/src/index.js
@@ -91,11 +91,11 @@ indy.issuerCreateCredentialOffer = function issuerCreateCredentialOffer (wh, cre
   return cb.promise
 }
 
-indy.issuerCreateCredential = function issuerCreateCredential (wh, credOffer, credReq, credValues, revRegId, blobStorageReaderHandle, cb) {
+indy.issuerCreateCredential = function issuerCreateCredential (wh, credOffer, credReq, credValues, revRegId, revIdx, blobStorageReaderHandle, cb) {
   cb = wrapIndyCallback(cb, function (data) {
     return [fromJson(data[0]), data[1], fromJson(data[2])]
   })
-  capi.issuerCreateCredential(wh, toJson(credOffer), toJson(credReq), toJson(credValues), revRegId, blobStorageReaderHandle, cb)
+  capi.issuerCreateCredential(wh, toJson(credOffer), toJson(credReq), toJson(credValues), revRegId, revIdx, blobStorageReaderHandle, cb)
   return cb.promise
 }
 

--- a/wrappers/nodejs/src/indy.cc
+++ b/wrappers/nodejs/src/indy.cc
@@ -528,22 +528,24 @@ void issuerCreateCredential_cb(indy_handle_t handle, indy_error_t xerr, const ch
   }
 }
 NAN_METHOD(issuerCreateCredential) {
-  INDY_ASSERT_NARGS(issuerCreateCredential, 7)
+  INDY_ASSERT_NARGS(issuerCreateCredential, 8)
   INDY_ASSERT_NUMBER(issuerCreateCredential, 0, wh)
   INDY_ASSERT_STRING(issuerCreateCredential, 1, credOffer)
   INDY_ASSERT_STRING(issuerCreateCredential, 2, credReq)
   INDY_ASSERT_STRING(issuerCreateCredential, 3, credValues)
   INDY_ASSERT_STRING(issuerCreateCredential, 4, revRegId)
-  INDY_ASSERT_NUMBER(issuerCreateCredential, 5, blobStorageReaderHandle)
-  INDY_ASSERT_FUNCTION(issuerCreateCredential, 6)
+  INDY_ASSERT_NUMBER(issuerCreateCredential, 5, revIdx)
+  INDY_ASSERT_NUMBER(issuerCreateCredential, 6, blobStorageReaderHandle)
+  INDY_ASSERT_FUNCTION(issuerCreateCredential, 7)
   indy_handle_t arg0 = argToInt32(info[0]);
   const char* arg1 = argToCString(info[1]);
   const char* arg2 = argToCString(info[2]);
   const char* arg3 = argToCString(info[3]);
   const char* arg4 = argToCString(info[4]);
   indy_handle_t arg5 = argToInt32(info[5]);
-  IndyCallback* icb = argToIndyCb(info[6]);
-  indyCalled(icb, indy_issuer_create_credential(icb->handle, arg0, arg1, arg2, arg3, arg4, arg5, issuerCreateCredential_cb));
+  indy_handle_t arg6 = argToInt32(info[6]);
+  IndyCallback* icb = argToIndyCb(info[7]);
+  indyCalled(icb, indy_issuer_create_credential(icb->handle, arg0, arg1, arg2, arg3, arg4, arg5, arg6, issuerCreateCredential_cb));
   delete arg1;
   delete arg2;
   delete arg3;

--- a/wrappers/nodejs/test/anoncreds.js
+++ b/wrappers/nodejs/test/anoncreds.js
@@ -55,7 +55,7 @@ test('anoncreds', async function (t) {
     name: { raw: 'Alex', encoded: '1139481716457488690172217916278103335' },
     height: { raw: '175', encoded: '175' },
     age: { raw: '28', encoded: '28' }
-  }, revocRegId, blobReaderHandle)
+  }, revocRegId, -1, blobReaderHandle)
   t.not(typeof cred, 'string')
 
   // Prover process and store credential

--- a/wrappers/python/indy/anoncreds.py
+++ b/wrappers/python/indy/anoncreds.py
@@ -409,6 +409,7 @@ async def issuer_create_credential(wallet_handle: int,
                                    cred_req_json: str,
                                    cred_values_json: str,
                                    rev_reg_id: Optional[str],
+                                   rev_idx: Optional[int],
                                    blob_storage_reader_handle: Optional[int]) -> (str, Optional[str], Optional[str]):
     """
     Check Cred Request for the given Cred Offer and issue Credential for the given Cred Request.
@@ -457,6 +458,7 @@ async def issuer_create_credential(wallet_handle: int,
                       It should not be parsed and are likely to change in future versions).
      }
      cred_revoc_id: local id for revocation info (Can be used for revocation of this cred)
+     rev_idx: revocation tail index, allow issuance of multiple credentials to same revocation index.
      revoc_reg_delta_json: Revocation registry delta json with a newly issued credential
     """
 
@@ -480,6 +482,7 @@ async def issuer_create_credential(wallet_handle: int,
     c_cred_values_json = c_char_p(cred_values_json.encode('utf-8'))
     c_rev_reg_id = c_char_p(rev_reg_id.encode('utf-8')) if rev_reg_id is not None else None
     c_blob_storage_reader_handle = c_int32(blob_storage_reader_handle) if blob_storage_reader_handle else -1
+    c_rev_idx = c_int32(rev_idx) if rev_idx else -1
 
     (cred_json, cred_revoc_id, revoc_reg_delta_json) = await do_call('indy_issuer_create_credential',
                                                                      c_wallet_handle,
@@ -487,6 +490,7 @@ async def issuer_create_credential(wallet_handle: int,
                                                                      c_cred_req_json,
                                                                      c_cred_values_json,
                                                                      c_rev_reg_id,
+                                                                     c_rev_idx,
                                                                      c_blob_storage_reader_handle,
                                                                      issuer_create_credential.cb)
     cred_json = cred_json.decode()

--- a/wrappers/python/tests/anoncreds/conftest.py
+++ b/wrappers/python/tests/anoncreds/conftest.py
@@ -358,7 +358,7 @@ async def prepopulated_wallet(wallet_handle, gvt_schema_json, xyz_schema_json, g
 
     (issuer_1_gvt_cred, _, _) = \
         await anoncreds.issuer_create_credential(wallet_handle, issuer_1_gvt_credential_offer_json,
-                                                 issuer_1_gvt_cred_req, gvt_cred_values_json, None, None)
+                                                 issuer_1_gvt_cred_req, gvt_cred_values_json, None,None, None)
 
     await anoncreds.prover_store_credential(wallet_handle, id_credential_1, issuer_1_gvt_cred_req_metadata,
                                             issuer_1_gvt_cred, issuer1_gvt_credential_def_json, None)
@@ -369,7 +369,7 @@ async def prepopulated_wallet(wallet_handle, gvt_schema_json, xyz_schema_json, g
 
     (issuer_1_xyz_cred, _, _) = \
         await anoncreds.issuer_create_credential(wallet_handle, issuer_1_xyz_credential_offer_json,
-                                                 issuer_1_xyz_cred_req, xyz_cred_values_json, None, None)
+                                                 issuer_1_xyz_cred_req, xyz_cred_values_json, None, None, None)
 
     await anoncreds.prover_store_credential(wallet_handle, id_credential_2, issuer_1_xyz_cred_req_metadata,
                                             issuer_1_xyz_cred, issuer1_xyz_credential_def_json, None)
@@ -380,7 +380,7 @@ async def prepopulated_wallet(wallet_handle, gvt_schema_json, xyz_schema_json, g
 
     (issuer_2_gvt_cred, _, _) = \
         await anoncreds.issuer_create_credential(wallet_handle, issuer_2_gvt_credential_offer_json,
-                                                 issuer_2_gvt_cred_req, gvt_2_cred_values_json, None, None)
+                                                 issuer_2_gvt_cred_req, gvt_2_cred_values_json, None, None, None)
 
     await anoncreds.prover_store_credential(wallet_handle, id_credential_3, issuer_2_gvt_cred_req_metadata,
                                             issuer_2_gvt_cred, issuer2_gvt_credential_def_json, None)

--- a/wrappers/python/tests/anoncreds/test_issuer_create_credential.py
+++ b/wrappers/python/tests/anoncreds/test_issuer_create_credential.py
@@ -17,4 +17,4 @@ async def test_issuer_create_credential_works_for_credential_values_not_correspo
     _, cred_offer, cred_req, _, _ = prepopulated_wallet
 
     with pytest.raises(error.CommonInvalidStructure):
-        await issuer_create_credential(wallet_handle, cred_offer, cred_req, xyz_cred_values_json, None, None)
+        await issuer_create_credential(wallet_handle, cred_offer, cred_req, xyz_cred_values_json, None, None, None)

--- a/wrappers/python/tests/anoncreds/test_prover_credential_attr_tag_policy.py
+++ b/wrappers/python/tests/anoncreds/test_prover_credential_attr_tag_policy.py
@@ -11,7 +11,7 @@ async def _check_catpol(wallet_handle, cred_def_json, cred_def_id, cred_id, cred
 
     # Write credential
     (cred, _, _) = await anoncreds.issuer_create_credential(wallet_handle, offer_json, cred_req,
-                                                    json.dumps(cred_value), None, None)
+                                                    json.dumps(cred_value), None, None, None)
     await anoncreds.prover_store_credential(wallet_handle, cred_id, cred_req_metadata, cred, cred_def_json, None)
 
     # Search on all tags

--- a/wrappers/python/tests/demo/test_anoncreds.py
+++ b/wrappers/python/tests/demo/test_anoncreds.py
@@ -45,7 +45,7 @@ async def test_anoncreds_demo_works(pool_name, path_home, wallet_config, credent
     })
 
     (cred_json, _, _) = await anoncreds.issuer_create_credential(wallet_handle, cred_offer_json, cred_req_json,
-                                                                 cred_values_json, None, None)
+                                                                 cred_values_json, None, None, None)
 
     # 7. Prover process and store credential
     cred_id = 'cred_id_1'
@@ -152,7 +152,7 @@ async def test_anoncreds_demo_works_for_revocation_proof(pool_name, path_home, w
 
     (cred_json, rev_id, rev_reg_delta_json) = \
         await anoncreds.issuer_create_credential(wallet_handle, cred_offer_json, cred_req_json,
-                                                 cred_values_json, rev_reg_id, blob_storage_reader_cfg_handle)
+                                                 cred_values_json, rev_reg_id, None, blob_storage_reader_cfg_handle)
 
     # 9. Prover process and store credential
     cred_id = 'cred_1_id'

--- a/wrappers/python/tests/interation/test_interaction.py
+++ b/wrappers/python/tests/interation/test_interaction.py
@@ -101,7 +101,7 @@ async def test_anoncreds_revocation_interaction_test_issuance_by_demand(pool_nam
 
     (cred_json, cred_rev_id, rev_reg_delta_json) = \
         await anoncreds.issuer_create_credential(issuer_wallet_handle, cred_offer_json, cred_req_json,
-                                                 cred_values_json, rev_reg_def_id, blob_storage_reader_cfg_handle)
+                                                 cred_values_json, rev_reg_def_id,None, blob_storage_reader_cfg_handle)
 
     # Issuer Posts Revocation Registry Delta to Ledger
     revoc_reg_entry_request = \

--- a/wrappers/python/tests/interation/test_interaction_several_credentials.py
+++ b/wrappers/python/tests/interation/test_interaction_several_credentials.py
@@ -196,6 +196,7 @@ async def test_anoncreds_revocation_interaction_test_issuance_by_demand_4_creds(
             cred_req_json,
             cred_values_json[i],
             rev_reg_def_id,
+            None,
             blob_storage_reader_cfg_handle
         )
 

--- a/wrappers/rust/indy-sys/src/anoncreds.rs
+++ b/wrappers/rust/indy-sys/src/anoncreds.rs
@@ -53,6 +53,7 @@ extern {
                                          cred_req_json: CString,
                                          cred_values_json: CString,
                                          rev_reg_id: CString,
+                                         rev_idx: i32,
                                          blob_storage_reader_handle: BlobStorageReaderHandle,
                                          cb: Option<ResponseStringStringStringCB>) -> Error;
 


### PR DESCRIPTION
This PR proposes an option for the issuer to specify a cred_rev_id (index in revocation registry) when a credential is issued.This gives more control for an issuer to manage revocation registry, a few examples can be

- Alice issues credentials with same cred_rev_id multiple times to Bob, who wants the same credential to be stored in multiple wallets, In this case Alice can revoke a credential of Bob by revoking a single index, this allows Alice to create a better controller logic for revocation registry
- Alice issues credentials with same cred_rev_id to multiple Holders e.g. Coupons

@DaevMithran


Signed-off-by: Pritam Singh <pkspritam16@gmail.com>