### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -38,6 +38,9 @@ complex design decision or a controversial PR.
 
 ## Maintainers
 
-* Slava - maintainer and scrum team lead. geo=Voronezh, Russia; github=vimmerru, rocket.chat=gudkov, jira=gudkov
 * Sergej - maintainer. geo=Voronezh, Russia; github=jovfer, rocket.chat=sergey.minaev, jira=sergey.minaev
+
+## Emeritus Maintainers
+
+* Slava - maintainer and scrum team lead. geo=Voronezh, Russia; github=vimmerru, rocket.chat=gudkov, jira=gudkov
 * Doug - vcx maintainer. geo=Utah, USA; github=glowkey; rocket.chat, jira=DouglasWightman


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>