### PR TITLE
Updating to latest Ubuntu version in cli dockerfile

### DIFF
--- a/cli/cli.dockerfile
+++ b/cli/cli.dockerfile
@@ -1,10 +1,26 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y apt-transport-https
+RUN DEBIAN_FRONTEND=noninteractive 
 
-ARG indy_stream=master
+RUN apt-get update -y && TZ=Etc/UTC apt-get -y install tzdata
+
+RUN apt-get update -y && apt-get install -y \
+    software-properties-common \
+    apt-transport-https \
+    curl \
+    build-essential \
+    git \
+    libzmq3-dev \
+    libsodium-dev \
+    pkg-config \
+    libncurses5 \
+    libssl-dev \
+    gnupg \
+    ca-certificates
+
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
-RUN echo "deb https://repo.sovrin.org/sdk/deb xenial $indy_stream" >> /etc/apt/sources.list
-
-RUN apt-get update && apt-get install -y indy-cli
+RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable"
+RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
+    libindy \
+    indy-cli


### PR DESCRIPTION
Creating this PR to update the indy-cli base image version from 16.04 to 20.04. I have also updated the dependencies required to install libindy and indy-cli. Looking for feedback from the maintainers if this will break any other test/workflow and fix accordingly.