### PR TITLE
fix: ignore credential not satisfying predicate

### DIFF
--- a/libindy/src/commands/anoncreds/prover.rs
+++ b/libindy/src/commands/anoncreds/prover.rs
@@ -856,7 +856,7 @@ impl ProverCommandExecutor {
                 let values = self.anoncreds_service.prover.get_credential_values_for_attribute(&credential.values.0, &predicate.name)
                     .ok_or_else(|| err_msg(IndyErrorKind::InvalidState, "Credential values not found"))?;
 
-                let satisfy = self.anoncreds_service.prover.attribute_satisfy_predicate(predicate, &values.encoded)?;
+                let satisfy = self.anoncreds_service.prover.attribute_satisfy_predicate(predicate, &values.encoded).unwrap_or(false);
                 if !satisfy { continue; }
             }
 


### PR DESCRIPTION
`fn _get_requested_credentials` throws an error even though the prover has a valid credential satisfying predicate. Let's say the prover has the following credential.

- cred1: have attribute `value=ANYTHING_BUT_NOT_A_NUMBER`
- cred2: have attribute `value=3`

and proof request with predicate
- value < 5

Ideally, `_get_requested_credentials` should return `[cred2]` in this case, but the function will throw an error. 