### PR TITLE
replace xamarinios1.0 with net8.0-ios as target framework

### DIFF
--- a/wrappers/dotnet/indy-sdk-dotnet-test/SetupAssemblyInitializer.cs
+++ b/wrappers/dotnet/indy-sdk-dotnet-test/SetupAssemblyInitializer.cs
@@ -28,8 +28,7 @@ namespace Hyperledger.Indy.Test
 
             // Step 4. Activate the configuration
             LogManager.Configuration = config;
-
-            Hyperledger.Indy.Utils.Logger.Init();
+            
             StorageUtils.CleanupStorage();
         }
 

--- a/wrappers/dotnet/indy-sdk-dotnet.sln
+++ b/wrappers/dotnet/indy-sdk-dotnet.sln
@@ -7,8 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "indy-sdk-dotnet", "indy-sdk
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "indy-sdk-dotnet-test", "indy-sdk-dotnet-test\indy-sdk-dotnet-test.csproj", "{D5DF480F-45B3-47D8-8C30-65A4DF0007D7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "indy-sdk-dotnet-doc", "indy-sdk-dotnet-doc\indy-sdk-dotnet-doc.csproj", "{9FAB78CF-D983-49A2-9ED3-EA53A6E0A40F}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,10 +21,6 @@ Global
 		{D5DF480F-45B3-47D8-8C30-65A4DF0007D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D5DF480F-45B3-47D8-8C30-65A4DF0007D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5DF480F-45B3-47D8-8C30-65A4DF0007D7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9FAB78CF-D983-49A2-9ED3-EA53A6E0A40F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9FAB78CF-D983-49A2-9ED3-EA53A6E0A40F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9FAB78CF-D983-49A2-9ED3-EA53A6E0A40F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9FAB78CF-D983-49A2-9ED3-EA53A6E0A40F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/wrappers/dotnet/indy-sdk-dotnet/indy-sdk-dotnet.csproj
+++ b/wrappers/dotnet/indy-sdk-dotnet/indy-sdk-dotnet.csproj
@@ -1,26 +1,12 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452;xamarinios10</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0-ios</TargetFrameworks>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
     <AssemblyName>Hyperledger.Indy</AssemblyName>
     <RootNamespace>Hyperledger.Indy</RootNamespace>
+    <PackageId>WalletFramework.Indy.Sdk</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.11.1</Version>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Authors>Symon Rottem, Tomislav Markovski</Authors>
-    <Company>Hyperledger Indy</Company>
-    <Product>Hyperledger Indy SDK</Product>
-    <Description>.NET wrapper for the Hyperledger Indy SDK.
-
-Please note that to function the C-Callable Hyperledger Indy SDK and its dependencies must be installed in the library/DLL search path - please see the project page for more information.</Description>
-    <PackageProjectUrl>https://github.com/hyperledger/indy-sdk</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/hyperledger/indy-sdk</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>hyperledger indy sdk</PackageTags>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageIconUrl></PackageIconUrl>
-    <AssemblyVersion>1.11.1</AssemblyVersion>
-    <FileVersion>1.11.1</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -28,10 +14,6 @@ Please note that to function the C-Callable Hyperledger Indy SDK and its depende
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibLog" Version="5.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR replaces the target framework "xamarinios10" with net8.0-ios in order to support MAUI.